### PR TITLE
techdebt: remove support for old distros, from sylabs 703

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Plugins must be compiled from inside the Apptainer source directory,
   and will use the main Apptainer `go.mod` file. Required for Go 1.18
   support.
+- Apptainer now requires squashfs-tools >=4.3, which is satisfied by
+  current EL / Ubuntu / Debian and other distributions.
 
 ### New features / functionalities
 

--- a/cmd/starter/c/include/capability.h
+++ b/cmd/starter/c/include/capability.h
@@ -23,11 +23,9 @@
 /* 37 is the latest cap since many kernel versions */
 #define CAPSET_MAX  37
 
-/* Support only 64 bits sets, since kernel 2.6.25 */
+/* Support only 64 bits sets, since kernel 2.6.26 */
 #ifdef _LINUX_CAPABILITY_VERSION_3
 #  define LINUX_CAPABILITY_VERSION  _LINUX_CAPABILITY_VERSION_3
-#elif defined(_LINUX_CAPABILITY_VERSION_2)
-#  define LINUX_CAPABILITY_VERSION  _LINUX_CAPABILITY_VERSION_2
 #else
 #  error Linux 64 bits capability set not supported
 #endif /* _LINUX_CAPABILITY_VERSION_3 */

--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -79,12 +79,7 @@ func (c ctx) apptainerInspect(t *testing.T) {
 	// it can't set system xattrs while rootless.
 	cmd := exec.Command("unsquashfs", "-user-xattrs", "-d", sandboxImage, squashImage)
 	if res := cmd.Run(t); res.Error != nil {
-		// If we failed, then try without -user-xattrs for older unsquashfs
-		// versions that don't have that flag.
-		cmd := exec.Command("unsquashfs", "-d", sandboxImage, squashImage)
-		if res := cmd.Run(t); res.Error != nil {
-			t.Fatalf("Unexpected error while running command.\n%s", res)
-		}
+		t.Fatalf("Unexpected error while running command.\n%s", res)
 	}
 
 	compareLabel := func(label, expected string, appName string) func(*testing.T, *inspect.Metadata) {

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -521,19 +521,6 @@ func testBadBridge(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout
 func TestAddDelNetworks(t *testing.T) {
 	test.EnsurePrivilege(t)
 
-	// centos 6 doesn't support bridge/veth, only macvlan
-	// just skip tests on centos 6, rhel 6
-	b, err := ioutil.ReadFile("/etc/system-release-cpe")
-	if err == nil {
-		fields := strings.Split(string(b), ":")
-		switch fields[2] {
-		case "centos", "redhat":
-			if strings.HasPrefix(fields[4], "6") {
-				t.Skipf("RHEL6/CentOS6 don't support CNI bridge/veth - skipping")
-			}
-		}
-	}
-
 	cniPath := &CNIPath{
 		Conf:   defaultCNIConfPath,
 		Plugin: defaultCNIPluginPath,


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#703
which fixed
- sylabs/singularity#82

The original PR description was:
> [techdebt: Remove workaround for squashfs-tools <4.3](https://github.com/sylabs/singularity/commit/df23c0a087f4418060975f87686d0c7c4acf7f6b) A workaround was in place for squashfs-tools <4.3 which does not support the `user-xattrs` flag. All our target distros use 4.3 or later, so remove the conditionals to simplify the squashfs unpack logic.
> 
> [techdebt: remove pkg/network test conditional for EL6](https://github.com/sylabs/singularity/commit/8c919c9d99ad83f6b1d42dffbd404e4908483696) We no longer support EL6 which has been EOL for some time.
> 
> [techdebt: drop _LINUX_CAPABILITY_VERSION_2 support](https://github.com/sylabs/singularity/commit/fe8da3c38c7ad44a0eae15f80ef3d6686eb094b4)
> 
> In starter we are currently allowing _LINUX_CAPABILITY_VERSION_2, but this was specific to kernel 2.6.25, and deprecated in 2.6.26, which is older than used by any system we target / test on.
> 
> See also:
> 
> https://github.com/torvalds/linux/blob/v2.6.26/include/linux/capability.h#L34
> 
> https://man7.org/linux/man-pages/man2/capset.2.html
> 
> > Kernels prior to 2.6.25 prefer 32-bit capabilities with version  _LINUX_CAPABILITY_VERSION_1.  Linux 2.6.25 added 64-bit  capability sets, with version _LINUX_CAPABILITY_VERSION_2.  There was, however, an API glitch, and Linux 2.6.26 added _LINUX_CAPABILITY_VERSION_3 to fix the problem.