### PR TITLE
e2e: switch to shared cache by default, from sylabs 975

### DIFF
--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -306,7 +306,7 @@ func (c actionTests) issue4823(t *testing.T) {
 			expected = e2e.ExpectError(e2e.ContainMatch, "Using image from cache")
 		}
 
-		c.env.ImgCacheDir = cacheDir
+		c.env.UnprivCacheDir = cacheDir
 		c.env.RunApptainer(
 			t,
 			e2e.AsSubtest(tt.name),

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -38,7 +38,7 @@ func prepTest(t *testing.T, testEnv e2e.TestEnv, testName string, cacheParentDir
 		ensureNotCached(t, testName, imagePath, cacheParentDir)
 	}
 
-	testEnv.ImgCacheDir = cacheParentDir
+	testEnv.UnprivCacheDir = cacheParentDir
 	testEnv.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
@@ -132,7 +132,7 @@ func (c cacheTests) testNoninteractiveCacheCmds(t *testing.T) {
 			prepTest(t, c.env, tt.name, cacheDir, imagePath)
 		}
 
-		c.env.ImgCacheDir = cacheDir
+		c.env.UnprivCacheDir = cacheDir
 		c.env.RunApptainer(
 			t,
 			e2e.AsSubtest(tt.name),
@@ -233,7 +233,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 			t.Fatalf("Could not create image cache handle: %v", err)
 		}
 
-		c.env.ImgCacheDir = cacheDir
+		c.env.UnprivCacheDir = cacheDir
 		prepTest(t, c.env, tc.name, cacheDir, imagePath)
 
 		c.env.RunApptainer(

--- a/e2e/cache/regressions.go
+++ b/e2e/cache/regressions.go
@@ -25,7 +25,7 @@ import (
 func (c cacheTests) issue5097(t *testing.T) {
 	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
 	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
+	c.env.UnprivCacheDir = imgCacheDir
 
 	tempDir, imgStoreCleanup := e2e.MakeTempDir(t, "", "", "image store")
 	defer imgStoreCleanup(t)
@@ -86,7 +86,7 @@ func (c cacheTests) issue5350(t *testing.T) {
 
 	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, outerDir)
 	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
+	c.env.UnprivCacheDir = imgCacheDir
 
 	if err := os.Chmod(outerDir, 0o000); err != nil {
 		t.Fatalf("Could not chmod 000 cache outer dir: %v", err)

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -41,14 +41,14 @@ func setupTemporaryDir(t *testing.T, testdir, label string) (string, func(*testi
 	}
 }
 
-// setupTemporaryCache creates a temporary cache directory and modifies
+// setupTemporaryCache creates temporary cache directories and modifies
 // the test environment to use it. The code calling this function is
 // responsible for calling the returned function when its done using the
 // temporary directory.
 func (c *ctx) setupTemporaryCache(t *testing.T) func(*testing.T) {
 	cacheDir, cleanup := setupTemporaryDir(t, c.env.TestDir, "cache-dir")
 
-	c.env.ImgCacheDir = cacheDir
+	c.env.UnprivCacheDir = cacheDir
 
 	return cleanup
 }
@@ -97,10 +97,10 @@ func (c ctx) assertLibraryCacheEntryExists(t *testing.T, imgPath, imgName string
 		t.Fatalf("Cannot get the shasum for image %s: %s", imgPath, err)
 	}
 
-	cacheEntryPath := filepath.Join(c.env.ImgCacheDir, "cache", "oras", shasum)
+	cacheEntryPath := filepath.Join(c.env.UnprivCacheDir, "cache", "oras", shasum)
 	if _, err := os.Stat(cacheEntryPath); os.IsNotExist(err) {
 		ls(t, c.env.TestDir)
-		ls(t, c.env.ImgCacheDir)
+		ls(t, c.env.UnprivCacheDir)
 		t.Fatalf("Cache entry %s for image %s with name %s does not exists: %s",
 			cacheEntryPath, imgPath, imgName, err)
 	}
@@ -109,7 +109,7 @@ func (c ctx) assertLibraryCacheEntryExists(t *testing.T, imgPath, imgName string
 // assertCacheDoesNotExist checks that the image cache that is associated to the
 // test DOES NOT exists.
 func (c ctx) assertCacheDoesNotExist(t *testing.T) {
-	cacheRoot := filepath.Join(c.env.ImgCacheDir, "cache")
+	cacheRoot := filepath.Join(c.env.UnprivCacheDir, "cache")
 	if _, err := os.Stat(cacheRoot); !os.IsNotExist(err) {
 		// The root of the cache does exists
 		t.Fatalf("cache has been incorrectly created (cache root: %s)", cacheRoot)
@@ -208,7 +208,7 @@ func (c ctx) testApptainerReadOnlyCacheDir(t *testing.T) {
 	defer cleanup(t)
 
 	// Change the mode of the image cache to read-only
-	err := os.Chmod(c.env.ImgCacheDir, 0o555)
+	err := os.Chmod(c.env.UnprivCacheDir, 0o555)
 	if err != nil {
 		t.Fatalf("failed to change the access mode to read-only: %s", err)
 	}
@@ -219,7 +219,7 @@ func (c ctx) testApptainerReadOnlyCacheDir(t *testing.T) {
 	// can delete the cache if it was created. Do this _before_
 	// calling c.assertCacheDoesNotExist because that function will
 	// fail if it find a cache.
-	err = os.Chmod(c.env.ImgCacheDir, 0o755)
+	err = os.Chmod(c.env.UnprivCacheDir, 0o755)
 	if err != nil {
 		t.Fatalf("failed to change the access mode to read-only: %s", err)
 	}

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -34,11 +34,6 @@ const (
 )
 
 func (c ctx) apptainerEnv(t *testing.T) {
-	// use a cache to not download images over and over
-	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
-	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
-
 	// Apptainer defines a path by default. See apptainerware/apptainer/etc/init.
 	defaultImage := "docker://alpine:3.8"
 
@@ -136,11 +131,6 @@ func (c ctx) apptainerEnvOption(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	imageDefaultPath := defaultPath + ":/go/bin:/usr/local/go/bin"
-
-	// use a cache to not download images over and over
-	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
-	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
 
 	tests := []struct {
 		name     string
@@ -356,11 +346,6 @@ func (c ctx) apptainerEnvFile(t *testing.T) {
 	dir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "envfile-", "")
 	defer cleanup(t)
 	p := filepath.Join(dir, "env.file")
-
-	// use a cache to not download images over and over
-	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
-	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
 
 	tests := []struct {
 		name     string

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -21,7 +21,8 @@ type TestEnv struct {
 	TestRegistry         string
 	HomeDir              string // HomeDir sets the home directory that will be used for the execution of a command
 	KeyringDir           string // KeyringDir sets the directory where the keyring will be created for the execution of a command (instead of using APPTAINER_KEYSDIR which should be avoided when running e2e tests)
-	ImgCacheDir          string // ImgCacheDir sets the location of the image cache to be used by the Apptainer command to be executed (instead of using APPTAINER_CACHE_DIR which should be avoided when running e2e tests)
+	PrivCacheDir         string // PrivCacheDir sets the location of the image cache to be used by the Apptainer command to be executed as root (instead of using APPTAINER_CACHE_DIR which should be avoided when running e2e tests)
+	UnprivCacheDir       string // UnprivCacheDir sets the location of the image cache to be used by the Apptainer command to be executed as the unpriv user (instead of using APPTAINER_CACHE_DIR which should be avoided when running e2e tests)
 	RunDisabled          bool
 	DisableCache         bool   // DisableCache can be set to disable the cache during the execution of a e2e command
 	InsecureRegistry     string // Insecure registry replaced with nip.io

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -54,6 +54,12 @@ type testStruct struct {
 }
 
 func (c *ctx) imagePull(t *testing.T, tt testStruct) {
+	// Use a one-time cache directory specific to this pull. This ensures we are always
+	// testing an entire pull operation, performing the download into an empty cache.
+	cacheDir, cleanup := e2e.MakeCacheDir(t, "")
+	defer cleanup(t)
+	c.env.UnprivCacheDir = cacheDir
+
 	// We use a string rather than a slice of strings to avoid having an empty
 	// element in the slice, which would cause the command to fail, without
 	// over-complicating the code.
@@ -488,7 +494,7 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 		}
 	}()
 
-	c.env.ImgCacheDir = cacheDir
+	c.env.UnprivCacheDir = cacheDir
 
 	disableCacheTests := []struct {
 		name      string

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -89,7 +89,6 @@ func (c ctx) apptainerSignIDOption(t *testing.T) {
 	}
 
 	c.env.KeyringDir = c.keyringDir
-	c.env.ImgCacheDir = c.imgCache
 
 	for _, tt := range tests {
 		c.env.RunApptainer(
@@ -129,7 +128,6 @@ func (c ctx) apptainerSignAllOption(t *testing.T) {
 	}
 
 	c.env.KeyringDir = c.keyringDir
-	c.env.ImgCacheDir = c.imgCache
 
 	for _, tt := range tests {
 		c.env.RunApptainer(
@@ -170,7 +168,6 @@ func (c ctx) apptainerSignGroupIDOption(t *testing.T) {
 	}
 
 	c.env.KeyringDir = c.keyringDir
-	c.env.ImgCacheDir = c.imgCache
 
 	for _, tt := range tests {
 		c.env.RunApptainer(
@@ -191,7 +188,6 @@ func (c ctx) apptainerSignKeyidxOption(t *testing.T) {
 
 	cmdArgs := []string{"--keyidx", "0", imgPath}
 	c.env.KeyringDir = c.keyringDir
-	c.env.ImgCacheDir = c.imgCache
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
@@ -235,18 +231,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	return testhelper.Tests{
 		"ordered": func(t *testing.T) {
 			var err error
-			// To speed up the tests, we use a common image cache (we pull the same image several times)
-			c.imgCache, err = ioutil.TempDir("", "e2e-sign-imgcache-")
-			if err != nil {
-				t.Fatalf("failed to create temporary directory: %s", err)
-			}
-			defer func() {
-				err := os.RemoveAll(c.imgCache)
-				if err != nil {
-					t.Fatalf("failed to delete temporary cache: %s", err)
-				}
-			}()
-
 			// We need one single key pair in a single keyring for all the tests
 			c.keyringDir, err = ioutil.TempDir("", "e2e-sign-keyring-")
 			if err != nil {

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -109,6 +109,20 @@ func Run(t *testing.T) {
 	testenv.TestRegistry = e2e.StartRegistry(t, testenv)
 	testenv.InsecureRegistry = strings.Replace(testenv.TestRegistry, "localhost", "127.0.0.1.nip.io", 1)
 
+	// Make shared cache dirs for privileged and unpriviliged E2E tests.
+	// Individual tests that depend on specific ordered cache behavior, or
+	// directly test the cache, should override the TestEnv values within the
+	// specific test.
+	privCacheDir, cleanPrivCache := e2e.MakeCacheDir(t, testenv.TestDir)
+	testenv.PrivCacheDir = privCacheDir
+	defer e2e.Privileged(func(t *testing.T) {
+		cleanPrivCache(t)
+	})
+
+	unprivCacheDir, cleanUnprivCache := e2e.MakeCacheDir(t, testenv.TestDir)
+	testenv.UnprivCacheDir = unprivCacheDir
+	defer cleanUnprivCache(t)
+
 	// e2e tests need to run in a somehow agnostic environment, so we
 	// don't use environment of user executing tests in order to not
 	// wrongly interfering with cache stuff, sylabs library tokens,


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 975

The original PR description was:
> The SingularityCmd construct used to execute singularity in the e2e tests has defaulted to a fresh, empty cache directory for each execution.
> 
> This means that we are downloading full container images on every e2e execution of singularity against docker or library, which slows things down and creates uneccesary request load on the Sylabs Library, Docker Hub, etc.
> 
> Switch to using a shared cache by default. Our cache structure has been concurrency safe (given atomic operations on local filesystems) for some time now crossed_fingers ... this will also now test that.
> 
> Pull tests are modified so that they explicitly use an empty cache, to test the entire pull flow, including container image download.
> 
> Any future tests that depend on exercising downloads, the cache specifically, or depend on a specific state / order of cached operations will need to also specify their own cache directory.