### PR TITLE
cgroups: rootless cgroups v2 / systemd support (run/shell/exec), from sylabs 618

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - The `--no-mount` flag & `APPTAINER_NO_MOUNT` env var can now be used to
   disable a `bind path` entry from `apptainer.conf` by specifying the
   absolute path to the destination of the bind.
+- Non-root users can now use `--apply-cgroups` with `run/shell/exec` to limit
+  container resource usage on a system using cgroups v2 and the systemd cgroups
+  manager.
 
 ### Bug fixes
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -31,7 +31,7 @@ var (
 	NetworkArgs      []string
 	DNS              string
 	Security         []string
-	CgroupsPath      string
+	CgroupsTOML      string
 	VMRAM            string
 	VMCPU            string
 	VMIP             string
@@ -249,7 +249,7 @@ var actionSecurityFlag = cmdline.Flag{
 // --apply-cgroups
 var actionApplyCgroupsFlag = cmdline.Flag{
 	ID:           "actionApplyCgroupsFlag",
-	Value:        &CgroupsPath,
+	Value:        &CgroupsTOML,
 	DefaultValue: "",
 	Name:         "apply-cgroups",
 	Usage:        "apply cgroups from file for container processes (root only)",

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -419,9 +419,17 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		generator.SetProcessEnvWithPrefixes(env.ApptainerPrefixes, "SHELL", ShellPath)
 	}
 
-	checkPrivileges(CgroupsPath != "", "--apply-cgroups", func() {
-		engineConfig.SetCgroupsPath(CgroupsPath)
-	})
+	if name != "" && uid != 0 && CgroupsTOML != "" {
+		sylog.Fatalf("Instances do not currently support rootless cgroups")
+	}
+
+	if uid != 0 {
+		sylog.Debugf("Recording rootless XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS")
+		engineConfig.SetXdgRuntimeDir(os.Getenv("XDG_RUNTIME_DIR"))
+		engineConfig.SetDbusSessionBusAddress(os.Getenv("DBUS_SESSION_BUS_ADDRESS"))
+	}
+
+	engineConfig.SetCgroupsTOML(CgroupsTOML)
 
 	if IsWritable && IsWritableTmpfs {
 		sylog.Warningf("Disabling --writable-tmpfs flag, mutually exclusive with --writable")

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
 	"github.com/apptainer/apptainer/e2e/internal/testhelper"
-	"github.com/apptainer/apptainer/internal/pkg/test/tool/require"
 	"github.com/google/uuid"
 )
 
@@ -46,17 +45,16 @@ type ctx struct {
 
 // moved from INSTANCE suite, as testing with systemd cgroup manager requires
 // e2e to be run without PID namespace
-func (c *ctx) instanceApplyCgroups(t *testing.T) {
-	require.Cgroups(t)
+func (c *ctx) instanceApply(t *testing.T, profile e2e.Profile) {
 	e2e.EnsureImage(t, c.env)
-
 	// pick up a random name
 	instanceName := randomName(t)
 	joinName := fmt.Sprintf("instance://%s", instanceName)
 
 	c.env.RunApptainer(
 		t,
-		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithProfile(profile),
+		e2e.WithRootlessEnv(),
 		e2e.WithCommand("instance start"),
 		e2e.WithArgs("--apply-cgroups", "testdata/cgroups/deny_device.toml", c.env.ImagePath, instanceName),
 		e2e.ExpectExit(0),
@@ -64,19 +62,97 @@ func (c *ctx) instanceApplyCgroups(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
-		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithProfile(profile),
+		e2e.WithRootlessEnv(),
 		e2e.WithCommand("exec"),
 		e2e.WithArgs(joinName, "cat", "/dev/null"),
-		e2e.ExpectExit(1),
+		e2e.ExpectExit(1, e2e.ExpectError(e2e.ContainMatch, "Operation not permitted")),
 	)
 
 	c.env.RunApptainer(
 		t,
-		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithProfile(profile),
+		e2e.WithRootlessEnv(),
 		e2e.WithCommand("instance stop"),
 		e2e.WithArgs(instanceName),
 		e2e.ExpectExit(0),
 	)
+}
+
+func (c *ctx) instanceApplyRoot(t *testing.T) {
+	c.instanceApply(t, e2e.RootProfile)
+}
+
+// TODO - when instance support for rootless cgroups is ready, this
+// should instead call instanceApply over the user profiles.
+func (c *ctx) instanceApplyRootless(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+	// pick up a random name
+	instanceName := randomName(t)
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithRootlessEnv(),
+		e2e.WithCommand("instance start"),
+		e2e.WithArgs("--apply-cgroups", "testdata/cgroups/memory_limit.toml", c.env.ImagePath, instanceName),
+		e2e.ExpectExit(255,
+			e2e.ExpectError(e2e.ContainMatch, "Instances do not currently support rootless cgroups")),
+	)
+}
+
+func (c *ctx) actionApply(t *testing.T, profile e2e.Profile) {
+	e2e.EnsureImage(t, c.env)
+
+	// Applies a memory limit so small that it should result in us being killed OOM (137)
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("memory"),
+		e2e.WithProfile(profile),
+		e2e.WithRootlessEnv(),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--apply-cgroups", "testdata/cgroups/memory_limit.toml", c.env.ImagePath, "/bin/sleep", "5"),
+		e2e.ExpectExit(137),
+	)
+
+	// Rootfull cgroups should be able to limit access to devices
+	if profile.Privileged() {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest("device"),
+			e2e.WithProfile(profile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs("--apply-cgroups", "testdata/cgroups/deny_device.toml", c.env.ImagePath, "cat", "/dev/null"),
+			e2e.ExpectExit(1,
+				e2e.ExpectError(e2e.ContainMatch, "Operation not permitted")),
+		)
+		return
+	}
+
+	// Cgroups v2 device limits are via ebpf and rootless cannot apply them.
+	// Check that attempting to apply a device limit warns that it won't take effect.
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("device"),
+		e2e.WithProfile(profile),
+		e2e.WithRootlessEnv(),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--apply-cgroups", "testdata/cgroups/deny_device.toml", c.env.ImagePath, "cat", "/dev/null"),
+		e2e.ExpectExit(0,
+			e2e.ExpectError(e2e.ContainMatch, "Device limits will not be applied with rootless cgroups")),
+	)
+}
+
+func (c *ctx) actionApplyRoot(t *testing.T) {
+	c.actionApply(t, e2e.RootProfile)
+}
+
+func (c *ctx) actionApplyRootless(t *testing.T) {
+	for _, profile := range []e2e.Profile{e2e.UserProfile, e2e.UserNamespaceProfile, e2e.FakerootProfile} {
+		t.Run(profile.String(), func(t *testing.T) {
+			c.actionApply(t, profile)
+		})
+	}
 }
 
 // E2ETests is the main func to trigger the test suite
@@ -88,6 +164,9 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	np := testhelper.NoParallel
 
 	return testhelper.Tests{
-		"instance apply cgroups": np(env.WithCgroupManagers(c.instanceApplyCgroups)),
+		"instance root cgroups":     np(env.WithRootManagers(c.instanceApplyRoot)),
+		"instance rootless cgroups": np(env.WithRootlessManagers(c.instanceApplyRootless)),
+		"action root cgroups":       np(env.WithRootManagers(c.actionApplyRoot)),
+		"action rootless cgroups":   np(env.WithRootlessManagers(c.actionApplyRootless)),
 	}
 }

--- a/e2e/internal/e2e/apptainercmd.go
+++ b/e2e/internal/e2e/apptainercmd.go
@@ -328,6 +328,15 @@ func WithEnv(envs []string) ApptainerCmdOp {
 	}
 }
 
