### PR TITLE
build: handle man pages with make install, from sylabs 551

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Update dependency to correctly unset variables in container startup
   environment processing. Fixes regression introduced in singularity-3.8.5.
 
+### Changed defaults / behaviours
+
+- `make install` now installs man pages. A separate `make man` is not
+  required.
+
+### Bug fixes
+
+- GitHub .deb packages correctly include man pages.
+
 ## v1.0.0 Release Candidate 1 - \[22-01-19\]
 
 ### Changes due to the project re-branding

--- a/dist/debian/apptainer.dirs
+++ b/dist/debian/apptainer.dirs
@@ -5,3 +5,4 @@ var/lib/apptainer/mnt/final
 var/lib/apptainer/mnt/overlay
 var/lib/apptainer/mnt/session
 usr/share/bash-completion
+usr/share/man/man1/apptainer*

--- a/dist/debian/apptainer.lintian-overrides
+++ b/dist/debian/apptainer.lintian-overrides
@@ -1,3 +1,4 @@
 # Apptainer requires root suid for operation
+apptainer: binary-without-manpage usr/bin/run-singularity
 apptainer: setuid-binary usr/libexec/apptainer/bin/starter-suid 4755 root/root
 

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -75,7 +75,7 @@ ifneq ($(NEW_VERSION),)
 	@debchange -v $(NEW_VERSION)$(VERSION_POSTFIX) "Version $(NEW_VERSION)" && debchange -m -r ""
 endif
 	@PATH=$(GOROOT)/bin:$$PATH ./mconfig $(SC_VERBOSE) -b $(DEB_SC_BUILDDIR) -P $(DEB_SC_PROFILE) $(SC_OPTIONS) \
-                --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib
+                --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib --mandir=/usr/share/man
 
 override_dh_auto_build:
 	@PATH=$(GOROOT)/bin:$$PATH dh_auto_build -Smakefile --parallel --max-parallel=$(MAKEPARALLEL) -D$(DEB_SC_BUILDDIR)

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -150,8 +150,7 @@ export PATH=$PWD/go/bin:$PATH
 export GOPATH=$PWD/gopath
 cd %{name}-%{package_version}
 
-mkdir -p $RPM_BUILD_ROOT%{_mandir}/man1
-make -C builddir DESTDIR=$RPM_BUILD_ROOT install man
+make -C builddir DESTDIR=$RPM_BUILD_ROOT install
 
 %posttrans
 # clean out empty directories under /etc/singularity

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -8,6 +8,7 @@ all: $(ALL)
 # install man pages
 .PHONY: man
 man: apptainer
+	@printf " MAN\n"
 	mkdir -p $(DESTDIR)$(MANDIR)/man1
 	$(V)$(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" $(GO_GCFLAGS) $(GO_ASMFLAGS) \
 		$(SOURCEDIR)/cmd/docs/docs.go man --dir $(DESTDIR)$(MANDIR)/man1
@@ -133,7 +134,7 @@ clean:
 	$(V)rm -rf $(BUILDDIR)/mergeddeps cscope.* $(CLEANFILES)
 
 .PHONY: install
-install: $(INSTALLFILES)
+install: $(INSTALLFILES) man
 	@echo " DONE"
 
 -include $(BUILDDIR)/mergeddeps


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#551
which fixed
- sylabs/singularity#512

The original PR description was:

> It's reasonable to expect that make install will install man pages,
but that hasn't been the case here... meaning we are somewhat unusual.
> 
> Have make install call the man target.
> 
> Ensure the resulting man pages are handled in the Debian package
properly.