### PR TITLE
 refactor: add files section helpers , from sylabs 783

### DIFF
--- a/pkg/build/types/definition.go
+++ b/pkg/build/types/definition.go
@@ -31,6 +31,12 @@ type Definition struct {
 	AppOrder []string `json:"appOrder"`
 }
 
+// WriteRaw writes the contents of definition d to w.
+func (d *Definition) WriteRaw(w io.Writer) error {
+	populateRaw(d, w)
+	return nil
+}
+
 // ImageData contains any scripts, metadata, etc... that needs to be
 // present in some form in the final built image.
 type ImageData struct {

--- a/pkg/build/types/definition.go
+++ b/pkg/build/types/definition.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 )
 
@@ -68,10 +69,43 @@ type Files struct {
 	Files []FileTransport `json:"files"`
 }
 
+// Stage returns the build stage referenced by the files section f, or "" if no stage is
+// referenced.
+func (f Files) Stage() string {
+	// Trim comments from args.
+	cleanArgs := strings.SplitN(f.Args, "#", 2)[0]
+
+	// If "stage <name>", return "<name>".
+	if args := strings.Fields(cleanArgs); len(args) == 2 && args[0] != "stage" {
+		return args[1]
+	}
+
+	return ""
+}
+
 // FileTransport holds source and destination information of files to copy into the container.
 type FileTransport struct {
 	Src string `json:"source"`
 	Dst string `json:"destination"`
+}
+
+// SourcePath returns the source path in the format as specified by the io/fs package.
+func (ft FileTransport) SourcePath() (string, error) {
+	path, err := filepath.Abs(ft.Src)
+	if err != nil {
+		return "", err
+	}
+
+	// Paths are slash-separated.
+	path = filepath.ToSlash(path)
+
+	// Special case: the root directory is named ".".
+	if path == "/" {
+		return ".", nil
+	}
+
+	// Paths must not start with a slash.
+	return strings.TrimPrefix(path, "/"), nil
 }
 
 // Script describes any script section of a definition.


### PR DESCRIPTION
This pulls in sylabs part of PR

- sylabs/singularity#783

The original PR description was:
> Add support for `%files` section during a remote build. This requires a compatible remote. Add `(Files).Stage()` and `(FileTransport).SourcePath()` helpers.