### PR TITLE
Add container stats, from sylabs 784

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Non-root users can now use `--apply-cgroups` with `run/shell/exec` to limit
   container resource usage on a system using cgroups v2 and the systemd cgroups
   manager.
+- Add instance stats command.
 
 ### Bug fixes
 

--- a/LICENSE_THIRD_PARTY.md
+++ b/LICENSE_THIRD_PARTY.md
@@ -280,3 +280,11 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
+
+## github.com/docker/cli
+
+The source files:
+
+* `internal/app/apptainer/instance_linux.go`
+
+Contain code from the docker cli project, under the Apache License, Version 2.0.

--- a/cmd/internal/cli/instance_linux.go
+++ b/cmd/internal/cli/instance_linux.go
@@ -23,6 +23,7 @@ func init() {
 		cmdManager.RegisterSubCmd(instanceCmd, instanceStartCmd)
 		cmdManager.RegisterSubCmd(instanceCmd, instanceStopCmd)
 		cmdManager.RegisterSubCmd(instanceCmd, instanceListCmd)
+		cmdManager.RegisterSubCmd(instanceCmd, instanceStatsCmd)
 	})
 }
 

--- a/cmd/internal/cli/instance_stats_linux.go
+++ b/cmd/internal/cli/instance_stats_linux.go
@@ -1,0 +1,80 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Vanessa Sochat. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"os"
+
+	"github.com/apptainer/apptainer/docs"
+	"github.com/apptainer/apptainer/internal/app/apptainer"
+	"github.com/apptainer/apptainer/pkg/cmdline"
+	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/spf13/cobra"
+)
+
+// Basic Design
+// apptainer instance stats <name>
+// apptainer instance stats --json <name>
+
+func init() {
+	addCmdInit(func(cmdManager *cmdline.CommandManager) {
+		cmdManager.RegisterFlagForCmd(&instanceStatsUserFlag, instanceStatsCmd)
+		cmdManager.RegisterFlagForCmd(&instanceStatsJSONFlag, instanceStatsCmd)
+	})
+}
+
+// -u|--user
+var instanceStatsUser string
+
+var instanceStatsUserFlag = cmdline.Flag{
+	ID:           "instanceStatsUserFlag",
+	Value:        &instanceStatsUser,
+	DefaultValue: "",
+	Name:         "user",
+	ShortHand:    "u",
+	Usage:        "view stats for an instance belonging to a user (root only)",
+	Tag:          "<username>",
+	EnvKeys:      []string{"USER"},
+}
+
+// -j|--json
+var instanceStatsJSON bool
+
+var instanceStatsJSONFlag = cmdline.Flag{
+	ID:           "instanceStatsJSONFlag",
+	Value:        &instanceStatsJSON,
+	DefaultValue: false,
+	Name:         "json",
+	ShortHand:    "j",
+	Usage:        "output stats in json",
+}
+
+// apptainer instance stats
+var instanceStatsCmd = &cobra.Command{
+	Args:                  cobra.ExactArgs(1),
+	DisableFlagsInUseLine: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		uid := os.Getuid()
+
+		// Root is required to look at stats for another user
+		if instanceStatsUser != "" && uid != 0 {
+			sylog.Fatalf("Only the root user can look at stats of a user's instance")
+		}
+
+		// Instance name is the only arg
+		name := args[0]
+		return apptainer.InstanceStats(name, instanceStatsUser, instanceStatsJSON)
+	},
+
+	Use:     docs.InstanceStatsUse,
+	Short:   docs.InstanceStatsShort,
+	Long:    docs.InstanceStatsLong,
+	Example: docs.InstanceStatsExample,
+}

