### PR TITLE
fix: Handle literal escaped newline \n in host environment vars, from sylabs 756

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Fixed `FATAL` error thrown by user configuration migration code that caused
   users with inaccessible home directories to be unable to use `apptainer`
   commands.
+- Pass through a literal `\n` in host environment variables to container.
 
 ## v1.0.1 - \[2022-03-15\]
 

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -287,6 +287,13 @@ func (c ctx) apptainerEnvOption(t *testing.T) {
 			matchVal: "Hello\nWorld",
 		},
 		{
+			name:     "TestEscapedNewline",
+			image:    c.env.ImagePath,
+			hostEnv:  []string{"ESCAPED=Hello\\nWorld"},
+			matchEnv: "ESCAPED",
+			matchVal: "Hello\\nWorld",
+		},
+		{
 			name:  "TestInvalidKey",
 			image: c.env.ImagePath,
 			// We try to set an invalid env var... and make sure

--- a/internal/pkg/util/fs/files/action_script.sh
+++ b/internal/pkg/util/fs/files/action_script.sh
@@ -70,7 +70,7 @@ restore_env() {
     for e in ${__exported_env__}; do
         key=${e%%=*}
         if ! test -v "${key}"; then
-            export "${e//'\n'/$IFS}"
+            export "${e//'\u000A'/$IFS}"
         elif test -z "${!key}"; then
             unset "${key}"
         fi


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#756
which fixed
- sylabs/singularity#752

The original PR description was:
> Since 3.6.0 we have been passing the entire host environment into the action script, it being stored with a single env var there. We use a newline as our IFS when processing this later on. This requires replacing newlines with some other char or string. To date we have been using the standard `\n` as the replacement. However, this means that any host env var containing a literal `\n` cannot be faithfully passed into the container.
> 
> There is no easy perfect solution to this at present.
> 
> We cannot do a full escaping of the host env vars, as reversing this in our action script requires either:
> 
> * Iterative processing on unescape, as look-ahead is important to understand the context of any `\`. This would be extremely messy and slow to implement in shell code, and impact maintainability in this area further.
> * Support for `printf` into a var (`-v`), an perhaps with the POSIX `%b` format code. While suported by bash, `-v` and `%b`are not
>       available in mvdan.cc/sh and using a subshell invocation of printf has significant performance problems.
> 
> 
> On balance, I think a sensible strategy is to use the unicode escaping `\u000A`. This prevents verbatim use of a host env var that contains `\u000A`, but this is less likely to be seen that `\n` and we can document the limitation. Continuing to use something that really does represent a newline is also good for sanity's sake.
> 
> I considered changing the IFS, but that still doesn't buy us a complete solution. I don't think there are any great choices here really. We should address the issue properly when a solution is available. Perhaps this is via us contributing some more printf feature support to mvdan.cc/sh when resources allow, and if it would be accepted there.