### PR TITLE
fix: ensure gengodep uses vendor dir if present, from sylabs 468

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   configuration file being written.
 - `--no-https` now applies to connections made to library services specified
   in `library://<hostname>/...` URIs.
+- Ensure `gengodep` in build uses vendor dir when present.
+- Fix `source` of a script on `PATH` and scoping of environment variables in
+  definition files (via dependency update).
 
 ### Changes for Testing / Development
 

--- a/makeit/gengodep
+++ b/makeit/gengodep
@@ -28,15 +28,9 @@ shift 4
 # get propagated down to go list.
 export GOPROXY
 
-if test -e "${srcdir}/vendor/modules.txt" ; then
-	mod_mode=vendor
-else
-	mod_mode=readonly
-fi
-
 template='{{ with $d := . }}{{ if not $d.Standard }}{{ range $d.GoFiles }}{{ printf "%s/%s\n" $d.Dir . }}{{ end }}{{ range $d.CgoFiles }}{{ printf "%s/%s\n" $d.Dir . }}{{ end }}{{ end }}{{ end }}'
 
-godeps=`${go} list -mod=${mod_mode} -deps -f "${template}" -tags "${gotags}" "$@" | sort -u`
+godeps=`${go} list -deps -f "${template}" -tags "${gotags}" "$@" | sort -u`
 
 for m in ${godeps}; do
     echo "$var += $m" >> ${depfile}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#468
which fixed
- sylabs/singularity#461

The original PR description was:

> In a previous PR, initialization of the `srcdir` variable was removed from `makeit/gengodep`. However, the `gengodep` script was still using `srcdir` when checking for a `${srcdir}/vendor/modules.txt`.
> 
> Ref: [48e7fab](https://github.com/sylabs/singularity/commit/48e7fab83e11a698adbd506d60e13fb375b00fec)
> 
> As a result, the vendor dir is never found, and `go` was run with `-mod=readonly`, which would lead to downloads.
> 
> Since go 1.14 the presence of a vendor dir infers `-mod=vendor` automatically, so we can just remove the handling here.