### PR TITLE
fix: Check image can be read before opening, from sylabs 788

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Fixed `FATAL` error thrown by user configuration migration code that caused
   users with inaccessible home directories to be unable to use `apptainer`
   commands.
+- Add specific error for unreadable image / overlay file.
 
 ## v1.0.1 - \[2022-03-15\]
 

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -401,7 +401,13 @@ func CopyFileAtomic(from, to string, mode os.FileMode) (err error) {
 	return nil
 }
 
-// IsWritable returns true of the file that is passed in
+// IsReadable returns true if the file that is passed in
+// is readable by the user (note: uid is checked, not euid).
+func IsReadable(path string) bool {
+	return unix.Access(path, unix.R_OK) == nil
+}
+
+// IsWritable returns true if the file that is passed in
 // is writable by the user (note: uid is checked, not euid).
 func IsWritable(path string) bool {
 	return unix.Access(path, unix.W_OK) == nil

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -370,6 +370,10 @@ func Init(path string, writable bool) (*Image, error) {
 	resolvedPath, err := ResolvePath(path)
 	if err != nil {
 		return nil, err
+	}
+
+	if !fs.IsReadable(resolvedPath) {
+		return nil, fmt.Errorf("%s is not readable by the current user, check permissions", resolvedPath)
 	}
 
 	img := &Image{


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#788
which fixed
- sylabs/singularity#786

The original PR description was:
> If an image cannot be read, attempts to open it with the various image format handling code will fail. Since we are using a fall-through approach to find the correct image format, these failures did not give a sensible error message.
> 
> Add an explicit check that the image is readable.
> 
> ```
> $ ls -lah overlay.img 
> ----------. 1 dtrudg dtrudg 1.0G May  4 10:55 overlay.img
> ```
> 
> Before...
> 
> ```
> $ singularity run --overlay overlay.img busybox_latest.sif 
> FATAL:   while loading overlay images: failed to open overlay image overlay.img: image format not recognized
> ```
> 
> After...
> 
> ```
> $ singularity run --overlay overlay.img busybox_latest.sif 
> FATAL:   while loading overlay images: failed to open overlay image overlay.img: /home/dtrudg/overlay.img is not readable by the current user, check permissions
> ```