### PR TITLE
feat: non-root, non --fakeroot builds with proot, from sylabs 879

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,9 @@ jobs:
       - name: Fetch deps
         run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup
 
+      - name: Install proot
+        run: sudo curl -L -o /usr/local/bin/proot https://proot.gitlab.io/proot/bin/proot && sudo chmod +x /usr/local/bin/proot 
+
       - name: Build and install Apptainer
         run: |
           ./mconfig -v -p /usr/local --with-suid
@@ -200,6 +203,9 @@ jobs:
 
       - name: Fetch deps
         run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
+
+      - name: Install proot
+        run: sudo curl -L -o /usr/local/bin/proot https://proot.gitlab.io/proot/bin/proot && sudo chmod +x /usr/local/bin/proot
 
       - name: Build and install Apptainer
         run: |
@@ -245,6 +251,9 @@ jobs:
       - name: Fetch deps
         if: env.run_tests
         run: sudo apt-get -q update && sudo apt-get install -y build-essential uidmap squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup
+
+      - name: Install proot
+        run: sudo curl -L -o /usr/local/bin/proot https://proot.gitlab.io/proot/bin/proot && sudo chmod +x /usr/local/bin/proot
 
       - name: Build and install Apptainer
         if: env.run_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,23 @@ For older changes see the [archived Singularity change log](https://github.com/a
   modes: `--userns` like the action flag and hidden options `--ignore-subuid`,
   `--ignore-fakeroot-command`, and `--ignore-userns`.
 
+### New features / functionalities
+
+- Non-root users can now build from a definition file, on systems that do not
+  support `--fakeroot`. This requires the statically built `proot` command
+  (<https://proot-me.github.io/>) to be available on the user `PATH`. These builds:
+  - Do not support `arch` / `debootstrap` / `yum` / `zypper` bootstraps. Use
+    `localimage`, `library`, `oras`, or one of the docker/oci sources.
+  - Do not support `%pre` and `%setup` sections.
+  - Run the `%post` sections of a build in the container as an emulated root
+    user.
+  - Run the `%test` section of a build as the non-root user, like `apptainer
+    test`.
+  - Are subject to any restrictions imposed in `apptainer.conf`.
+  - Incur a performance penalty due to `proot`'s `ptrace` based interception of syscalls.
+  - May fail if the `%post` script requires privileged operations that `proot`
+    cannot emulate.
+
 ## v1.1.0-rc.1 - \[2022-08-01\]
 
 ### Changed defaults / behaviours

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -42,6 +42,7 @@ var (
 	NoMount          []string
 	DMTCPLaunch      string
 	DMTCPRestart     string
+	Proot            string
 
 	IsBoot          bool
 	IsFakeroot      bool
@@ -802,6 +803,17 @@ var actionPidsLimitFlag = cmdline.Flag{
 	EnvKeys:      []string{"PIDS_LIMIT"},
 }
 
+// --proot (hidden)
+var actionProotFlag = cmdline.Flag{
+	ID:           "actionProot",
+	Value:        &Proot,
+	DefaultValue: "",
+	Name:         "proot",
+	Usage:        "Bind proot from the host into /.singularity.d/libs",
+	EnvKeys:      []string{"PROOT"},
+	Hidden:       true,
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -892,5 +904,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionMemorySwapFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionOomKillDisableFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionPidsLimitFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionProotFlag, actionsCmd...)
 	})
 }

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -483,6 +483,11 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		sylog.Fatalf("while setting checkpoint configuration: %s", err)
 	}
 
+	if Proot != "" && uid != 0 {
+		sylog.Debugf("Binding proot from %s", Proot)
+		engineConfig.AppendLibrariesPath(Proot)
+	}
+
 	engineConfig.SetAddCaps(AddCaps)
 	engineConfig.SetDropCaps(DropCaps)
 	engineConfig.SetConfigurationFile(configurationFile)

--- a/e2e/testdata/proot_alpine.def
+++ b/e2e/testdata/proot_alpine.def
@@ -1,0 +1,16 @@
+bootstrap: oras
+from: ghcr.io/apptainer/alpine:3.15.0
+
+%post
+  echo "Running %post as $(id -u)"
+  # We should appear to be root
+  test $(id -u) -eq 0
+  # We should be able to install some software
+  apk add wget
+
+%test
+  echo "Running %post as $(id -u)"
+  # We should not appear to be root
+  test $(id -u) -ne 0
+  # wget was installed
+  wget --version

