### PR TITLE
tests: allow for cgroups freeze/thaw that isn't instant, from sylabs 570

### DIFF
--- a/internal/pkg/cgroups/manager_linux_v1_test.go
+++ b/internal/pkg/cgroups/manager_linux_v1_test.go
@@ -195,8 +195,8 @@ func testFreezeThawV1(t *testing.T, systemd bool) {
 
 	manager.Freeze()
 	// cgroups v1 freeze is to uninterruptible sleep
-	ensureState(t, pid, "D")
+	ensureStateBecomes(t, pid, "D")
 
 	manager.Thaw()
-	ensureState(t, pid, "RS")
+	ensureStateBecomes(t, pid, "RS")
 }

--- a/internal/pkg/cgroups/manager_linux_v2_test.go
+++ b/internal/pkg/cgroups/manager_linux_v2_test.go
@@ -195,11 +195,11 @@ func testFreezeThawV2(t *testing.T, systemd bool) {
 	// cgroups v2 freeze is to interruptible sleep, which could actually occur
 	// for our cat /dev/zero while it's running, so check freeze marker as well
 	// as the process state here.
-	ensureState(t, pid, "S")
+	ensureStateBecomes(t, pid, "S")
 	freezePath := path.Join(manager.cgroup.Path(""), "cgroup.freeze")
 	ensureInt(t, freezePath, 1)
 
 	manager.Thaw()
-	ensureState(t, pid, "RS")
+	ensureStateBecomes(t, pid, "RS")
 	ensureInt(t, freezePath, 0)
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#570
which fixed
- sylabs/singularity#565

The original PR description was:
> Freezing a cgroup is almost always instant for our trivial test cases... except when it isn't due to system load, slow qemu emulation of alternate architectures etc.
> 
> The Linux docs explicitly show this in their example :-)
> 
> ```
> to freeze all tasks in the container :
>    # echo FROZEN > /sys/fs/cgroup/freezer/0/freezer.state
>    # cat /sys/fs/cgroup/freezer/0/freezer.state
>    FREEZING
>    # cat /sys/fs/cgroup/freezer/0/freezer.state
>    FROZEN
> ```
> 
> Allow up to 5 retries, separated by 1 second for processes to be suspended in our tests.
> 
> Verified by running the tests in a hard loop on a loaded and slow constrained system, and observing behaviour.