### PR TITLE
feat: enable native v2 unified cgroups config, from sylabs 539

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 ### New features / functionalities
 
 - Apptainer now supports the `riscv64` architecture.
+- Native cgroups v2 resource limits can be specified using the `[unified]` key
+  in a cgroups toml file applied via `--apply-cgroups`.
 
 ### Bug fixes
 

--- a/internal/pkg/cgroups/config_linux.go
+++ b/internal/pkg/cgroups/config_linux.go
@@ -171,8 +171,8 @@ type Config struct {
 	// Limits are a set of key value pairs that define RDMA resource limits,
 	// where the key is device name and value is resource limits.
 	Rdma map[string]LinuxRdma `toml:"rdma" json:"rdma,omitempty"`
-	// TODO: Enable support for native cgroup v2 resource specifications
-	// Unified map[string]string `toml:"unified" json:"unified,omitempty"`
+	// Native cgroups v2 unified hierarchy resource limits.
+	Unified map[string]string `toml:"unified" json:"unified,omitempty"`
 }
 
 // LoadConfig loads a cgroups config file into our native cgroups.Config struct

--- a/internal/pkg/cgroups/example/cgroups-unified.toml
+++ b/internal/pkg/cgroups/example/cgroups-unified.toml
@@ -1,0 +1,6 @@
+#
+# Cgroups configuration file example using unified key for cgroups v2 only
+#
+
+[unified]
+    "pids.max" = "512"

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -71,8 +71,7 @@ func (m *Manager) GetCgroupRootPath() (rootPath string, err error) {
 }
 
 // UpdateFromSpec updates the existing managed cgroup using configuration from
-// an OCI LinuxResources spec struct. The `Unified` key for native v2 cgroup
-// specifications is not yet supported.
+// an OCI LinuxResources spec struct.
 func (m *Manager) UpdateFromSpec(resources *specs.LinuxResources) (err error) {
 	if m.group == "" || m.cgroup == nil {
 		return ErrUnitialized
@@ -110,7 +109,7 @@ func (m *Manager) UpdateFromSpec(resources *specs.LinuxResources) (err error) {
 func (m *Manager) UpdateFromFile(path string) error {
 	spec, err := LoadResources(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("while loading cgroups file %s: %w", path, err)
 	}
 	return m.UpdateFromSpec(&spec)
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#539
which fixed
- sylabs/singularity#538

The original PR description was:
> Allow the `unified` key to be used in a cgroups config toml file, to directly apply resource limits using the v2 unified hierarchy, rather than v1 -> v2 translation.