### PR TITLE
fix: don't freeze for http(s) pull without content-length, from sylabs 1088

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Set the `--net` flag if `--network` or `--network-args` is set rather
   than silently ignoring them if `--net` was not set.
+- Do not hang on pull from http(s) source that doesn't provide a content-length.
 
 ## v1.1.3 - \[2022-10-25\]
 

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -665,6 +665,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("concurrencyConfig", c.testConcurrencyConfig)
 			t.Run("concurrentPulls", c.testConcurrentPulls)
 		},
+		"issueSylabs1087": c.issueSylabs1087,
 		// Manipulates umask for the process, so must be run alone to avoid
 		// causing permission issues for other tests.
 		"pullUmaskCheck": np(c.testPullUmask),

--- a/internal/pkg/client/progress.go
+++ b/internal/pkg/client/progress.go
@@ -56,7 +56,8 @@ func ProgressBarCallback(ctx context.Context) ProgressCallback {
 	if sylog.GetLevel() <= -1 {
 		// If we don't need a bar visible, we just copy data through the callback func
 		return func(totalSize int64, r io.Reader, w io.Writer) error {
-			return CopyWithContext(ctx, w, r)
+			_, err := CopyWithContext(ctx, w, r)
+			return err
 		}
 	}
 
@@ -67,10 +68,15 @@ func ProgressBarCallback(ctx context.Context) ProgressCallback {
 		bodyProgress := bar.ProxyReader(r)
 		defer bodyProgress.Close()
 
-		err := CopyWithContext(ctx, w, bodyProgress)
+		written, err := CopyWithContext(ctx, w, bodyProgress)
 		if err != nil {
 			bar.Abort(true)
 			return err
+		}
+
+		// Must ensure bar is complete for a download with unknown size, or it will hang.
+		if totalSize <= 0 {
+			bar.SetTotal(written, true)
 		}
 		p.Wait()
 
@@ -78,12 +84,12 @@ func ProgressBarCallback(ctx context.Context) ProgressCallback {
 	}
 }
 
-func CopyWithContext(ctx context.Context, dst io.Writer, src io.Reader) error {
+func CopyWithContext(ctx context.Context, dst io.Writer, src io.Reader) (written int64, err error) {
 	// Copy will call the Reader and Writer interface multiple time, in order
 	// to copy by chunk (avoiding loading the whole file in memory).
 	// I insert the ability to cancel before read time as it is the earliest
 	// possible in the call process.
-	_, err := io.Copy(dst, readerFunc(func(p []byte) (int, error) {
+	written, err = io.Copy(dst, readerFunc(func(p []byte) (int, error) {
 		// golang non-blocking channel: https://gobyexample.com/non-blocking-channel-operations
 		select {
 		// if context has been canceled
@@ -95,7 +101,7 @@ func CopyWithContext(ctx context.Context, dst io.Writer, src io.Reader) error {
 			return src.Read(p)
 		}
 	}))
-	return err
+	return written, err
 }
 
 // DownloadProgressBar is used for chunked container-library-client downloads.


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1088
 which fixed
- sylabs/singularity# 1087

The original PR description was:
> When an http(s) pull doesn't provide a content-length header, we need to ensure the progress bar completes. If we don't do this, the CLI hangs indefinitely.