### PR TITLE
e2e: Add E2E_GROUPS & E2E_TESTS to filter e2e test runs, from sylabs 860

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ For older changes see the [archived Singularity change log](https://github.com/a
   modes: `--userns` like the action flag and hidden options `--ignore-subuid`,
   `--ignore-fakeroot-command`, and `--ignore-userns`.
 
+### Development / Testing
+
+- The `e2e-test` makefile target now accepts an argument `E2E_GROUPS` to only
+  run specified groups of end to end tests. E.g. `make -C builddir e2e-test
+  E2E_GROUPS=VERSION,HELP` will run end to end tests in the `VERSION` and `HELP`
+  groups only.
+- The `e2e-test` makefile target now accepts an argument `E2E_TESTS` which is a
+  regular expression specifying the names of (top level) end to end tests that
+  should be run. E.g. `make -C builddir e2e-test E2E_TESTS=^semantic` will only
+  run end to end tests with a name that begins with `semantic`.
+
 ## v1.1.0-rc.1 - \[2022-08-01\]
 
 ### Changed defaults / behaviours

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,141 +1,175 @@
 # End-to-End Testing
 
-This package contains the end-to-end tests for `apptainer`.
+This package contains the end-to-end (e2e) tests for `apptainer`.
 
 ## Contributing
 
-For this example, we're going to use a topic of `env` or
-`environment variable tests`.
+The e2e tests are split into *groups*, which gather tests that exercise a
+specific area of functionality.
 
-- Add your topic as a runtime-hook in `suite.go`.
+For this example, we're going to use a a group called `ENV` which would hold
+tests relevant to environment variable handling.
+
+- Add your group into the `e2eGroups` struct in `suite.go`. This is a map from
+  the name of the group (in upper case), to the `E2ETests` function declared
+  in the group's package.
 
 ```go
-// RunE2ETests by functionality
-t.Run("BUILD", imgbuild.RunE2ETests)
-t.Run("ACTIONS", actions.RunE2ETests)
-t.Run("ENV", env.RunE2ETests)
+var e2eGroups = map[string]testhelper.Group{
+    ...
+    "ENV":        env.E2ETests,
 ```
 
-- Create a directory for your topic.
+- Now create a directory for your group.
 
 ```sh
 mkdir -p e2e/env
 ```
 
-- Create a source file to include your topic's tests.
+- Create a source file that will hold your groups's tests.
 
 ```sh
 touch e2e/env/env.go
 ```
 
-- Optionally create a source file to include helpers for your topic's test.
+- Optionally create a source file to include helpers for your group's test.
 
 ```sh
 touch e2e/env/env_utils.go
 ```
 
-- Add a package declaration to your topic's test file that matches what you put
-  in `suite.go`
+- Add a package declaration to the test file (e2e/env/env.go) that matches what
+  you put in `suite.go`
 
 ```go
 package env
 ```
 
-- Add a variable to store the testing settings in your topic's test file.
+- Declare a ctx struct that holds the `e2e.TestEnv` structure, and can be
+  extended with any other group-specific variables.
 
 ```go
-import (
-        "github.com/kelseyhightower/envconfig"
-)
-
-type testingEnv struct {
-	// base env for running tests
-	CmdPath     string `split_words:"true"`
-	TestDir     string `split_words:"true"`
-	RunDisabled bool   `default:"false"`
-}
-
-var testenv testingEnv
-```
-
-- Add a entry-point to your topic's test file that matches what you put in
-  `suite.go`
-
-```go
-//RunE2ETests is the main func to trigger the test suite
-func RunE2ETests(t *testing.T) {
-	err := envconfig.Process("E2E", &testenv)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+type ctx struct {
+    env e2e.TestEnv
 }
 ```
 
-- Create a test in your topic's test file as you normally would in `go`.
+- Add tests, which are member functions of the `ctx`. The following example
+  tests that when an environment variable is set, it can be echoed from a
+  `apptainer exec`.
 
 ```go
-func TestEnv(t *Testing.T) {
-	...
+func (c ctx) echoEnv(t *testing.T) {
+    e2e.EnsureImage(t, c.env)
+
+    env := []string{`FOO=BAR`}
+    c.env.RunApptainer(
+        t,
+        e2e.WithProfile(e2e.UserProfile),
+        e2e.WithCommand("exec"),
+        e2e.WithEnv(env),
+        e2e.WithArgs("/bin/sh", "-c" "echo $FOO"),
+        e2e.ExpectExit(
+            0,
+            e2e.ExpectOutput(e2e.ExactMatch, "BAR"),
+        ),
+    )
+}
+
+```
+
+Note that we use a helper function `e2e.EnsureImage` to make sure the test image
+that we will run has been created. We use the `c.env.RunApptainer` function to
+actually execute `apptainer`, and specify arguments, expected output etc.
+
+- Now add a public `E2ETests` function to the package, which returns a
+  `testhelper.Tests` struct, holding the test we want to run:
+
+```go
+func E2ETests(env e2e.TestEnv) testhelper.Tests {
+    c := ctx{
+        env: env,
+    }
+
+    return testhelper.Tests{
+        "environment echo": c.echoEnv,
+    }
 }
 ```
 
-- Run your test from your entry-point function using a `go` sub-test.
-
-```go
-//RunE2ETests is the main func to trigger the test suite
-func RunE2ETests(t *testing.T) {
-	err := envconfig.Process("E2E", &testenv)
-        if err != nil {
-        	t.Fatal(err.Error())
-        }
-        
-	// Add tests
-	t.Run("TestEnv", TestEnv)
-}
-```
-
-- Example of what your topic's test file might look like:
+- Putting this altogether, the `e2e/env/env.go` will look like:
 
 ```go
 package env 
 
 import (
-	"github.com/kelseyhightower/envconfig"
+    "testing"
+
+    "github.com/apptainer/apptainer/e2e/internal/e2e"
+    "github.com/apptainer/apptainer/e2e/internal/testhelper"
 )
 
-type testingEnv struct {
-	// base env for running tests
-	CmdPath     string `split_words:"true"`
-	TestDir     string `split_words:"true"`
-	RunDisabled bool   `default:"false"`
+type ctx struct {
+    env e2e.TestEnv
 }
 
-var testenv testingEnv
+func (c ctx) echoEnv(t *testing.T) {
+    e2e.EnsureImage(t, c.env)
 
-func TestEnv(t *testing.T) {
-	...
+    env := []string{`FOO=BAR`}
+    c.env.RunApptainer(
+        t,
+        e2e.WithProfile(e2e.UserProfile),
+        e2e.WithCommand("exec"),
+        e2e.WithEnv(env),
+        e2e.WithArgs("/bin/sh", "-c" "echo $FOO"),
+        e2e.ExpectExit(
+            0,
+            e2e.ExpectOutput(e2e.ExactMatch, "BAR"),
+        ),
+    )
 }
 
-//RunE2ETests is the main func to trigger the test suite
-func RunE2ETests(t *testing.T) {
-	err := envconfig.Process("E2E", &testenv)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+func E2ETests(env e2e.TestEnv) testhelper.Tests {
+    c := ctx{
+        env: env,
+    }
 
-	t.Run("TestEnv", TestEnv)
+    return testhelper.Tests{
+        "environment echo": c.echoEnv,
+    }
 }
 ```
 
 ## Running
 
-Test your topic using the `e2e` target in the `Makefile`. To avoid skipping
-these tests (default), make sure you set the environment variable
-`APPTAINER_E2E` to `1`.
+To run all end to end tests, use the `e2e-tests` make target:
 
 ```sh
-APPTAINER_E2E=1 make -C builddir e2e-test
+make -C builddir e2e-test
 ```
 
-- Verify that your test was run by modifying the `Makefile` to add a verbose
-  flag (`go test -v`) and re-running the previous `make` step.
+To run all tests in a specific group, or groups, specify the group names (comma
+seperated) in an `E2E_GROUPS=` argument to the make target:
+
+```sh
+# Only run tests in the VERSION and HELP groups
+make -C builddir e2e-test E2E_GROUPS=VERSION,HELP
+```
+
+To run specific top-level tests (as defined in the `testhelper.Tests` struct
+returned by eache group's `E2ETests` function) supply a regular expression in an
+`E2E_TESTS` argument to the make target:
+
+```sh
+# Only run e2e tests with a name that begins with 'semantic'
+make -C builddir e2e-test E2E_TESTS=^semantic
+```
+
+You can combine the `E2E_GROUPS` and `E2E_TESTS` arguments to limit the tests
+that are run:
+
+```sh
+# Only run e2e tests in the VERSION group that have a name that begins with 'semantic'
+make -C builddir e2e-test E2E_GROUP=VERSION E2E_TESTS=^semantic
+```

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -58,10 +58,48 @@ import (
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
 	"github.com/apptainer/apptainer/e2e/internal/testhelper"
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
+	"github.com/apptainer/apptainer/pkg/util/slice"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
 )
 
-var runDisabled = flag.Bool("run_disabled", false, "run tests that have been temporarily disabled")
+var (
+	runDisabled = flag.Bool("run_disabled", false, "run tests that have been temporarily disabled")
+	runGroups   = flag.String("e2e_groups", "", "specify a comma separated list of e2e groups to run")
+	runTests    = flag.String("e2e_tests", "", "specify a regex matching e2e tests to run")
+)
+
+// Groups run inside a PID NS
+var e2eGroups = map[string]testhelper.Group{
+	"ACTIONS":    actions.E2ETests,
+	"BUILDCFG":   e2ebuildcfg.E2ETests,
+	"BUILD":      imgbuild.E2ETests,
+	"CACHE":      cache.E2ETests,
+	"CGROUPS":    cgroups.E2ETests,
+	"CMDENVVARS": cmdenvvars.E2ETests,
+	"CONFIG":     config.E2ETests,
+	"DELETE":     delete.E2ETests,
+	"DOCKER":     docker.E2ETests,
+	"ECL":        ecl.E2ETests,
+	"ENV":        apptainerenv.E2ETests,
+	"GPU":        gpu.E2ETests,
+	"HELP":       help.E2ETests,
+	"INSPECT":    inspect.E2ETests,
+	"INSTANCE":   instance.E2ETests,
+	"KEY":        key.E2ETests,
+	"LEGACY":     legacy.E2ETests,
+	"OCI":        oci.E2ETests,
+	"OVERLAY":    overlay.E2ETests,
+	"PLUGIN":     plugin.E2ETests,
+	"PULL":       pull.E2ETests,
+	"PUSH":       push.E2ETests,
+	"REMOTE":     remote.E2ETests,
+	"RUN":        run.E2ETests,
+	"RUNHELP":    runhelp.E2ETests,
+	"SECURITY":   security.E2ETests,
+	"SIGN":       sign.E2ETests,
+	"VERIFY":     verify.E2ETests,
+	"VERSION":    version.E2ETests,
+}
 
 // Run is the main func for the test framework, initializes the required vars
 // and sets the environment for the RunE2ETests framework
@@ -175,34 +213,16 @@ func Run(t *testing.T) {
 
 	suite := testhelper.NewSuite(t, testenv)
 
-	suite.AddGroup("ACTIONS", actions.E2ETests)
-	suite.AddGroup("BUILDCFG", e2ebuildcfg.E2ETests)
-	suite.AddGroup("BUILD", imgbuild.E2ETests)
-	suite.AddGroup("CACHE", cache.E2ETests)
-	suite.AddGroup("CGROUPS", cgroups.E2ETests)
-	suite.AddGroup("CMDENVVARS", cmdenvvars.E2ETests)
-	suite.AddGroup("CONFIG", config.E2ETests)
-	suite.AddGroup("DELETE", delete.E2ETests)
-	suite.AddGroup("DOCKER", docker.E2ETests)
-	suite.AddGroup("ECL", ecl.E2ETests)
-	suite.AddGroup("ENV", apptainerenv.E2ETests)
-	suite.AddGroup("GPU", gpu.E2ETests)
-	suite.AddGroup("HELP", help.E2ETests)
-	suite.AddGroup("INSPECT", inspect.E2ETests)
-	suite.AddGroup("INSTANCE", instance.E2ETests)
-	suite.AddGroup("KEY", key.E2ETests)
-	suite.AddGroup("LEGACY", legacy.E2ETests)
-	suite.AddGroup("OCI", oci.E2ETests)
-	suite.AddGroup("OVERLAY", overlay.E2ETests)
-	suite.AddGroup("PLUGIN", plugin.E2ETests)
-	suite.AddGroup("PULL", pull.E2ETests)
-	suite.AddGroup("PUSH", push.E2ETests)
-	suite.AddGroup("REMOTE", remote.E2ETests)
-	suite.AddGroup("RUN", run.E2ETests)
-	suite.AddGroup("RUNHELP", runhelp.E2ETests)
-	suite.AddGroup("SECURITY", security.E2ETests)
-	suite.AddGroup("SIGN", sign.E2ETests)
-	suite.AddGroup("VERIFY", verify.E2ETests)
-	suite.AddGroup("VERSION", version.E2ETests)
-	suite.Run()
+	groups := []string{}
+	if runGroups != nil && *runGroups != "" {
+		groups = strings.Split(*runGroups, ",")
+	}
+
+	for key, val := range e2eGroups {
+		if len(groups) == 0 || slice.ContainsString(groups, key) {
+			suite.AddGroup(key, val)
+		}
+	}
+
+	suite.Run(runTests)
 }

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -68,7 +68,11 @@ short-integration-test:
 		./pkg/network
 	@echo "       PASS"
 
+
 .PHONY: e2e-test
+
+e2e-test: GROUPS_FLAG := $(if $(E2E_GROUPS),-e2e_groups $(E2E_GROUPS))
+e2e-test: TESTS_FLAG := $(if $(E2E_TESTS),-e2e_tests $(E2E_TESTS))
 e2e-test: EXTRA_FLAGS := $(if $(filter yes,$(strip $(JUNIT_OUTPUT))),-junit $(BUILDDIR_ABSPATH)/e2e-test.xml)
 e2e-test:
 	# Run the majority of e2e tests, which will use a separate pid and mount namespace
@@ -76,7 +80,7 @@ e2e-test:
 	$(V)rm -f $(BUILDDIR_ABSPATH)/e2e-cmd-coverage
 	$(V)cd $(SOURCEDIR) && \
 		APPTAINER_E2E_COVERAGE=$(BUILDDIR_ABSPATH)/e2e-cmd-coverage \
-		scripts/e2e-test -v $(GO_RACE) $(EXTRA_FLAGS)
+		scripts/e2e-test -v $(GO_RACE) $(EXTRA_FLAGS $(GROUPS_FLAG) $(TESTS_FLAG))
 	@echo "       PASS"
 	@echo " TEST e2e-coverage"
 	$(V)cd $(SOURCEDIR) && \

--- a/scripts/e2e-test
+++ b/scripts/e2e-test
@@ -4,6 +4,8 @@
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 
+set +x
+
 if test ! -e scripts/go-test ; then
 	echo 'E: Cannot find scripts/go-test. Abort.'
 	exit 1

--- a/scripts/go-test.in
+++ b/scripts/go-test.in
@@ -114,6 +114,16 @@ for arg in "$@" ; do
 			set -- "$@" -v
 			;;
 
+		-e2e_groups)
+		    e2e_groups="${1}"
+			skip=true
+			;;
+
+		-e2e_tests)
+			e2e_tests="${1}"
+			skip=true
+			;;
+
 		*)
 			set -- "$@" "${arg}"
 			;;
