### PR TITLE
adding support for --sparse when creating ext3, from sylabs 864

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes Since Last Release
+
+### New features / functionalities
+
+- Add `--sparse` flag to `overlay create` command to allow generation of a
+  sparse ext3 overlay image.
+
 ## v1.1.0-rc.2 - \[2022-08-16\]
 
 ### Changed defaults / behaviours

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,8 @@ acknowledging that you agree to the [Developer Certificate of Origin](DCO.md).
      [this post on golang.org](https://golang.org/doc/effective_go.html#commentary)
 1. Make sure you have locally tested using `make -C builddir test` and that all
    tests succeed before submitting the PR.
+1. If you accidentally changed code in a submodule, you can undo it like
+   `git submodule foreach --recursive git reset --hard` before committing.
 1. If possible, run `make -C builddir testall` locally, after setting the
    environment variables `E2E_DOCKER_USERNAME` and `E2E_DOCKER_PASSWORD`
    appropriately for an authorized Docker Hub account. This is required as

--- a/cmd/internal/cli/overlay.go
+++ b/cmd/internal/cli/overlay.go
@@ -21,6 +21,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&overlaySizeFlag, OverlayCreateCmd)
 		cmdManager.RegisterFlagForCmd(&overlayCreateDirFlag, OverlayCreateCmd)
 		cmdManager.RegisterFlagForCmd(&overlayFakerootFlag, OverlayCreateCmd)
+		cmdManager.RegisterFlagForCmd(&overlaySparseFlag, OverlayCreateCmd)
 	})
 }
 

--- a/cmd/internal/cli/overlay_create.go
+++ b/cmd/internal/cli/overlay_create.go
@@ -17,6 +17,7 @@ var (
 	overlaySize       int
 	overlayDirs       []string
 	isOverlayFakeroot bool
+	overlaySparse     bool
 )
 
 // -s|--size
@@ -27,6 +28,17 @@ var overlaySizeFlag = cmdline.Flag{
 	Name:         "size",
 	ShortHand:    "s",
 	Usage:        "size of the EXT3 writable overlay in MiB",
+}
+
+// --sparse/-S
+var overlaySparseFlag = cmdline.Flag{
+	ID:           "overlaySparseFlag",
+	Value:        &overlaySparse,
+	DefaultValue: false,
+	Name:         "sparse",
+	ShortHand:    "S",
+	Usage:        "create a sparse overlay",
+	EnvKeys:      []string{"SPARSE"},
 }
 
 // --create-dir
@@ -53,7 +65,7 @@ var overlayFakerootFlag = cmdline.Flag{
 var OverlayCreateCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := apptainer.OverlayCreate(overlaySize, args[0], isOverlayFakeroot, overlayDirs...); err != nil {
+		if err := apptainer.OverlayCreate(overlaySize, args[0], overlaySparse, isOverlayFakeroot, overlayDirs...); err != nil {
 			sylog.Fatalf(err.Error())
 		}
 		return nil

--- a/docs/content.go
+++ b/docs/content.go
@@ -1083,6 +1083,9 @@ Enterprise Performance Computing (EPC)`
   To create a single EXT3 writable overlay image:
   $ apptainer overlay create --size 1024 /tmp/my_overlay.img
 
+  To create a sparse overlay when creating a new ext3 file system image:
+  $ apptainer overlay create --size 1024 --sparse /tmp/ext3_overlay.img
+
   To create an EXT3 writable overlay image for use with --fakeroot actions:
   $ apptainer overlay create --fakeroot --size 1024 /tmp/my_overlay.img`
 

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -90,6 +90,13 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 			exit:    255,
 		},
 		{
+			name:    "create ext3 sparse overlay image",
+			profile: e2e.UserProfile,
+			command: "overlay",
+			args:    []string{"create", "--size", "128", "--sparse", ext3Image},
+			exit:    0,
+		},
+		{
 			name:    "create ext3 overlay image",
 			profile: e2e.UserProfile,
 			command: "overlay",

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -34,6 +34,7 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 
 	sifSignedImage := filepath.Join(tmpDir, "signed.sif")
 	sifImage := filepath.Join(tmpDir, "unsigned.sif")
+	ext3SparseImage := filepath.Join(tmpDir, "image.sparse.ext3")
 	ext3Image := filepath.Join(tmpDir, "image.ext3")
 	ext3DirImage := filepath.Join(tmpDir, "imagedir.ext3")
 
@@ -93,7 +94,7 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 			name:    "create ext3 sparse overlay image",
 			profile: e2e.UserProfile,
 			command: "overlay",
-			args:    []string{"create", "--size", "128", "--sparse", ext3Image},
+			args:    []string{"create", "--size", "128", "--sparse", ext3SparseImage},
 			exit:    0,
 		},
 		{

--- a/internal/app/apptainer/overlay_create.go
+++ b/internal/app/apptainer/overlay_create.go
@@ -84,7 +84,7 @@ func findConvertCommand(overlaySparse bool) (string, error) {
 
 	// Sparse overlay requires truncate -s
 	if overlaySparse {
-		truncate, err := exec.LookPath(truncateBinary)
+		truncate, err := bin.FindBin(truncateBinary)
 		if err != nil {
 			return command, err
 		}

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -37,6 +37,7 @@ func FindBin(name string) (path string, err error) {
 		"rm",
 		"stdbuf",
 		"true",
+		"truncate",
 		"uname":
 		return findOnPath(name, true)
 	// Executables that might be run privileged from the suid flow


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 864
 which fixed
- sylabs/singularity# 610

The original PR description was:

> We basically want to add support for a sparse overlay, and we can do that by using truncate -s (size) instead of dd. In the case the command is not found, an error is issued and the user can decide to install or not use it. I think it would be overkill to hard code information about all OS versions / support but if anyone has ideas for how to reasonably do this we can return a more specific error message. I am not running the e2e tests locally but will see how they do in the CI! :)