--- a/e2e/testdata/proot_centos.def
+++ b/e2e/testdata/proot_centos.def
@@ -1,0 +1,16 @@
+bootstrap: docker
+from: centos:centos7
+
+%post
+  echo "Running %post as $(id -u)"
+  # We should appear to be root
+  test $(id -u) -eq 0
+  # We should be able to install some software
+  yum -y install wget
+
+%test
+  echo "Running %post as $(id -u)"
+  # We should not appear to be root
+  test $(id -u) -ne 0
+  # wget was installed
+  wget --version

--- a/e2e/testdata/proot_ubuntu.def
+++ b/e2e/testdata/proot_ubuntu.def
@@ -1,0 +1,17 @@
+bootstrap: docker
+from: ubuntu:focal
+
+%post
+  echo "Running %post as $(id -u)"
+  # We should appear to be root
+  test $(id -u) -eq 0
+  # We should be able to install some software
+  apt -y update
+  apt -y install wget
+
+%test
+  echo "Running %post as $(id -u)"
+  # We should not appear to be root
+  test $(id -u) -ne 0
+  # wget was installed
+  wget --version

--- a/examples/docker/Apptainer
+++ b/examples/docker/Apptainer
@@ -7,3 +7,7 @@ From: busybox:latest   # This is a comment
 %post
     echo "Hello from inside the container"
     echo "Install additional software here"
+
+%test
+    echo "Hello from the test script"
+

--- a/examples/library/Apptainer
+++ b/examples/library/Apptainer
@@ -8,3 +8,7 @@ From: alpine:3.11.5
 %post
     echo "Hello from inside the container"
     echo "Install additional software here"
+
+%test
+    echo "Hello from the test script"
+

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -122,11 +122,16 @@ func (s *stage) runPostScript(sessionResolv, sessionHosts string) error {
 			return fmt.Errorf("while processing section %%post arguments: %s", err)
 		}
 
-		exe := filepath.Join(buildcfg.BINDIR, "apptainer")
-
-		env := currentEnvNoApptainer([]string{"DEBUG", "NV", "NVCCLI", "ROCM", "BINDPATH", "MOUNT"})
+		env := currentEnvNoApptainer([]string{"DEBUG", "NV", "NVCCLI", "ROCM", "BINDPATH", "MOUNT", "PROOT"})
 		cmdArgs = append(cmdArgs, s.b.RootfsPath)
+
+		if os.Getenv("APPTAINER_PROOT") != "" {
+			cmdArgs = append(cmdArgs, "/.singularity.d/libs/proot", "-0")
+		}
+
 		cmdArgs = append(cmdArgs, args...)
+
+		exe := filepath.Join(buildcfg.BINDIR, "apptainer")
 		cmd := exec.Command(exe, cmdArgs...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -154,14 +159,14 @@ func (s *stage) runTestScript(sessionResolv, sessionHosts string) error {
 			cmdArgs = append(cmdArgs, "-B", sessionHosts+":/etc/hosts")
 		}
 
-		exe := filepath.Join(buildcfg.BINDIR, "apptainer")
-
 		cmdArgs = append(cmdArgs, s.b.RootfsPath)
+
+		exe := filepath.Join(buildcfg.BINDIR, "apptainer")
 		cmd := exec.Command(exe, cmdArgs...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Dir = "/"
-		cmd.Env = currentEnvNoApptainer([]string{"DEBUG", "NV", "NVCCLI", "ROCM", "BINDPATH", "MOUNT", "WRITABLE_TMPFS"})
+		cmd.Env = currentEnvNoApptainer([]string{"DEBUG", "NV", "NVCCLI", "ROCM", "BINDPATH", "MOUNT", "WRITABLE_TMPFS", "PROOT"})
 
 		sylog.Infof("Running testscript")
 		return cmd.Run()

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -58,6 +58,7 @@ func FindBin(name string) (path string, err error) {
 		"newuidmap",
 		"nvidia-container-cli",
 		"pacstrap",
+		"proot",
 		"rpm",
 		"rpmkeys",
 		"squashfuse",


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 879
 which fixed
- sylabs/singularity# 880

The original PR description was:
> Non-root users can now build from a definition file, on systems that do not support `--fakeroot`. This requires the statically built `proot` command (https://proot-me.github.io/) to be available on the user `PATH`.
> 
> These builds:
> 
> * Do not support `arch` / `debootstrap` / `yum` / `zypper` bootstraps. Use `localimage`, `library`, `oras`, or one of the docker/oci sources.
> 
> * Do not support `%pre` and `%setup` sections.
> 
> * Run the `%post` sections of a build in the container as an emulated root user.
> 
> * Run the `%test` section of a build as the non-root user, like `singularity test`.
> 
> * Are subject to any restrictions imposed in `singularity.conf`.
> 
> * Incur a performance penalty due to `proot`'s `ptrace` based interception of syscalls.
> 
> * May fail if the `%post` and `%test` scripts require privileged operations that `proot` cannot emulate.