### PR TITLE
fix: Don't prompt y/n to overwrite output in noninteractive build, from sylabs 527

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes Since Last Release
 
+### Bug fixes
+
+- Don't prompt for y/n to overwrite an existing file when build is
+  called from a non-interactive environment. Fail with an error.
+
 ## v1.0.0 - \[2022-03-02\]
 
 ### Comparison to SingularityCE

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"syscall"
 
 	"github.com/apptainer/apptainer/docs"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
@@ -22,6 +23,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/image"
 	ocitypes "github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var buildArgs struct {
@@ -315,6 +317,10 @@ func checkBuildTarget(path string) error {
 			}
 		}
 		if !buildArgs.update && !forceOverwrite {
+			// If non-interactive, die... don't try to prompt the user y/n
+			if !term.IsTerminal(syscall.Stdin) {
+				return fmt.Errorf("build target '%s' already exists. Use --force if you want to overwrite it", f.Name())
+			}
 
 			question := fmt.Sprintf("Build target '%s' already exists and will be deleted during the build process. Do you want to continue? [N/y] ", f.Name())
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#527
which fixed
- sylabs/singularity#521

The original PR description was:

> If a `singularity build` is run without a terminal Stdin (i.e. non-interactive), fail quickly if the output file already exists. Don't get stuck trying to ask for a y/n that won't come.
> 
> This is a quick fix addressing this specific common location where a non-interactive build can get hung up... and there is a `--force` flag to be employed so nobody needs to pipe in a 'y'.
> 
> Really there should be a proper review of where the interactive package is used, and sensible behavior of the functions for these types of uses. We maybe should have variant functions that e.g. fail or fall to a default if Stdin isn't a terminal. However we also need to consider usage that pipes in to answer a prompt (e.g. provide encryption passphrase) from another tool.
> 
> Will open a tech-debt issue for the above.