--- a/docs/content.go
+++ b/docs/content.go
@@ -555,6 +555,20 @@ Enterprise Performance Computing (EPC)`
   Stopping /tmp/my-sql.sif mysql`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// instance stats
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	InstanceStatsUse   string = `stats [stats options...] <instance name>`
+	InstanceStatsShort string = `Get stats for a named instance`
+	InstanceStatsLong  string = `
+  The instance stats command allows you to get statistics for a named instance,
+  either printed to the terminal or in json. If you are root, you can optionally
+  ask for statistics for a container instance belonging to a specific user.`
+	InstanceStatsExample string = `
+  $ apptainer instance stats mysql
+  $ apptainer instance stats --json mysql
+  $ sudo apptainer instance stats --user <username> user-mysql`
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// instance stop
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	InstanceStopUse   string = `stop [stop options...] [instance]`

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -43,6 +43,79 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
+// instanceStats tests an instance ability to output stats
+func (c *ctx) instanceStats(t *testing.T, profile e2e.Profile) {
+	e2e.EnsureImage(t, c.env)
+
+	// All tests require root
+	tests := []struct {
+		name           string
+		createArgs     []string
+		startErrorCode int
+		statsErrorCode int
+	}{
+		{
+			name:           "basic stats create",
+			createArgs:     []string{"--apply-cgroups", "testdata/cgroups/cpu_success.toml", c.env.ImagePath},
+			statsErrorCode: 0,
+			startErrorCode: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// stats only for privileged atm
+			if !profile.Privileged() {
+				t.Skip()
+			}
+
+			// We always expect stats output, not create
+			createExitFunc := []e2e.ApptainerCmdResultOp{}
+			instanceName := randomName(t)
+
+			// Start the instance with cgroups for stats
+			createArgs := append(tt.createArgs, instanceName)
+			c.env.RunApptainer(
+				t,
+				e2e.AsSubtest("start"),
+				e2e.WithProfile(profile),
+				e2e.WithCommand("instance start"),
+				e2e.WithArgs(createArgs...),
+				e2e.ExpectExit(tt.startErrorCode, createExitFunc...),
+			)
+
+			// Get stats for the instance
+			c.env.RunApptainer(
+				t,
+				e2e.AsSubtest("stats"),
+				e2e.WithProfile(profile),
+				e2e.WithCommand("instance stats"),
+				e2e.WithArgs(instanceName),
+				e2e.ExpectExit(tt.statsErrorCode,
+					e2e.ExpectOutput(e2e.ContainMatch, instanceName),
+					e2e.ExpectOutput(e2e.ContainMatch, "INSTANCE NAME"),
+					e2e.ExpectOutput(e2e.ContainMatch, "CPU USAGE"),
+					e2e.ExpectOutput(e2e.ContainMatch, "MEM USAGE / LIMIT"),
+					e2e.ExpectOutput(e2e.ContainMatch, "MEM %"),
+					e2e.ExpectOutput(e2e.ContainMatch, "BLOCK I/O"),
+					e2e.ExpectOutput(e2e.ContainMatch, "PIDS"),
+					e2e.ExpectOutput(e2e.ContainMatch, "GiB"),
+					e2e.ExpectOutput(e2e.ContainMatch, "KiB"),
+					e2e.ExpectOutput(e2e.ContainMatch, "MiB"),
+				),
+			)
+			c.env.RunApptainer(
+				t,
+				e2e.AsSubtest("stop"),
+				e2e.WithProfile(profile),
+				e2e.WithCommand("instance stop"),
+				e2e.WithArgs(instanceName),
+				e2e.ExpectExit(0),
+			)
+		})
+	}
+}
+
 // moved from INSTANCE suite, as testing with systemd cgroup manager requires
 // e2e to be run without PID namespace
 func (c *ctx) instanceApply(t *testing.T, profile e2e.Profile) {
@@ -164,6 +237,10 @@ func (c *ctx) instanceApply(t *testing.T, profile e2e.Profile) {
 
 func (c *ctx) instanceApplyRoot(t *testing.T) {
 	c.instanceApply(t, e2e.RootProfile)
+}
+
+func (c *ctx) instanceStatsRoot(t *testing.T) {
+	c.instanceStats(t, e2e.RootProfile)
 }
 
 // TODO - when instance support for rootless cgroups is ready, this
@@ -290,6 +367,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	np := testhelper.NoParallel
 
 	return testhelper.Tests{
+		"instance stats":            np(env.WithRootManagers(c.instanceStatsRoot)),
 		"instance root cgroups":     np(env.WithRootManagers(c.instanceApplyRoot)),
 		"instance rootless cgroups": np(env.WithRootlessManagers(c.instanceApplyRootless)),
 		"action root cgroups":       np(env.WithRootManagers(c.actionApplyRoot)),

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,8 @@ require (
 	oras.land/oras-go v1.1.1
 )
 
+require github.com/docker/go-units v0.4.0
+
 require (
 	github.com/AdamKorcz/go-fuzz-headers v0.0.0-20210319161527-f761c2329661 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
@@ -82,7 +84,6 @@ require (
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
-	github.com/docker/go-units v0.4.0 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/godbus/dbus/v5 v5.0.6 // indirect

--- a/internal/app/apptainer/instance_linux.go
+++ b/internal/app/apptainer/instance_linux.go
@@ -7,6 +7,9 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// Includes code from https://github.com/docker/cli
+// Released under the Apache License Version 2.0
+
 package apptainer
 
 import (
@@ -14,13 +17,18 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
+	"strings"
 	"syscall"
 	"text/tabwriter"
 	"time"
 
+	"github.com/apptainer/apptainer/internal/pkg/cgroups"
 	"github.com/apptainer/apptainer/internal/pkg/instance"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/fs/proc"
+	units "github.com/docker/go-units"
+	libcgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 )
 
 type instanceInfo struct {
@@ -126,19 +134,127 @@ func WriteInstancePidFile(name, pidFile string) error {
 	return nil
 }
 
+// instanceListOrError is a private function to retrieve named instances or fail if there are no instances
+// We wrap the error from instance.List to provide a more specific error message
+func instanceListOrError(instanceUser, name string) ([]*instance.File, error) {
+	ii, err := instance.List(instanceUser, name, instance.AppSubDir)
+	if err != nil {
+		return ii, fmt.Errorf("could not retrieve instance list: %w", err)
+	}
+	if len(ii) == 0 {
+		return ii, fmt.Errorf("no instance found")
+	}
+	return ii, err
+}
+
+// calculate BlockIO counts up read/write totals
+func calculateBlockIO(stats *libcgroups.BlkioStats) (float64, float64) {
+	var read, write float64
+	for _, entry := range stats.IoServiceBytesRecursive {
+		switch strings.ToLower(entry.Op) {
+		case "read":
+			read += float64(entry.Value)
+		case "write":
+			write += float64(entry.Value)
+		}
+	}
+	return read, write
+}
+
+// calculateMemoryUsage returns the current usage, limit, and percentage
+func calculateMemoryUsage(stats *libcgroups.MemoryStats) (float64, float64, float64) {
+	// Note that there is also MaxUsage
+	memUsage := float64(stats.Usage.Usage)
+	memLimit := 0.0
+	memPercent := 0.0
+
+	// Calculate total memory of system
+	in := &syscall.Sysinfo_t{}
+	err := syscall.Sysinfo(in)
+	if err == nil {
+		memLimit = float64(in.Totalram) * float64(in.Unit)
+	}
+	if memLimit != 0 {
+		memPercent = memUsage / memLimit * 100.0
+	}
+	return memUsage, memLimit, memPercent
+}
+
+// InstanceStats uses underlying cgroups to get statistics for a named instance
+func InstanceStats(name, instanceUser string, formatJSON bool) error {
+	ii, err := instanceListOrError(instanceUser, name)
+	if err != nil {
+		return err
+	}
+	// Instance stats required 1 instance
+	if len(ii) != 1 {
+		return fmt.Errorf("query returned more than one instance (%d)", len(ii))
+	}
+
+	// Grab our instance to interact with!
+	i := ii[0]
+	if !formatJSON {
+		sylog.Infof("Stats for %s instance of %s (PID=%d)\n", i.Name, i.Image, i.Pid)
+	}
+
+	// Cut out early if we do not have cgroups
+	if !i.Cgroup {
+		url := "the Apptainer instance user guide for instructions"
+		return fmt.Errorf("stats are only available if cgroups are enabled, see %s", url)
+	}
+
+	// Get a cgroupfs managed cgroup from the pid
+	manager, err := cgroups.GetManagerForPid(i.Pid)
+	if err != nil {
+		return fmt.Errorf("while getting cgroup manager for pid: %v", err)
+	}
+	stats, err := manager.GetStats()
+	if err != nil {
+		return fmt.Errorf("while getting stats for pid: %v", err)
+	}
+
+	// Do we want json?
+	if formatJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "\t")
+		err = enc.Encode(stats)
+		return err
+	}
+
+	// Otherwise print shortened table
+	tabWriter := tabwriter.NewWriter(os.Stdout, 0, 8, 4, ' ', 0)
+	defer tabWriter.Flush()
+
+	// Stats can be added from this set:
+	// https://github.com/opencontainers/runc/blob/main/libcontainer/cgroups/stats.go
+	_, err = fmt.Fprintln(tabWriter, "INSTANCE NAME\tCPU USAGE\tMEM USAGE / LIMIT\tMEM %\tBLOCK I/O\tPIDS")
+	if err != nil {
+		return fmt.Errorf("could not write stats header: %v", err)
+	}
+
+	// CpuUsage denotes the usage of a CPU, aggregate since container inception.
+	// TODO CPU time needs to be a percentage
+	totalCPUTime := strconv.FormatUint(stats.CpuStats.CpuUsage.TotalUsage, 10) + " ns"
+	memUsage, memLimit, memPercent := calculateMemoryUsage(&stats.MemoryStats)
+	blockRead, blockWrite := calculateBlockIO(&stats.BlkioStats)
+
+	// Generate a shortened stats list
+	_, err = fmt.Fprintf(tabWriter, "%s\t%s\t%s / %s\t%.2f%s\t%s / %s\t%d\n", i.Name, totalCPUTime, units.BytesSize(memUsage), units.BytesSize(memLimit), memPercent, "%", units.BytesSize(blockRead), units.BytesSize(blockWrite), stats.PidsStats.Current)
+	if err != nil {
+		return fmt.Errorf("could not write instance stats: %v", err)
+	}
+	return nil
+}
+
 // StopInstance fetches instance list, applying name and
 // user filters, and stops them by sending a signal sig. If an instance
 // is still running after a grace period defined by timeout is expired,
 // it will be forcibly killed.
 func StopInstance(name, user string, sig syscall.Signal, timeout time.Duration) error {
-	ii, err := instance.List(user, name, instance.AppSubDir)
+	ii, err := instanceListOrError(user, name)
 	if err != nil {
-		return fmt.Errorf("could not retrieve instance list: %v", err)
+		return err
 	}
-	if len(ii) == 0 {
-		return fmt.Errorf("no instance found")
-	}
-
 	stoppedPID := make(chan int, 1)
 	stopped := make([]int, 0)
 

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -110,6 +110,15 @@ func (m *Manager) GetCgroupRelPath() (relPath string, err error) {
 	return filepath.Clean(pathParts[1]), nil
 }
 
+// GetStats wraps the Manager.GetStats from runc
+func (m *Manager) GetStats() (*lccgroups.Stats, error) {
+	stats, err := m.cgroup.GetStats()
+	if err != nil {
+		return &lccgroups.Stats{}, fmt.Errorf("could not get stats from cgroups manager: %x", err)
+	}
+	return stats, nil
+}
+
 // UpdateFromSpec updates the existing managed cgroup using configuration from
 // an OCI LinuxResources spec struct.
 func (m *Manager) UpdateFromSpec(resources *specs.LinuxResources) (err error) {


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#784
which fixed
- sylabs/singularity#191

The original PR description was:
> This is the start of work to add `singularity instance stats <instance>` to show a similar view to docker stats, but for a singularity instance! As a test example:
> 
> ![image](https://user-images.githubusercontent.com/814322/167210816-252104e8-024b-4830-8975-2b12ddc49526.png)
> 
> The only wonky one is the CPU - and this is because the runc cgroups manager doesn't have any representation of percentages - what seems to be done with docker/podman is that you have to record two points in time and then calculate the difference. We can probably do that, but I was too lazy for this first shot. So for now - we have nanoseconds! laughing
> 
> To reproduce using this locally you can do:
> 
> ```shell
> $ touch null.toml
> $ sudo singularity instance start --apply-cgroups null.toml docker://busybox test
> ```
> 
> And then from your singularity built from the PR:
> 
> ```shell
> $ sudo ./singularity instance stats test 
> ```
> 
> ```shell
> INFO:    Stats for test instance of /home/vanessa/go/src/github.com/sylabs/singularity/busybox_latest.sif (PID=742982)
> INSTANCE NAME    CPU USAGE      MEM USAGE / LIMIT      MEM %    BLOCK I/O      PIDS
> test             38112275 ns    6.773MiB / 15.33GiB    0.04%    713KiB / 0B    7
> ```
> 
> Note that you can also add `--json` to get a large dump of data!
> 
> ```shell
> $ sudo ./singularity instance stats --json test 
> ```
> 
> I had added the `--user` flag but if it's the case that this _always_ needs to be run with sudo I'm not sure it makes sense? Let me know.