### PR TITLE
Replace Deprecated Title Function, from sylabs 966

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.3.0
 	mvdan.cc/sh/v3 v3.5.1
@@ -153,7 +154,6 @@ require (
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
-	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220624142145-8cd45d7dbd1f // indirect
 	google.golang.org/grpc v1.47.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/internal/app/apptainer/remote_status.go
+++ b/internal/app/apptainer/remote_status.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -14,12 +14,13 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/apptainer/apptainer/internal/pkg/remote"
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 	"github.com/apptainer/apptainer/pkg/sylog"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const statusLine = "%s\t%s\t%s\t%s\n"
@@ -111,7 +112,7 @@ func RemoteStatus(usrConfigFile, name string) (err error) {
 	fmt.Fprintf(tw, statusLine, "SERVICE", "STATUS", "VERSION", "URI")
 	for _, n := range names {
 		s := smap[n]
-		fmt.Fprintf(tw, statusLine, strings.Title(s.name), s.status, s.version, s.uri)
+		fmt.Fprintf(tw, statusLine, cases.Title(language.English).String(s.name), s.status, s.version, s.uri)
 	}
 	tw.Flush()
 

--- a/pkg/util/user-agent/agent.go
+++ b/pkg/util/user-agent/agent.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -13,6 +13,9 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var value string
@@ -33,13 +36,13 @@ func Value() string {
 func InitValue(name, version string) {
 	value = fmt.Sprintf("%v (%v %v) %v",
 		apptainerVersion(name, version),
-		strings.Title(runtime.GOOS),
+		cases.Title(language.English).String(runtime.GOOS),
 		runtime.GOARCH,
 		goVersion())
 }
 
 func apptainerVersion(name, version string) string {
-	product := strings.Title(name)
+	product := cases.Title(language.English).String(name)
 	ver := strings.Split(version, "-")[0]
 	return fmt.Sprintf("%v/%v", product, ver)
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 966

The original PR description was:
> Replace use of [func strings.Title](https://pkg.go.dev/strings#Title), which was deprecated in Go 1.18 ([ref](https://go.dev/doc/go1.18#strings)).