### PR TITLE
fix: set CAP_NET_ADMIN with --nvccli, from sylabs 1076

### DIFF
--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -399,7 +399,6 @@ static void set_rpc_privileges(void) {
         priv->capabilities.bounding |= capflag(CAP_DAC_READ_SEARCH);
         priv->capabilities.bounding |= capflag(CAP_FOWNER);
         priv->capabilities.bounding |= capflag(CAP_KILL);
-        priv->capabilities.bounding |= capflag(CAP_MKNOD);
         priv->capabilities.bounding |= capflag(CAP_NET_ADMIN);
         priv->capabilities.bounding |= capflag(CAP_SETGID);
         priv->capabilities.bounding |= capflag(CAP_SETPCAP);

--- a/internal/pkg/util/gpu/nvidia.go
+++ b/internal/pkg/util/gpu/nvidia.go
@@ -52,19 +52,21 @@ var nVDriverDefaultCapabilities = []string{
 
 // nVCLIAmbientCaps is the ambient capability set required by nvidia-container-cli.
 var nVCLIAmbientCaps = []uintptr{
-	uintptr(capabilities.Map["CAP_KILL"].Value),
-	uintptr(capabilities.Map["CAP_SETUID"].Value),
-	uintptr(capabilities.Map["CAP_SETGID"].Value),
-	uintptr(capabilities.Map["CAP_SYS_CHROOT"].Value),
-	uintptr(capabilities.Map["CAP_CHOWN"].Value),
-	uintptr(capabilities.Map["CAP_FOWNER"].Value),
-	uintptr(capabilities.Map["CAP_MKNOD"].Value),
+	// Set by default in starter bounding set
 	uintptr(capabilities.Map["CAP_SYS_ADMIN"].Value),
-	uintptr(capabilities.Map["CAP_DAC_READ_SEARCH"].Value),
-	uintptr(capabilities.Map["CAP_SYS_PTRACE"].Value),
+	uintptr(capabilities.Map["CAP_MKNOD"].Value),
+	// Additionally set in starter with nvCCLICaps
+	uintptr(capabilities.Map["CAP_CHOWN"].Value),
 	uintptr(capabilities.Map["CAP_DAC_OVERRIDE"].Value),
-	uintptr(capabilities.Map["CAP_SETPCAP"].Value),
+	uintptr(capabilities.Map["CAP_DAC_READ_SEARCH"].Value),
+	uintptr(capabilities.Map["CAP_FOWNER"].Value),
+	uintptr(capabilities.Map["CAP_KILL"].Value),
 	uintptr(capabilities.Map["CAP_NET_ADMIN"].Value),
+	uintptr(capabilities.Map["CAP_SETGID"].Value),
+	uintptr(capabilities.Map["CAP_SETPCAP"].Value),
+	uintptr(capabilities.Map["CAP_SETUID"].Value),
+	uintptr(capabilities.Map["CAP_SYS_CHROOT"].Value),
+	uintptr(capabilities.Map["CAP_SYS_PTRACE"].Value),
 }
 
 // NVCLIConfigure calls out to the nvidia-container-cli configure operation.


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1076
 which fixed
- sylabs/singularity# 1075

The original PR description was:
> Ensure that CAP_NET_ADMIN is set in the ambient set in nvccli Go code.
> 
> In addition:
> 
>  * Tidy up the Go code so that capabilities are ordered the same as in starter code, for easy comparison.
>  * Remove a redundant addition of CAP_MKNOD in starter (already set in line above).