### PR TITLE
build: Update build / package deps and deb: fix runtime libglib2.0-0 dependency, from sylabs 765 & 769

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,6 +27,7 @@ sudo apt-get install -y \
     squashfs-tools \
     squashfuse \
     cryptsetup \
+    runc \
     curl wget git
 ```
 
@@ -43,6 +44,7 @@ sudo yum install -y \
     squashfs-tools \
     squashfuse \
     cryptsetup \
+    runc \
     wget git
 ```
 
@@ -57,6 +59,9 @@ sudo zypper install -y \
   cryptsetup sysuser-tools \
   gcc go
 ```
+
+_Note - `runc` can be ommitted if you will not use the `apptainer oci`
+commands._
 
 ## Install Go
 

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -16,6 +16,7 @@ Build-Depends:
  uuid-dev,
  devscripts,
  libseccomp-dev,
+ libglib2.0-dev,
  cryptsetup,
  golang-go (>= 2:1.13~~)
 Standards-Version: 3.9.8
@@ -25,7 +26,7 @@ Vcs-Browser: https://github.com/apptainer/apptainer
 
 Package: apptainer
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, squashfs-tools, squashfuse
+Depends: ${misc:Depends}, ${shlibs:Depends}, libglib2.0, squashfs-tools, squashfuse, runc
 Conflicts: singularity-container
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -26,7 +26,7 @@ Vcs-Browser: https://github.com/apptainer/apptainer
 
 Package: apptainer
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libglib2.0, squashfs-tools, squashfuse, runc
+Depends: ${misc:Depends}, ${shlibs:Depends}, libglib2.0-0, squashfs-tools, squashfuse, runc
 Conflicts: singularity-container
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -64,12 +64,16 @@ BuildRequires: git
 BuildRequires: gcc
 BuildRequires: make
 BuildRequires: libseccomp-devel
+BuildRequires: cryptsetup
+
+Requires: cryptsetup
+Requires: glib2
+Requires: runc
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs
 %else
 Requires: squashfs-tools
 %endif
-BuildRequires: cryptsetup
 Requires: squashfuse
 
 %description


### PR DESCRIPTION
This pulls in sylabs PRs

- sylabs/singularity#765
- sylabs/singularity#769
which fixed
- sylabs/singularity#768

The original PR descriptions were:
> Tidy up the build vs runtime dependencies for 3.10 so that packages install deps for all functionality correctly.
> 
> Add `runc` dependency.
> Ensure `glib2` dependency is correct (for conmon).
> Ensure `cryptsetup` dependency is correct.

> The binary package is `libglib2.0-0` even if the headers are in `libglib2.0-dev` without the `-0`.
> 
> Also, the deb package build doesn't validate the requires, so my local test build did not catch this one. cry