### PR TITLE
adding interactive stats to instance stats, from sylabs 894

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes Since Last Release
+
+### New features / functionalities
+
+- The `instance stats` command displays the resource usage every second. The
+  `--no-stream` option disables this interactive mode and shows the
+  point-in-time usage.
+
 ## v1.1.0-rc.2 - \[2022-08-16\]
 
 ### Changed defaults / behaviours

--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -581,6 +581,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/blang/semver/blob/master/v4/LICENSE>
 
+## github.com/buger/goterm
+
+**License:** MIT
+
+**License URL:** <https://github.com/buger/goterm/blob/master/LICENSE>
+
 ## github.com/buger/jsonparser
 
 **License:** MIT

--- a/cmd/internal/cli/instance_stats_linux.go
+++ b/cmd/internal/cli/instance_stats_linux.go
@@ -27,6 +27,7 @@ func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterFlagForCmd(&instanceStatsUserFlag, instanceStatsCmd)
 		cmdManager.RegisterFlagForCmd(&instanceStatsJSONFlag, instanceStatsCmd)
+		cmdManager.RegisterFlagForCmd(&instanceStatsNoStreamFlag, instanceStatsCmd)
 	})
 }
 
@@ -56,6 +57,18 @@ var instanceStatsJSONFlag = cmdline.Flag{
 	Usage:        "output stats in json",
 }
 
+// --no-stream
+
+var instanceStatsNoStream bool
+
+var instanceStatsNoStreamFlag = cmdline.Flag{
+	ID:           "instanceStatsNoStreamFlag",
+	Value:        &instanceStatsNoStream,
+	DefaultValue: false,
+	Name:         "no-stream",
+	Usage:        "disable streaming (live update) of instance stats",
+}
+
 // apptainer instance stats
 var instanceStatsCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
@@ -70,7 +83,7 @@ var instanceStatsCmd = &cobra.Command{
 
 		// Instance name is the only arg
 		name := args[0]
-		return apptainer.InstanceStats(name, instanceStatsUser, instanceStatsJSON)
+		return apptainer.InstanceStats(cmd.Context(), name, instanceStatsUser, instanceStatsJSON, instanceStatsNoStream)
 	},
 
 	Use:     docs.InstanceStatsUse,

--- a/docs/content.go
+++ b/docs/content.go
@@ -566,10 +566,13 @@ Enterprise Performance Computing (EPC)`
 	InstanceStatsLong  string = `
   The instance stats command allows you to get statistics for a named instance,
   either printed to the terminal or in json. If you are root, you can optionally
-  ask for statistics for a container instance belonging to a specific user.`
+  ask for statistics for a container instance belonging to a specific user. If
+  you add --no-stream, you will only see one timepoint. Asking for json implies
+  the same.`
 	InstanceStatsExample string = `
   $ apptainer instance stats mysql
   $ apptainer instance stats --json mysql
+  $ apptainer instance stats --no-stream mysql
   $ sudo apptainer instance stats --user <username> user-mysql`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -92,7 +92,7 @@ func (c *ctx) instanceStats(t *testing.T, profile e2e.Profile) {
 				e2e.AsSubtest("stats"),
 				e2e.WithProfile(profile),
 				e2e.WithCommand("instance stats"),
-				e2e.WithArgs(instanceName),
+				e2e.WithArgs("--no-stream", instanceName),
 				e2e.ExpectExit(tt.statsErrorCode,
 					e2e.ExpectOutput(e2e.ContainMatch, instanceName),
 					e2e.ExpectOutput(e2e.ContainMatch, "INSTANCE NAME"),

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/apptainer/container-library-client v1.3.3
 	github.com/apptainer/sif/v2 v2.7.2
 	github.com/blang/semver/v4 v4.0.0
+	github.com/buger/goterm v1.0.4
 	github.com/buger/jsonparser v1.1.1
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/containerd/containerd v1.6.8

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
+github.com/buger/goterm v1.0.4 h1:Z9YvGmOih81P0FbVtEYTFF6YsSgxSUKEhf/f9bTMXbY=
+github.com/buger/goterm v1.0.4/go.mod h1:HiFWV3xnkolgrBV3mY8m0X0Pumt4zg4QhbdOzQtB8tE=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
@@ -1774,6 +1776,7 @@ golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 894
 which fixed
- sylabs/singularity# 892

The original PR description was:
> This PR will add streaming stats, meaning that we get (and refresh) stats each second on a running instance instead of showing one timepoint. The default will be to stream stats for an instance, meaning pinging for an update every second. If --no-stream is added we only print one timepoint.
> 
> Here is how I tested locally:
> 
> ```shell
> cd ./builddir
> make
> ```
> 
> ```shell
> $ touch null.toml
> $ sudo singularity instance start --apply-cgroups null.toml docker://busybox test
> ```
> 
> ```shell
> $ sudo ./singularity instance stats test 
> ```
> 
> And then stream!
> 
> ```shell
> $ sudo ./singularity instance stats test
> INFO:    Stats for test instance of /root/.singularity/cache/oci-tmp/3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83 (PID=1257775)
> INSTANCE NAME    CPU USAGE    MEM USAGE / LIMIT    MEM %    BLOCK I/O    PIDS
> test    55749960 ns    6.027MiB / 15.33GiB    0.04%    522KiB / 0B    7
> test    55749960 ns    6.027MiB / 15.33GiB    0.04%    522KiB / 0B    7
> test    55749960 ns    6.027MiB / 15.33GiB    0.04%    522KiB / 0B    7
> test    55749960 ns    6.027MiB / 15.33GiB    0.04%    522KiB / 0B    7
> test    55749960 ns    6.027MiB / 15.33GiB    0.04%    522KiB / 0B    7
> test    55749960 ns    6.027MiB / 15.33GiB    0.04%    522KiB / 0B    7
> test    55749960 ns    6.027MiB / 15.33GiB    0.04%    522KiB / 0B    7
> test    55749960 ns    6.027MiB / 15.33GiB    0.04%    522KiB / 0B    7
> test    55749960 ns    6.027MiB / 15.33GiB    0.04%    522KiB / 0B    7
> ^CINFO:    Detected Control + C, exiting.
> ```
> 
> I also shelled in and made sure to goof off a bit to ensure that the stats were updating (they were).