@@ -124,6 +134,22 @@ if ${use_gotestsum} ; then
 	if ${verbose} ; then
 		gotestrunner_format=standard-verbose
 	fi
+fi
+
+if ${use_gotestsum} ; then
+	if ${verbose} ; then
+		gotestrunner_format=standard-verbose
+	fi
+fi
+
+if  [ -n "${e2e_groups}" ] ; then
+	set -- "$@" "-e2e_groups"
+	set -- "$@" "${e2e_groups}"
+fi
+
+if  [ -n "${e2e_tests}" ] ; then
+	set -- "$@" "-e2e_tests"
+	set -- "$@" "${e2e_tests}"
 fi
 
 # capture exit code


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 860
 which fixed
- sylabs/singularity# 820

The original PR description was:
> The e2e test suite is cumbersome for developers. To date it has not
> been possible to run a subset of tests without commenting out portions
> of the `suite.go` and group specific test code.
> 
> Add an `E2E_GROUPS` argument to the `make e2e-test` target that will
> allow developers to run only the specificed groups of e2e tests.
> 
> Add an `E2E_TESTS` argument to the `make e2e-test` target that takes a
> regexp to filter the top-level test names that will be run.
> 
> ```
> # Only run tests in the VERSION and HELP groups
> make -C builddir e2e-test E2E_GROUPS=VERSION,HELP
> ```
> 
> To run specific top-level tests (as defined in the `testhelper.Tests`
> struct returned by each group's `E2ETests` function) supply a regular
> expression in an `E2E_TESTS` argument to the make target:
> 
> ```
> # Only run e2e tests with a name that begins with 'semantic'
> make -C builddir e2e-test E2E_TESTS=^semantic
> ```
> 
> You can combine the `E2E_GROUPS` and `E2E_TESTS` arguments to limit
> the tests that are run:
> 
> ```
> # Only run e2e tests in the VERSION group that have a name that begins with 'semantic'
> make -C builddir e2e-test E2E_GROUP=VERSION E2E_TESTS=^semantic
> ```
> 
> Also tidied up the docs, minimally.