### PR TITLE
Update markdown files & plugin examples go.mod, from sylabs 639

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,7 +69,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export GOVERSION=1.17.7 OS=linux ARCH=amd64  # change this as you need
+export GOVERSION=1.17.8 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${GOVERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${GOVERSION}.${OS}-${ARCH}.tar.gz
@@ -131,7 +131,7 @@ To build a specific version of Apptainer, check out a
 for example:
 
 ```sh
-git checkout v3.8.5
+git checkout v1.0.0
 ```
 
 ## Compiling Apptainer

--- a/e2e/plugin/testdata/cli/go.mod
+++ b/e2e/plugin/testdata/cli/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/apptainer/apptainer v0.0.0
-	github.com/spf13/cobra v1.3.0
+	github.com/spf13/cobra v1.4.0
 )
 
 replace github.com/apptainer/apptainer => ./apptainer_source

--- a/examples/plugins/cli-plugin/go.mod
+++ b/examples/plugins/cli-plugin/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/apptainer/apptainer v0.0.0
-	github.com/spf13/cobra v1.3.0
+	github.com/spf13/cobra v1.4.0
 )
 
 replace github.com/apptainer/apptainer => ./apptainer_source

--- a/examples/plugins/log-plugin/go.mod
+++ b/examples/plugins/log-plugin/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/apptainer/apptainer v0.0.0
-	github.com/spf13/cobra v1.3.0
+	github.com/spf13/cobra v1.4.0
 )
 
 replace github.com/apptainer/apptainer => ./apptainer_source


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#639

The original PR description was:

> Update markdown docs for a 3.9.6.
> 
> Update the go.mod files for plugin examples following a number of dep updates.