+// WithRootlessEnv passes through XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS
+// for rootless operations that need these e.g. systemd cgroups interaction.
+func WithRootlessEnv() ApptainerCmdOp {
+	return func(s *apptainerCmd) {
+		s.envs = append(s.envs, "XDG_RUNTIME_DIR="+os.Getenv("XDG_RUNTIME_DIR"))
+		s.envs = append(s.envs, "DBUS_SESSION_BUS_ADDRESS="+os.Getenv("DBUS_SESSION_BUS_ADDRESS"))
+	}
+}
+
 // WithDir sets the current working directory for the execution of a command.
 func WithDir(dir string) ApptainerCmdOp {
 	return func(s *apptainerCmd) {

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -405,7 +405,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 
 	return testhelper.Tests{
 		"ordered": testhelper.NoParallel(
-			env.WithCgroupManagers(func(t *testing.T) {
+			env.WithRootManagers(func(t *testing.T) {
 				t.Run("basic", c.testOciBasic)
 				t.Run("attach", c.testOciAttach)
 				t.Run("run", c.testOciRun)

--- a/e2e/testdata/cgroups/memory_limit.toml
+++ b/e2e/testdata/cgroups/memory_limit.toml
@@ -1,0 +1,2 @@
+[memory]
+  limit = 1024

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -12,10 +12,14 @@ package cgroups
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/apptainer/apptainer/internal/pkg/util/env"
+	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	lccgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	lcmanager "github.com/opencontainers/runc/libcontainer/cgroups/manager"
 	lcconfigs "github.com/opencontainers/runc/libcontainer/configs"
@@ -206,6 +210,34 @@ func (m *Manager) Destroy() (err error) {
 	return m.cgroup.Destroy()
 }
 
+// checkRootless identifies if rootless cgroups are required / supported
+func checkRootless(group string, systemd bool) (rootless bool, err error) {
+	if os.Getuid() == 0 {
+		if systemd {
+			if !strings.HasPrefix(group, "system.slice:") {
+				return false, fmt.Errorf("systemd cgroups require a cgroups path beginning with 'system.slice:'")
+			}
+		}
+		return false, nil
+	}
+
+	if !cgroups.IsCgroup2HybridMode() && !cgroups.IsCgroup2UnifiedMode() {
+		return false, fmt.Errorf("rootless cgroups requires cgroups v2")
+	}
+	if !systemd {
+		return false, fmt.Errorf("rootless cgroups require 'systemd cgroups' to be enabled in apptainer.conf")
+	}
+	if os.Getenv("XDG_RUNTIME_DIR") == "" || os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
+		return false, fmt.Errorf("rootless cgroups require a D-Bus session - check that XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS are set")
+	}
+
+	if !strings.HasPrefix(group, "user.slice:") {
+		return false, fmt.Errorf("rootless cgroups require a cgroups path beginning with 'user.slice:'")
+	}
+
+	return true, nil
+}
+
 // newManager creates a new Manager, with the associated resources and cgroup.
 // The Manager is ready to manage the cgroup but does not apply limits etc.
 func newManager(resources *specs.LinuxResources, group string, systemd bool) (manager *Manager, err error) {
@@ -214,6 +246,25 @@ func newManager(resources *specs.LinuxResources, group string, systemd bool) (ma
 	}
 	if group == "" {
 		return nil, fmt.Errorf("a cgroup name/path is required")
+	}
+
+	rootless, err := checkRootless(group, systemd)
+	if err != nil {
+		return nil, err
+	}
+	// Rootless manager code invokes systemctl, which it expects to be on PATH.
+	// Must set default PATH as starter sets up a very stripped down environment.
+	if rootless {
+		sylog.Debugf("Using rootless cgroups")
+		oldPath := os.Getenv("PATH")
+		if err := os.Setenv("PATH", env.DefaultPath); err != nil {
+			return nil, fmt.Errorf("could not set default PATH for cgroups manager to locate systemctl: %w", err)
+		}
+		defer os.Setenv("PATH", oldPath)
+
+		if len(resources.Devices) > 0 {
+			sylog.Warningf("Device limits will not be applied with rootless cgroups")
+		}
 	}
 
 	spec := &specs.Spec{
@@ -226,7 +277,7 @@ func newManager(resources *specs.LinuxResources, group string, systemd bool) (ma
 	opts := &lcspecconv.CreateOpts{
 		CgroupName:       group,
 		UseSystemdCgroup: systemd,
-		RootlessCgroups:  false,
+		RootlessCgroups:  rootless,
 		Spec:             spec,
 	}
 
@@ -259,8 +310,14 @@ func NewManagerWithSpec(spec *specs.LinuxResources, pid int, group string, syste
 		group = filepath.Join("/apptainer", strconv.Itoa(pid))
 	}
 	if group == "" && systemd {
-		group = "system.slice:apptainer:" + strconv.Itoa(pid)
+		if os.Getuid() == 0 {
+			group = "system.slice:apptainer:" + strconv.Itoa(pid)
+		} else {
+			group = "user.slice:apptainer:" + strconv.Itoa(pid)
+		}
 	}
+
+	sylog.Debugf("Creating cgroups manager for %s", group)
 
 	// Create the manager
 	mgr, err := newManager(spec, group, systemd)

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -406,7 +406,7 @@ func (e *EngineOperations) PostStartProcess(ctx context.Context, pid int) error 
 
 		// If we are using cgroups with this instance then mark that in the instance config.
 		// We don't store the path, as we will get the cgroup manager by Pid.
-		if e.EngineConfig.GetCgroupsPath() != "" {
+		if e.EngineConfig.GetCgroupsTOML() != "" {
 			file.Cgroup = true
 		}
 

--- a/internal/pkg/util/starter/starter.go
+++ b/internal/pkg/util/starter/starter.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -105,6 +105,9 @@ func Run(name string, config *config.Common, ops ...CommandOp) error {
 	if err := c.init(config, ops...); err != nil {
 		return fmt.Errorf("while initializing starter command: %s", err)
 	}
+
+	sylog.Debugf("Setting GOGC=off for starter")
+	c.env = append(c.env, "GOGC=off")
 
 	cmd := exec.Command(c.path)
 	cmd.Args = []string{name}

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -74,69 +74,71 @@ type DMTCPConfig struct {
 
 // JSONConfig stores engine specific configuration that is allowed to be set by the user.
 type JSONConfig struct {
-	ScratchDir        []string          `json:"scratchdir,omitempty"`
-	OverlayImage      []string          `json:"overlayImage,omitempty"`
-	NetworkArgs       []string          `json:"networkArgs,omitempty"`
-	Security          []string          `json:"security,omitempty"`
-	FilesPath         []string          `json:"filesPath,omitempty"`
-	LibrariesPath     []string          `json:"librariesPath,omitempty"`
-	FuseMount         []FuseMount       `json:"fuseMount,omitempty"`
-	ImageList         []image.Image     `json:"imageList,omitempty"`
-	BindPath          []BindPath        `json:"bindpath,omitempty"`
-	ApptainerEnv      map[string]string `json:"apptainerEnv,omitempty"`
-	UnixSocketPair    [2]int            `json:"unixSocketPair,omitempty"`
-	OpenFd            []int             `json:"openFd,omitempty"`
-	TargetGID         []int             `json:"targetGID,omitempty"`
-	Image             string            `json:"image"`
-	ImageArg          string            `json:"imageArg"`
-	Workdir           string            `json:"workdir,omitempty"`
-	CgroupsPath       string            `json:"cgroupsPath,omitempty"`
-	HomeSource        string            `json:"homedir,omitempty"`
-	HomeDest          string            `json:"homeDest,omitempty"`
-	Command           string            `json:"command,omitempty"`
-	Shell             string            `json:"shell,omitempty"`
-	TmpDir            string            `json:"tmpdir,omitempty"`
-	AddCaps           string            `json:"addCaps,omitempty"`
-	DropCaps          string            `json:"dropCaps,omitempty"`
-	Hostname          string            `json:"hostname,omitempty"`
-	Network           string            `json:"network,omitempty"`
-	DNS               string            `json:"dns,omitempty"`
-	Cwd               string            `json:"cwd,omitempty"`
-	SessionLayer      string            `json:"sessionLayer,omitempty"`
-	ConfigurationFile string            `json:"configurationFile,omitempty"`
-	EncryptionKey     []byte            `json:"encryptionKey,omitempty"`
-	TargetUID         int               `json:"targetUID,omitempty"`
-	WritableImage     bool              `json:"writableImage,omitempty"`
-	WritableTmpfs     bool              `json:"writableTmpfs,omitempty"`
-	Contain           bool              `json:"container,omitempty"`
-	NvLegacy          bool              `json:"nvLegacy,omitempty"`
-	NvCCLI            bool              `json:"nvCCLI,omitempty"`
-	NvCCLIEnv         []string          `json:"NvCCLIEnv,omitempty"`
-	Rocm              bool              `json:"rocm,omitempty"`
-	CustomHome        bool              `json:"customHome,omitempty"`
-	Instance          bool              `json:"instance,omitempty"`
-	InstanceJoin      bool              `json:"instanceJoin,omitempty"`
-	BootInstance      bool              `json:"bootInstance,omitempty"`
-	RunPrivileged     bool              `json:"runPrivileged,omitempty"`
-	AllowSUID         bool              `json:"allowSUID,omitempty"`
-	KeepPrivs         bool              `json:"keepPrivs,omitempty"`
-	NoPrivs           bool              `json:"noPrivs,omitempty"`
-	NoProc            bool              `json:"noProc,omitempty"`
-	NoSys             bool              `json:"noSys,omitempty"`
-	NoDev             bool              `json:"noDev,omitempty"`
-	NoDevPts          bool              `json:"noDevPts,omitempty"`
-	NoHome            bool              `json:"noHome,omitempty"`
-	NoTmp             bool              `json:"noTmp,omitempty"`
-	NoHostfs          bool              `json:"noHostfs,omitempty"`
-	NoCwd             bool              `json:"noCwd,omitempty"`
-	SkipBinds         []string          `json:"skipBinds,omitempty"`
-	NoInit            bool              `json:"noInit,omitempty"`
-	Fakeroot          bool              `json:"fakeroot,omitempty"`
-	SignalPropagation bool              `json:"signalPropagation,omitempty"`
-	RestoreUmask      bool              `json:"restoreUmask,omitempty"`
-	DeleteTempDir     string            `json:"deleteTempDir,omitempty"`
-	Umask             int               `json:"umask,omitempty"`
-	DMTCPConfig       DMTCPConfig       `json:"dmtcpConfig,omitempty"`
+	ScratchDir            []string          `json:"scratchdir,omitempty"`
+	OverlayImage          []string          `json:"overlayImage,omitempty"`
+	NetworkArgs           []string          `json:"networkArgs,omitempty"`
+	Security              []string          `json:"security,omitempty"`
+	FilesPath             []string          `json:"filesPath,omitempty"`
+	LibrariesPath         []string          `json:"librariesPath,omitempty"`
+	FuseMount             []FuseMount       `json:"fuseMount,omitempty"`
+	ImageList             []image.Image     `json:"imageList,omitempty"`
+	BindPath              []BindPath        `json:"bindpath,omitempty"`
+	ApptainerEnv          map[string]string `json:"apptainerEnv,omitempty"`
+	UnixSocketPair        [2]int            `json:"unixSocketPair,omitempty"`
+	OpenFd                []int             `json:"openFd,omitempty"`
+	TargetGID             []int             `json:"targetGID,omitempty"`
+	Image                 string            `json:"image"`
+	ImageArg              string            `json:"imageArg"`
+	Workdir               string            `json:"workdir,omitempty"`
+	CgroupsTOML           string            `json:"cgroupsTOML,omitempty"`
+	HomeSource            string            `json:"homedir,omitempty"`
+	HomeDest              string            `json:"homeDest,omitempty"`
+	Command               string            `json:"command,omitempty"`
+	Shell                 string            `json:"shell,omitempty"`
+	TmpDir                string            `json:"tmpdir,omitempty"`
+	AddCaps               string            `json:"addCaps,omitempty"`
+	DropCaps              string            `json:"dropCaps,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Network               string            `json:"network,omitempty"`
+	DNS                   string            `json:"dns,omitempty"`
+	Cwd                   string            `json:"cwd,omitempty"`
+	SessionLayer          string            `json:"sessionLayer,omitempty"`
+	ConfigurationFile     string            `json:"configurationFile,omitempty"`
+	EncryptionKey         []byte            `json:"encryptionKey,omitempty"`
+	TargetUID             int               `json:"targetUID,omitempty"`
+	WritableImage         bool              `json:"writableImage,omitempty"`
+	WritableTmpfs         bool              `json:"writableTmpfs,omitempty"`
+	Contain               bool              `json:"container,omitempty"`
+	NvLegacy              bool              `json:"nvLegacy,omitempty"`
+	NvCCLI                bool              `json:"nvCCLI,omitempty"`
+	NvCCLIEnv             []string          `json:"NvCCLIEnv,omitempty"`
+	Rocm                  bool              `json:"rocm,omitempty"`
+	CustomHome            bool              `json:"customHome,omitempty"`
+	Instance              bool              `json:"instance,omitempty"`
+	InstanceJoin          bool              `json:"instanceJoin,omitempty"`
+	BootInstance          bool              `json:"bootInstance,omitempty"`
+	RunPrivileged         bool              `json:"runPrivileged,omitempty"`
+	AllowSUID             bool              `json:"allowSUID,omitempty"`
+	KeepPrivs             bool              `json:"keepPrivs,omitempty"`
+	NoPrivs               bool              `json:"noPrivs,omitempty"`
+	NoProc                bool              `json:"noProc,omitempty"`
+	NoSys                 bool              `json:"noSys,omitempty"`
+	NoDev                 bool              `json:"noDev,omitempty"`
+	NoDevPts              bool              `json:"noDevPts,omitempty"`
+	NoHome                bool              `json:"noHome,omitempty"`
+	NoTmp                 bool              `json:"noTmp,omitempty"`
+	NoHostfs              bool              `json:"noHostfs,omitempty"`
+	NoCwd                 bool              `json:"noCwd,omitempty"`
+	SkipBinds             []string          `json:"skipBinds,omitempty"`
+	NoInit                bool              `json:"noInit,omitempty"`
+	Fakeroot              bool              `json:"fakeroot,omitempty"`
+	SignalPropagation     bool              `json:"signalPropagation,omitempty"`
+	RestoreUmask          bool              `json:"restoreUmask,omitempty"`
+	DeleteTempDir         string            `json:"deleteTempDir,omitempty"`
+	Umask                 int               `json:"umask,omitempty"`
+	DMTCPConfig           DMTCPConfig       `json:"dmtcpConfig,omitempty"`
+	XdgRuntimeDir         string            `json:"xdgRuntimeDir,omitempty"`
+	DbusSessionBusAddress string            `json:"dbusSessionBusAddress,omitempty"`
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.
@@ -605,14 +607,14 @@ func (e *EngineConfig) GetSecurity() []string {
 	return e.JSON.Security
 }
 
-// SetCgroupsPath sets path to cgroups profile.
-func (e *EngineConfig) SetCgroupsPath(path string) {
-	e.JSON.CgroupsPath = path
+// SetCgroupsTOML sets path to cgroups TOML file to apply.
+func (e *EngineConfig) SetCgroupsTOML(path string) {
+	e.JSON.CgroupsTOML = path
 }
 
-// GetCgroupsPath returns path to cgroups profile.
-func (e *EngineConfig) GetCgroupsPath() string {
-	return e.JSON.CgroupsPath
+// GetCgroupsTOML returns path to cgroups TOML file to apply.
+func (e *EngineConfig) GetCgroupsTOML() string {
+	return e.JSON.CgroupsTOML
 }
 
 // SetTargetUID sets target UID to execute the container process as user ID.
@@ -827,4 +829,24 @@ func (e *EngineConfig) SetDMTCPConfig(config DMTCPConfig) {
 // GetDMTCPConfig returns the dmtcp configuration to be used for the container process.
 func (e *EngineConfig) GetDMTCPConfig() DMTCPConfig {
 	return e.JSON.DMTCPConfig
+}
+
+// SetXdgRuntimeDir sets a XDG_RUNTIME_DIR value for rootless operations
+func (e *EngineConfig) SetXdgRuntimeDir(path string) {
+	e.JSON.XdgRuntimeDir = path
+}
+
+// GetXdgRuntimeDir gets the XDG_RUNTIME_DIR value for rootless operations
+func (e *EngineConfig) GetXdgRuntimeDir() string {
+	return e.JSON.XdgRuntimeDir
+}
+
+// SetDbusSessionBusAddress sets a DBUS_SESSION_BUS_ADDRESS value for rootless operations
+func (e *EngineConfig) SetDbusSessionBusAddress(address string) {
+	e.JSON.DbusSessionBusAddress = address
+}
+
+// GetDbusSessionBusAddress gets the DBUS_SESSION_BUS_ADDRESS value for rootless operations
+func (e *EngineConfig) GetDbusSessionBusAddress() string {
+	return e.JSON.DbusSessionBusAddress
 }

--- a/scripts/e2e-test
+++ b/scripts/e2e-test
@@ -38,5 +38,6 @@ id_vars="E2E_ORIG_UID=$uid E2E_ORIG_GID=$gid"
 proxy_vars="HTTP_PROXY=$HTTP_PROXY HTTPS_PROXY=$HTTPS_PROXY ALL_PROXY=$ALL_PROXY NO_PROXY=$NO_PROXY"
 cred_vars="E2E_DOCKER_USERNAME=$E2E_DOCKER_USERNAME E2E_DOCKER_PASSWORD=$E2E_DOCKER_PASSWORD"
 docker_mirror_vars="E2E_DOCKER_MIRROR=$E2E_DOCKER_MIRROR E2E_DOCKER_MIRROR_INSECURE=$E2E_DOCKER_MIRROR_INSECURE"
-export sudo_args="env -i PATH=$PATH HOME=$HOME $id_vars $proxy_vars $docker_mirror_vars $cred_vars APPTAINER_E2E_COVERAGE=$APPTAINER_E2E_COVERAGE"
+rootless_vars="XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
+export sudo_args="env -i PATH=$PATH HOME=$HOME $id_vars $proxy_vars $docker_mirror_vars $cred_vars $rootless_vars APPTAINER_E2E_COVERAGE=$APPTAINER_E2E_COVERAGE"
 exec scripts/go-test -sudo -parallel $procs -tags "e2e_test" "$@" ./e2e


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#618
which fixed
- sylabs/singularity#300

The original PR description was:
> Allow the `--apply-cgroups` flag to be used by non-root users so long
> as:
> 
> * The system is using cgroups v2 and the systemd cgroup manager.
> * There is a D-Bus session and XDG_RUNTIME_DIR (required for the
>       systemd cgroups manager interactions).
> 
> 
> There is no support for instances, as additional work is required to
> allow instance exec'd process to be added to the cgroup without root
> permissions.
> 
> Both the EngineCongfig code, and the E2E test code, have been modified to
> pass through XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS where needed.