### PR TITLE
refactor: move execStarter functionality out of CLI layer, from sylabs 1013

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -17,88 +17,88 @@ import (
 
 // actionflags.go contains flag variables for action-like commands to draw from
 var (
-	AppName          string
-	BindPaths        []string
-	Mounts           []string
-	HomePath         string
-	OverlayPath      []string
-	ScratchPath      []string
-	WorkdirPath      string
-	PwdPath          string
-	ShellPath        string
-	Hostname         string
-	Network          string
-	NetworkArgs      []string
-	DNS              string
-	Security         []string
-	CgroupsTOMLFile  string
-	VMRAM            string
-	VMCPU            string
-	VMIP             string
-	ContainLibsPath  []string
-	FuseMount        []string
-	ApptainerEnv     map[string]string
-	ApptainerEnvFile string
-	NoMount          []string
-	DMTCPLaunch      string
-	DMTCPRestart     string
+	appName          string
+	bindPaths        []string
+	mounts           []string
+	homePath         string
+	overlayPath      []string
+	scratchPath      []string
+	workdirPath      string
+	pwdPath          string
+	shellPath        string
+	hostname         string
+	network          string
+	networkArgs      []string
+	dns              string
+	security         []string
+	cgroupsTOMLFile  string
+	vmRAM            string
+	vmCPU            string
+	vmIP             string
+	containLibsPath  []string
+	fuseMount        []string
+	apptainerEnv     map[string]string
+	apptainerEnvFile string
+	noMount          []string
+	dmtcpLaunch      string
+	dmtcpRestart     string
 
-	IsBoot          bool
-	IsFakeroot      bool
-	IsCleanEnv      bool
-	IsCompat        bool
-	IsContained     bool
-	IsContainAll    bool
-	IsWritable      bool
-	IsWritableTmpfs bool
-	Nvidia          bool
-	NvCCLI          bool
-	Rocm            bool
-	NoEval          bool
-	NoHome          bool
-	NoInit          bool
-	NoNvidia        bool
-	NoRocm          bool
-	NoUmask         bool
-	VM              bool
-	VMErr           bool
-	IsSyOS          bool
+	isBoot          bool
+	isFakeroot      bool
+	isCleanEnv      bool
+	isCompat        bool
+	isContained     bool
+	isContainAll    bool
+	isWritable      bool
+	isWritableTmpfs bool
+	nvidia          bool
+	nvCCLI          bool
+	rocm            bool
+	noEval          bool
+	noHome          bool
+	noInit          bool
+	noNvidia        bool
+	noRocm          bool
+	noUmask         bool
+	vm              bool
+	vmErr           bool
+	isSyOS          bool
 	disableCache    bool
 
-	NetNamespace  bool
-	UtsNamespace  bool
-	UserNamespace bool
-	PidNamespace  bool
-	IpcNamespace  bool
+	netNamespace  bool
+	utsNamespace  bool
+	userNamespace bool
+	pidNamespace  bool
+	ipcNamespace  bool
 
-	AllowSUID bool
-	KeepPrivs bool
-	NoPrivs   bool
-	AddCaps   string
-	DropCaps  string
+	allowSUID bool
+	keepPrivs bool
+	noPrivs   bool
+	addCaps   string
+	dropCaps  string
 
-	BlkioWeight       int
-	BlkioWeightDevice []string
-	CPUShares         int
-	CPUs              string // decimal
-	CPUSetCPUs        string
-	CPUSetMems        string
-	Memory            string // bytes
-	MemoryReservation string // bytes
-	MemorySwap        string // bytes
-	OomKillDisable    bool
-	PidsLimit         int
-	Unsquash          bool
+	blkioWeight       int
+	blkioWeightDevice []string
+	cpuShares         int
+	cpus              string // decimal
+	cpuSetCPUs        string
+	cpuSetMems        string
+	memory            string // bytes
+	memoryReservation string // bytes
+	memorySwap        string // bytes
+	oomKillDisable    bool
+	pidsLimit         int
+	unsquash          bool
 
-	IgnoreSubuid      bool
-	IgnoreFakerootCmd bool
-	IgnoreUserns      bool
+	ignoreSubuid      bool
+	ignoreFakerootCmd bool
+	ignoreUserns      bool
 )
 
 // --app
 var actionAppFlag = cmdline.Flag{
 	ID:           "actionAppFlag",
-	Value:        &AppName,
+	Value:        &appName,
 	DefaultValue: "",
 	Name:         "app",
 	Usage:        "set an application to run inside a container",
@@ -108,7 +108,7 @@ var actionAppFlag = cmdline.Flag{
 // -B|--bind
 var actionBindFlag = cmdline.Flag{
 	ID:           "actionBindFlag",
-	Value:        &BindPaths,
+	Value:        &bindPaths,
 	DefaultValue: cmdline.StringArray{}, // to allow commas in bind path
 	Name:         "bind",
 	ShortHand:    "B",
@@ -121,7 +121,7 @@ var actionBindFlag = cmdline.Flag{
 // --mount
 var actionMountFlag = cmdline.Flag{
 	ID:           "actionMountFlag",
-	Value:        &Mounts,
+	Value:        &mounts,
 	DefaultValue: cmdline.StringArray{},
 	Name:         "mount",
 	Usage:        "a mount specification e.g. 'type=bind,source=/opt,destination=/hostopt'.",
@@ -133,7 +133,7 @@ var actionMountFlag = cmdline.Flag{
 // -H|--home
 var actionHomeFlag = cmdline.Flag{
 	ID:           "actionHomeFlag",
-	Value:        &HomePath,
+	Value:        &homePath,
 	DefaultValue: CurrentUser.HomeDir,
 	Name:         "home",
 	ShortHand:    "H",
@@ -145,7 +145,7 @@ var actionHomeFlag = cmdline.Flag{
 // -o|--overlay
 var actionOverlayFlag = cmdline.Flag{
 	ID:           "actionOverlayFlag",
-	Value:        &OverlayPath,
+	Value:        &overlayPath,
 	DefaultValue: []string{},
 	Name:         "overlay",
 	ShortHand:    "o",
@@ -157,7 +157,7 @@ var actionOverlayFlag = cmdline.Flag{
 // -S|--scratch
 var actionScratchFlag = cmdline.Flag{
 	ID:           "actionScratchFlag",
-	Value:        &ScratchPath,
+	Value:        &scratchPath,
 	DefaultValue: []string{},
 	Name:         "scratch",
 	ShortHand:    "S",
@@ -169,7 +169,7 @@ var actionScratchFlag = cmdline.Flag{
 // -W|--workdir
 var actionWorkdirFlag = cmdline.Flag{
 	ID:           "actionWorkdirFlag",
-	Value:        &WorkdirPath,
+	Value:        &workdirPath,
 	DefaultValue: "",
 	Name:         "workdir",
 	ShortHand:    "W",
@@ -191,7 +191,7 @@ var actionDisableCacheFlag = cmdline.Flag{
 // -s|--shell
 var actionShellFlag = cmdline.Flag{
 	ID:           "actionShellFlag",
-	Value:        &ShellPath,
+	Value:        &shellPath,
 	DefaultValue: "",
 	Name:         "shell",
 	ShortHand:    "s",
@@ -203,7 +203,7 @@ var actionShellFlag = cmdline.Flag{
 // --pwd
 var actionPwdFlag = cmdline.Flag{
 	ID:           "actionPwdFlag",
-	Value:        &PwdPath,
+	Value:        &pwdPath,
 	DefaultValue: "",
 	Name:         "pwd",
 	Usage:        "initial working directory for payload process inside the container",
@@ -214,7 +214,7 @@ var actionPwdFlag = cmdline.Flag{
 // --hostname
 var actionHostnameFlag = cmdline.Flag{
 	ID:           "actionHostnameFlag",
-	Value:        &Hostname,
+	Value:        &hostname,
 	DefaultValue: "",
 	Name:         "hostname",
 	Usage:        "set container hostname",
@@ -225,7 +225,7 @@ var actionHostnameFlag = cmdline.Flag{
 // --network
 var actionNetworkFlag = cmdline.Flag{
 	ID:           "actionNetworkFlag",
-	Value:        &Network,
+	Value:        &network,
 	DefaultValue: "",
 	Name:         "network",
 	Usage:        "specify desired network type separated by commas, each network will bring up a dedicated interface inside container",
@@ -236,7 +236,7 @@ var actionNetworkFlag = cmdline.Flag{
 // --network-args
 var actionNetworkArgsFlag = cmdline.Flag{
 	ID:           "actionNetworkArgsFlag",
-	Value:        &NetworkArgs,
+	Value:        &networkArgs,
 	DefaultValue: []string{},
 	Name:         "network-args",
 	Usage:        "specify network arguments to pass to CNI plugins",
@@ -247,7 +247,7 @@ var actionNetworkArgsFlag = cmdline.Flag{
 // --dns
 var actionDNSFlag = cmdline.Flag{
 	ID:           "actionDnsFlag",
-	Value:        &DNS,
+	Value:        &dns,
 	DefaultValue: "",
 	Name:         "dns",
 	Usage:        "list of DNS server separated by commas to add in resolv.conf",
@@ -257,7 +257,7 @@ var actionDNSFlag = cmdline.Flag{
 // --security
 var actionSecurityFlag = cmdline.Flag{
 	ID:           "actionSecurityFlag",
-	Value:        &Security,
+	Value:        &security,
 	DefaultValue: []string{},
 	Name:         "security",
 	Usage:        "enable security features (SELinux, Apparmor, Seccomp)",
@@ -267,7 +267,7 @@ var actionSecurityFlag = cmdline.Flag{
 // --apply-cgroups
 var actionApplyCgroupsFlag = cmdline.Flag{
 	ID:           "actionApplyCgroupsFlag",
-	Value:        &CgroupsTOMLFile,
+	Value:        &cgroupsTOMLFile,
 	DefaultValue: "",
 	Name:         "apply-cgroups",
 	Usage:        "apply cgroups from file for container processes (root only)",
@@ -277,7 +277,7 @@ var actionApplyCgroupsFlag = cmdline.Flag{
 // --vm-ram
 var actionVMRAMFlag = cmdline.Flag{
 	ID:           "actionVMRAMFlag",
-	Value:        &VMRAM,
+	Value:        &vmRAM,
 	DefaultValue: "1024",
 	Name:         "vm-ram",
 	Usage:        "amount of RAM in MiB to allocate to Virtual Machine (implies --vm)",
@@ -288,7 +288,7 @@ var actionVMRAMFlag = cmdline.Flag{
 // --vm-cpu
 var actionVMCPUFlag = cmdline.Flag{
 	ID:           "actionVMCPUFlag",
-	Value:        &VMCPU,
+	Value:        &vmCPU,
 	DefaultValue: "1",
 	Name:         "vm-cpu",
 	Usage:        "number of CPU cores to allocate to Virtual Machine (implies --vm)",
@@ -299,7 +299,7 @@ var actionVMCPUFlag = cmdline.Flag{
 // --vm-ip
 var actionVMIPFlag = cmdline.Flag{
 	ID:           "actionVMIPFlag",
-	Value:        &VMIP,
+	Value:        &vmIP,
 	DefaultValue: "dhcp",
 	Name:         "vm-ip",
 	Usage:        "IP Address to assign for container usage. Defaults to DHCP within bridge network.",
@@ -310,7 +310,7 @@ var actionVMIPFlag = cmdline.Flag{
 // hidden flag to handle APPTAINER_CONTAINLIBS environment variable
 var actionContainLibsFlag = cmdline.Flag{
 	ID:           "actionContainLibsFlag",
-	Value:        &ContainLibsPath,
+	Value:        &containLibsPath,
 	DefaultValue: []string{},
 	Name:         "containlibs",
 	Hidden:       true,
@@ -320,7 +320,7 @@ var actionContainLibsFlag = cmdline.Flag{
 // --fusemount
 var actionFuseMountFlag = cmdline.Flag{
 	ID:           "actionFuseMountFlag",
-	Value:        &FuseMount,
+	Value:        &fuseMount,
 	DefaultValue: []string{},
 	Name:         "fusemount",
 	Usage:        "A FUSE filesystem mount specification of the form '<type>:<fuse command> <mountpoint>' - where <type> is 'container' or 'host', specifying where the mount will be performed ('container-daemon' or 'host-daemon' will run the FUSE process detached). <fuse command> is the path to the FUSE executable, plus options for the mount. <mountpoint> is the location in the container to which the FUSE mount will be attached. E.g. 'container:sshfs 10.0.0.1:/ /sshfs'. Implies --pid.",
@@ -341,7 +341,7 @@ var actionTmpDirFlag = cmdline.Flag{
 // --boot
 var actionBootFlag = cmdline.Flag{
 	ID:           "actionBootFlag",
-	Value:        &IsBoot,
+	Value:        &isBoot,
 	DefaultValue: false,
 	Name:         "boot",
 	Usage:        "execute /sbin/init to boot container (root only)",
@@ -351,7 +351,7 @@ var actionBootFlag = cmdline.Flag{
 // -f|--fakeroot
 var actionFakerootFlag = cmdline.Flag{
 	ID:           "actionFakerootFlag",
-	Value:        &IsFakeroot,
+	Value:        &isFakeroot,
 	DefaultValue: false,
 	Name:         "fakeroot",
 	ShortHand:    "f",
@@ -362,7 +362,7 @@ var actionFakerootFlag = cmdline.Flag{
 // -e|--cleanenv
 var actionCleanEnvFlag = cmdline.Flag{
 	ID:           "actionCleanEnvFlag",
-	Value:        &IsCleanEnv,
+	Value:        &isCleanEnv,
 	DefaultValue: false,
 	Name:         "cleanenv",
 	ShortHand:    "e",
@@ -373,7 +373,7 @@ var actionCleanEnvFlag = cmdline.Flag{
 // --compat
 var actionCompatFlag = cmdline.Flag{
 	ID:           "actionCompatFlag",
-	Value:        &IsCompat,
+	Value:        &isCompat,
 	DefaultValue: false,
 	Name:         "compat",
 	Usage:        "apply settings for increased OCI/Docker compatibility. Infers --containall, --no-init, --no-umask, --no-eval, --writable-tmpfs.",
@@ -383,7 +383,7 @@ var actionCompatFlag = cmdline.Flag{
 // -c|--contain
 var actionContainFlag = cmdline.Flag{
 	ID:           "actionContainFlag",
-	Value:        &IsContained,
+	Value:        &isContained,
 	DefaultValue: false,
 	Name:         "contain",
 	ShortHand:    "c",
@@ -394,7 +394,7 @@ var actionContainFlag = cmdline.Flag{
 // -C|--containall
 var actionContainAllFlag = cmdline.Flag{
 	ID:           "actionContainAllFlag",
-	Value:        &IsContainAll,
+	Value:        &isContainAll,
 	DefaultValue: false,
 	Name:         "containall",
 	ShortHand:    "C",
@@ -405,7 +405,7 @@ var actionContainAllFlag = cmdline.Flag{
 // --nv
 var actionNvidiaFlag = cmdline.Flag{
 	ID:           "actionNvidiaFlag",
-	Value:        &Nvidia,
+	Value:        &nvidia,
 	DefaultValue: false,
 	Name:         "nv",
 	Usage:        "enable Nvidia support",
@@ -415,7 +415,7 @@ var actionNvidiaFlag = cmdline.Flag{
 // --nvccli
 var actionNvCCLIFlag = cmdline.Flag{
 	ID:           "actionNvCCLIFlag",
-	Value:        &NvCCLI,
+	Value:        &nvCCLI,
 	DefaultValue: false,
 	Name:         "nvccli",
 	Usage:        "use nvidia-container-cli for GPU setup (experimental)",
@@ -425,7 +425,7 @@ var actionNvCCLIFlag = cmdline.Flag{
 // --rocm flag to automatically bind
 var actionRocmFlag = cmdline.Flag{
 	ID:           "actionRocmFlag",
-	Value:        &Rocm,
+	Value:        &rocm,
 	DefaultValue: false,
 	Name:         "rocm",
 	Usage:        "enable experimental Rocm support",
@@ -435,7 +435,7 @@ var actionRocmFlag = cmdline.Flag{
 // -w|--writable
 var actionWritableFlag = cmdline.Flag{
 	ID:           "actionWritableFlag",
-	Value:        &IsWritable,
+	Value:        &isWritable,
 	DefaultValue: false,
 	Name:         "writable",
 	ShortHand:    "w",
@@ -446,7 +446,7 @@ var actionWritableFlag = cmdline.Flag{
 // --writable-tmpfs
 var actionWritableTmpfsFlag = cmdline.Flag{
 	ID:           "actionWritableTmpfsFlag",
-	Value:        &IsWritableTmpfs,
+	Value:        &isWritableTmpfs,
 	DefaultValue: false,
 	Name:         "writable-tmpfs",
 	Usage:        "makes the file system accessible as read-write with non persistent data (with overlay support only)",
@@ -456,7 +456,7 @@ var actionWritableTmpfsFlag = cmdline.Flag{
 // --no-home
 var actionNoHomeFlag = cmdline.Flag{
 	ID:           "actionNoHomeFlag",
-	Value:        &NoHome,
+	Value:        &noHome,
 	DefaultValue: false,
 	Name:         "no-home",
 	Usage:        "do NOT mount users home directory if /home is not the current working directory",
@@ -466,7 +466,7 @@ var actionNoHomeFlag = cmdline.Flag{
 // --no-mount
 var actionNoMountFlag = cmdline.Flag{
 	ID:           "actionNoMountFlag",
-	Value:        &NoMount,
+	Value:        &noMount,
 	DefaultValue: []string{},
 	Name:         "no-mount",
 	Usage:        "disable one or more 'mount xxx' options set in apptainer.conf and/or specify absolute destination path to disable a bind path entry, or 'bind-paths' to disable all bind path entries.",
@@ -476,7 +476,7 @@ var actionNoMountFlag = cmdline.Flag{
 // --no-init
 var actionNoInitFlag = cmdline.Flag{
 	ID:           "actionNoInitFlag",
-	Value:        &NoInit,
+	Value:        &noInit,
 	DefaultValue: false,
 	Name:         "no-init",
 	Usage:        "do NOT start shim process with --pid",
@@ -486,7 +486,7 @@ var actionNoInitFlag = cmdline.Flag{
 // hidden flag to disable nvidia bindings when 'always use nv = yes'
 var actionNoNvidiaFlag = cmdline.Flag{
 	ID:           "actionNoNvidiaFlag",
-	Value:        &NoNvidia,
+	Value:        &noNvidia,
 	DefaultValue: false,
 	Name:         "no-nv",
 	Hidden:       true,
@@ -496,7 +496,7 @@ var actionNoNvidiaFlag = cmdline.Flag{
 // hidden flag to disable rocm bindings when 'always use rocm = yes'
 var actionNoRocmFlag = cmdline.Flag{
 	ID:           "actionNoRocmFlag",
-	Value:        &NoRocm,
+	Value:        &noRocm,
 	DefaultValue: false,
 	Name:         "no-rocm",
 	Hidden:       true,
@@ -506,7 +506,7 @@ var actionNoRocmFlag = cmdline.Flag{
 // --vm
 var actionVMFlag = cmdline.Flag{
 	ID:           "actionVMFlag",
-	Value:        &VM,
+	Value:        &vm,
 	DefaultValue: false,
 	Name:         "vm",
 	Usage:        "enable VM support",
@@ -516,7 +516,7 @@ var actionVMFlag = cmdline.Flag{
 // --vm-err
 var actionVMErrFlag = cmdline.Flag{
 	ID:           "actionVMErrFlag",
-	Value:        &VMErr,
+	Value:        &vmErr,
 	DefaultValue: false,
 	Name:         "vm-err",
 	Usage:        "enable attaching stderr from VM",
@@ -527,7 +527,7 @@ var actionVMErrFlag = cmdline.Flag{
 // TODO: Keep this in production?
 var actionSyOSFlag = cmdline.Flag{
 	ID:           "actionSyOSFlag",
-	Value:        &IsSyOS,
+	Value:        &isSyOS,
 	DefaultValue: false,
 	Name:         "syos",
 	Usage:        "execute SyOS shell",
@@ -537,7 +537,7 @@ var actionSyOSFlag = cmdline.Flag{
 // -p|--pid
 var actionPidNamespaceFlag = cmdline.Flag{
 	ID:           "actionPidNamespaceFlag",
-	Value:        &PidNamespace,
+	Value:        &pidNamespace,
 	DefaultValue: false,
 	Name:         "pid",
 	ShortHand:    "p",
@@ -548,7 +548,7 @@ var actionPidNamespaceFlag = cmdline.Flag{
 // -i|--ipc
 var actionIpcNamespaceFlag = cmdline.Flag{
 	ID:           "actionIpcNamespaceFlag",
-	Value:        &IpcNamespace,
+	Value:        &ipcNamespace,
 	DefaultValue: false,
 	Name:         "ipc",
 	ShortHand:    "i",
@@ -559,7 +559,7 @@ var actionIpcNamespaceFlag = cmdline.Flag{
 // -n|--net
 var actionNetNamespaceFlag = cmdline.Flag{
 	ID:           "actionNetNamespaceFlag",
-	Value:        &NetNamespace,
+	Value:        &netNamespace,
 	DefaultValue: false,
 	Name:         "net",
 	ShortHand:    "n",
@@ -570,7 +570,7 @@ var actionNetNamespaceFlag = cmdline.Flag{
 // --uts
 var actionUtsNamespaceFlag = cmdline.Flag{
 	ID:           "actionUtsNamespaceFlag",
-	Value:        &UtsNamespace,
+	Value:        &utsNamespace,
 	DefaultValue: false,
 	Name:         "uts",
 	Usage:        "run container in a new UTS namespace",
@@ -580,7 +580,7 @@ var actionUtsNamespaceFlag = cmdline.Flag{
 // -u|--userns
 var actionUserNamespaceFlag = cmdline.Flag{
 	ID:           "actionUserNamespaceFlag",
-	Value:        &UserNamespace,
+	Value:        &userNamespace,
 	DefaultValue: false,
 	Name:         "userns",
 	ShortHand:    "u",
@@ -591,7 +591,7 @@ var actionUserNamespaceFlag = cmdline.Flag{
 // --keep-privs
 var actionKeepPrivsFlag = cmdline.Flag{
 	ID:           "actionKeepPrivsFlag",
-	Value:        &KeepPrivs,
+	Value:        &keepPrivs,
 	DefaultValue: false,
 	Name:         "keep-privs",
 	Usage:        "let root user keep privileges in container (root only)",
@@ -601,7 +601,7 @@ var actionKeepPrivsFlag = cmdline.Flag{
 // --no-privs
 var actionNoPrivsFlag = cmdline.Flag{
 	ID:           "actionNoPrivsFlag",
-	Value:        &NoPrivs,
+	Value:        &noPrivs,
 	DefaultValue: false,
 	Name:         "no-privs",
 	Usage:        "drop all privileges from root user in container)",
@@ -611,7 +611,7 @@ var actionNoPrivsFlag = cmdline.Flag{
 // --add-caps
 var actionAddCapsFlag = cmdline.Flag{
 	ID:           "actionAddCapsFlag",
-	Value:        &AddCaps,
+	Value:        &addCaps,
 	DefaultValue: "",
 	Name:         "add-caps",
 	Usage:        "a comma separated capability list to add",
@@ -621,7 +621,7 @@ var actionAddCapsFlag = cmdline.Flag{
 // --drop-caps
 var actionDropCapsFlag = cmdline.Flag{
 	ID:           "actionDropCapsFlag",
-	Value:        &DropCaps,
+	Value:        &dropCaps,
 	DefaultValue: "",
 	Name:         "drop-caps",
 	Usage:        "a comma separated capability list to drop",
@@ -631,7 +631,7 @@ var actionDropCapsFlag = cmdline.Flag{
 // --allow-setuid
 var actionAllowSetuidFlag = cmdline.Flag{
 	ID:           "actionAllowSetuidFlag",
-	Value:        &AllowSUID,
+	Value:        &allowSUID,
 	DefaultValue: false,
 	Name:         "allow-setuid",
 	Usage:        "allow setuid binaries in container (root only)",
@@ -641,7 +641,7 @@ var actionAllowSetuidFlag = cmdline.Flag{
 // --env
 var actionEnvFlag = cmdline.Flag{
 	ID:           "actionEnvFlag",
-	Value:        &ApptainerEnv,
+	Value:        &apptainerEnv,
 	DefaultValue: map[string]string{},
 	Name:         "env",
 	Usage:        "pass environment variable to contained process",
@@ -650,7 +650,7 @@ var actionEnvFlag = cmdline.Flag{
 // --env-file
 var actionEnvFileFlag = cmdline.Flag{
 	ID:           "actionEnvFileFlag",
-	Value:        &ApptainerEnvFile,
+	Value:        &apptainerEnvFile,
 	DefaultValue: "",
 	Name:         "env-file",
 	Usage:        "pass environment variables from file to contained process",
@@ -660,7 +660,7 @@ var actionEnvFileFlag = cmdline.Flag{
 // --no-umask
 var actionNoUmaskFlag = cmdline.Flag{
 	ID:           "actionNoUmask",
-	Value:        &NoUmask,
+	Value:        &noUmask,
 	DefaultValue: false,
 	Name:         "no-umask",
 	Usage:        "do not propagate umask to the container, set default 0022 umask",
@@ -670,7 +670,7 @@ var actionNoUmaskFlag = cmdline.Flag{
 // --no-eval
 var actionNoEvalFlag = cmdline.Flag{
 	ID:           "actionNoEval",
-	Value:        &NoEval,
+	Value:        &noEval,
 	DefaultValue: false,
 	Name:         "no-eval",
 	Usage:        "do not shell evaluate env vars or OCI container CMD/ENTRYPOINT/ARGS",
@@ -680,7 +680,7 @@ var actionNoEvalFlag = cmdline.Flag{
 // --dmtcp-launch
 var actionDMTCPLaunchFlag = cmdline.Flag{
 	ID:           "actionDMTCPLaunchFlag",
-	Value:        &DMTCPLaunch,
+	Value:        &dmtcpLaunch,
 	DefaultValue: "",
 	Name:         "dmtcp-launch",
 	Usage:        "checkpoint for dmtcp to save container process state to (experimental)",
@@ -690,7 +690,7 @@ var actionDMTCPLaunchFlag = cmdline.Flag{
 // --dmtcp-restart
 var actionDMTCPRestartFlag = cmdline.Flag{
 	ID:           "actionDMTCPrestartFlag",
-	Value:        &DMTCPRestart,
+	Value:        &dmtcpRestart,
 	DefaultValue: "",
 	Name:         "dmtcp-restart",
 	Usage:        "checkpoint for dmtcp to use to restart container process (experimental)",
@@ -700,7 +700,7 @@ var actionDMTCPRestartFlag = cmdline.Flag{
 // --blkio-weight
 var actionBlkioWeightFlag = cmdline.Flag{
 	ID:           "actionBlkioWeight",
-	Value:        &BlkioWeight,
+	Value:        &blkioWeight,
 	DefaultValue: 0,
 	Name:         "blkio-weight",
 	Usage:        "Block IO relative weight in range 10-1000, 0 to disable",
@@ -710,7 +710,7 @@ var actionBlkioWeightFlag = cmdline.Flag{
 // --blkio-weight-device
 var actionBlkioWeightDeviceFlag = cmdline.Flag{
 	ID:           "actionBlkioWeightDevice",
-	Value:        &BlkioWeightDevice,
+	Value:        &blkioWeightDevice,
 	DefaultValue: []string{},
 	Name:         "blkio-weight-device",
 	Usage:        "Device specific block IO relative weight",
@@ -720,7 +720,7 @@ var actionBlkioWeightDeviceFlag = cmdline.Flag{
 // --cpu-shares
 var actionCPUSharesFlag = cmdline.Flag{
 	ID:           "actionCPUShares",
-	Value:        &CPUShares,
+	Value:        &cpuShares,
 	DefaultValue: -1,
 	Name:         "cpu-shares",
 	Usage:        "CPU shares for container",
@@ -730,7 +730,7 @@ var actionCPUSharesFlag = cmdline.Flag{
 // --cpus
 var actionCPUsFlag = cmdline.Flag{
 	ID:           "actionCPUs",
-	Value:        &CPUs,
+	Value:        &cpus,
 	DefaultValue: "",
 	Name:         "cpus",
 	Usage:        "Number of CPUs available to container",
@@ -740,7 +740,7 @@ var actionCPUsFlag = cmdline.Flag{
 // --cpuset-cpus
 var actionCPUsetCPUsFlag = cmdline.Flag{
 	ID:           "actionCPUsetCPUs",
-	Value:        &CPUSetCPUs,
+	Value:        &cpuSetCPUs,
 	DefaultValue: "",
 	Name:         "cpuset-cpus",
 	Usage:        "List of host CPUs available to container",
@@ -750,7 +750,7 @@ var actionCPUsetCPUsFlag = cmdline.Flag{
 // --cpuset-mems
 var actionCPUsetMemsFlag = cmdline.Flag{
 	ID:           "actionCPUsetMems",
-	Value:        &CPUSetMems,
+	Value:        &cpuSetMems,
 	DefaultValue: "",
 	Name:         "cpuset-mems",
 	Usage:        "List of host memory nodes available to container",
@@ -760,7 +760,7 @@ var actionCPUsetMemsFlag = cmdline.Flag{
 // --memory
 var actionMemoryFlag = cmdline.Flag{
 	ID:           "actionMemory",
-	Value:        &Memory,
+	Value:        &memory,
 	DefaultValue: "",
 	Name:         "memory",
 	Usage:        "Memory limit in bytes",
@@ -770,7 +770,7 @@ var actionMemoryFlag = cmdline.Flag{
 // --memory-reservation
 var actionMemoryReservationFlag = cmdline.Flag{
 	ID:           "actionMemoryReservation",
-	Value:        &MemoryReservation,
+	Value:        &memoryReservation,
 	DefaultValue: "",
 	Name:         "memory-reservation",
 	Usage:        "Memory soft limit in bytes",
@@ -780,7 +780,7 @@ var actionMemoryReservationFlag = cmdline.Flag{
 // --memory-swap
 var actionMemorySwapFlag = cmdline.Flag{
 	ID:           "actionMemorySwap",
-	Value:        &MemorySwap,
+	Value:        &memorySwap,
 	DefaultValue: "",
 	Name:         "memory-swap",
 	Usage:        "Swap limit, use -1 for unlimited swap",
@@ -790,7 +790,7 @@ var actionMemorySwapFlag = cmdline.Flag{
 // --oom-kill-disable
 var actionOomKillDisableFlag = cmdline.Flag{
 	ID:           "oomKillDisable",
-	Value:        &OomKillDisable,
+	Value:        &oomKillDisable,
 	DefaultValue: false,
 	Name:         "oom-kill-disable",
 	Usage:        "Disable OOM killer",
@@ -800,7 +800,7 @@ var actionOomKillDisableFlag = cmdline.Flag{
 // --pids-limit
 var actionPidsLimitFlag = cmdline.Flag{
 	ID:           "actionPidsLimit",
-	Value:        &PidsLimit,
+	Value:        &pidsLimit,
 	DefaultValue: 0,
 	Name:         "pids-limit",
 	Usage:        "Limit number of container PIDs, use -1 for unlimited",
@@ -810,7 +810,7 @@ var actionPidsLimitFlag = cmdline.Flag{
 // --unsquash
 var actionUnsquashFlag = cmdline.Flag{
 	ID:           "actionUnsquashFlag",
-	Value:        &Unsquash,
+	Value:        &unsquash,
 	DefaultValue: false,
 	Name:         "unsquash",
 	Usage:        "Convert SIF file to temporary sandbox before running",
@@ -820,7 +820,7 @@ var actionUnsquashFlag = cmdline.Flag{
 // --ignore-subuid
 var actionIgnoreSubuidFlag = cmdline.Flag{
 	ID:           "actionIgnoreSubuidFlag",
-	Value:        &IgnoreSubuid,
+	Value:        &ignoreSubuid,
 	DefaultValue: false,
 	Name:         "ignore-subuid",
 	Usage:        "ignore entries inside /etc/subuid",
@@ -831,7 +831,7 @@ var actionIgnoreSubuidFlag = cmdline.Flag{
 // --ignore-fakeroot-command
 var actionIgnoreFakerootCommand = cmdline.Flag{
 	ID:           "actionIgnoreFakerootCommandFlag",
-	Value:        &IgnoreFakerootCmd,
+	Value:        &ignoreFakerootCmd,
 	DefaultValue: false,
 	Name:         "ignore-fakeroot-command",
 	Usage:        "ignore fakeroot command",
@@ -842,7 +842,7 @@ var actionIgnoreFakerootCommand = cmdline.Flag{
 // --ignore-userns
 var actionIgnoreUsernsFlag = cmdline.Flag{
 	ID:           "actionIgnoreUsernsFlag",
-	Value:        &IgnoreUserns,
+	Value:        &ignoreUserns,
 	DefaultValue: false,
 	Name:         "ignore-userns",
 	Usage:        "ignore user namespaces",

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/client/oci"
 	"github.com/apptainer/apptainer/internal/pkg/client/oras"
 	"github.com/apptainer/apptainer/internal/pkg/client/shub"
+	"github.com/apptainer/apptainer/internal/pkg/runtime/launch"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/uri"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -62,12 +63,12 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 	// --compat infers other options that give increased OCI / Docker compatibility
 	// Excludes uts/user/net namespaces as these are restrictive for many Apptainer
 	// installs.
-	if IsCompat {
-		IsContainAll = true
-		IsWritableTmpfs = true
-		NoInit = true
-		NoUmask = true
-		NoEval = true
+	if isCompat {
+		isContainAll = true
+		isWritableTmpfs = true
+		noInit = true
+		noUmask = true
+		noEval = true
 	}
 }
 
@@ -170,7 +171,7 @@ func setVM(cmd *cobra.Command) {
 	}
 
 	// since --syos is a boolean, it cannot be added to the above list
-	if IsSyOS && !VM {
+	if isSyOS && !vm {
 		// let the user know that passing --syos implicitly enables --vm
 		sylog.Warningf("The --syos option requires a virtual machine, automatically enabling --vm option.")
 		cmd.Flags().Set("vm", "true")
@@ -186,12 +187,13 @@ var ExecCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		a := append([]string{"/.singularity.d/actions/exec"}, args[1:]...)
 		setVM(cmd)
-		if VM {
+		if vm {
 			execVM(cmd, args[0], a)
 			return
 		}
-
-		execStarter(cmd, args[0], a, "")
+		if err := launchContainer(cmd, args[0], a, ""); err != nil {
+			sylog.Fatalf("%s", err)
+		}
 	},
 
 	Use:     docs.ExecUse,
@@ -209,11 +211,13 @@ var ShellCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		a := []string{"/.singularity.d/actions/shell"}
 		setVM(cmd)
-		if VM {
+		if vm {
 			execVM(cmd, args[0], a)
 			return
 		}
-		execStarter(cmd, args[0], a, "")
+		if err := launchContainer(cmd, args[0], a, ""); err != nil {
+			sylog.Fatalf("%s", err)
+		}
 	},
 
 	Use:     docs.ShellUse,
@@ -231,11 +235,13 @@ var RunCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		a := append([]string{"/.singularity.d/actions/run"}, args[1:]...)
 		setVM(cmd)
-		if VM {
+		if vm {
 			execVM(cmd, args[0], a)
 			return
 		}
-		execStarter(cmd, args[0], a, "")
+		if err := launchContainer(cmd, args[0], a, ""); err != nil {
+			sylog.Fatalf("%s", err)
+		}
 	},
 
 	Use:     docs.RunUse,
@@ -253,15 +259,96 @@ var TestCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		a := append([]string{"/.singularity.d/actions/test"}, args[1:]...)
 		setVM(cmd)
-		if VM {
+		if vm {
 			execVM(cmd, args[0], a)
 			return
 		}
-		execStarter(cmd, args[0], a, "")
+		if err := launchContainer(cmd, args[0], a, ""); err != nil {
+			sylog.Fatalf("%s", err)
+		}
 	},
 
 	Use:     docs.RunTestUse,
 	Short:   docs.RunTestShort,
 	Long:    docs.RunTestLong,
 	Example: docs.RunTestExample,
+}
+
+func launchContainer(cmd *cobra.Command, image string, args []string, instanceName string) error {
+	ns := launch.Namespaces{
+		User: userNamespace,
+		UTS:  utsNamespace,
+		PID:  pidNamespace,
+		IPC:  ipcNamespace,
+		Net:  netNamespace,
+	}
+
+	cgJSON, err := getCgroupsJSON()
+	if err != nil {
+		return err
+	}
+
+	ki, err := getEncryptionMaterial(cmd)
+	if err != nil {
+		return err
+	}
+
+	opts := []launch.Option{
+		launch.OptWritable(isWritable),
+		launch.OptWritableTmpfs(isWritableTmpfs),
+		launch.OptOverlayPaths(overlayPath),
+		launch.OptScratchDirs(scratchPath),
+		launch.OptWorkDir(workdirPath),
+		launch.OptHome(
+			homePath,
+			cmd.Flag(actionHomeFlag.Name).Changed,
+			noHome,
+		),
+		launch.OptMounts(bindPaths, mounts, fuseMount),
+		launch.OptNoMount(noMount),
+		launch.OptNvidia(nvidia, nvCCLI),
+		launch.OptNoNvidia(noNvidia),
+		launch.OptRocm(rocm),
+		launch.OptNoRocm(noRocm),
+		launch.OptContainLibs(containLibsPath),
+		launch.OptEnv(apptainerEnv, apptainerEnvFile, isCleanEnv),
+		launch.OptNoEval(noEval),
+		launch.OptNamespaces(ns),
+		launch.OptNetwork(network, networkArgs),
+		launch.OptHostname(hostname),
+		launch.OptDNS(dns),
+		launch.OptCaps(addCaps, dropCaps),
+		launch.OptAllowSUID(allowSUID),
+		launch.OptKeepPrivs(keepPrivs),
+		launch.OptNoPrivs(noPrivs),
+		launch.OptSecurity(security),
+		launch.OptNoUmask(noUmask),
+		launch.OptCgroupsJSON(cgJSON),
+		launch.OptConfigFile(configurationFile),
+		launch.OptShellPath(shellPath),
+		launch.OptPwdPath(pwdPath),
+		launch.OptFakeroot(isFakeroot),
+		launch.OptBoot(isBoot),
+		launch.OptNoInit(noInit),
+		launch.OptContain(isContained),
+		launch.OptContainAll(isContainAll),
+		launch.OptAppName(appName),
+		launch.OptKeyInfo(ki),
+		launch.OptCacheDisabled(disableCache),
+		launch.OptDMTCPLaunch(dmtcpLaunch),
+		launch.OptDMTCPRestart(dmtcpRestart),
+		launch.OptUnsquash(unsquash),
+		launch.OptIgnoreSubuid(ignoreSubuid),
+		launch.OptIgnoreFakerootCmd(ignoreFakerootCmd),
+		launch.OptIgnoreUserns(ignoreUserns),
+		launch.OptUseBuildConfig(useBuildConfig),
+		launch.OptTmpDir(tmpDir),
+	}
+
+	l, err := launch.NewLauncher(opts...)
+	if err != nil {
+		return fmt.Errorf("while configuring container: %s", err)
+	}
+
+	return l.Exec(cmd.Context(), image, args, instanceName)
 }

--- a/cmd/internal/cli/cgroups_test.go
+++ b/cmd/internal/cli/cgroups_test.go
@@ -119,8 +119,8 @@ func Test_getBlkioLimits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			BlkioWeight = tt.blkioWeight
-			BlkioWeightDevice = tt.blkioWeightDevice
+			blkioWeight = tt.blkioWeight
+			blkioWeightDevice = tt.blkioWeightDevice
 
 			blkio, err := getBlkioLimits()
 
@@ -235,10 +235,10 @@ func Test_getCpuLimits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			CPUShares = tt.cpuShares
-			CPUSetCPUs = tt.cpusetCPUs
-			CPUSetMems = tt.cpusetMems
-			CPUs = tt.cpus
+			cpuShares = tt.cpuShares
+			cpuSetCPUs = tt.cpusetCPUs
+			cpuSetMems = tt.cpusetMems
+			cpus = tt.cpus
 
 			cpu, err := getCPULimits()
 
@@ -421,10 +421,10 @@ func Test_getMemoryLimits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			Memory = tt.memory
-			MemoryReservation = tt.memoryReservation
-			MemorySwap = tt.memorySwap
-			OomKillDisable = tt.oomKillDisable
+			memory = tt.memory
+			memoryReservation = tt.memoryReservation
+			memorySwap = tt.memorySwap
+			oomKillDisable = tt.oomKillDisable
 
 			mem, err := getMemoryLimits()
 
@@ -496,7 +496,7 @@ func Test_getPidsLimits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			PidsLimit = tt.pidsLimit
+			pidsLimit = tt.pidsLimit
 
 			pids, err := getPidsLimits()
 

--- a/cmd/internal/cli/checkpoint.go
+++ b/cmd/internal/cli/checkpoint.go
@@ -167,7 +167,9 @@ var CheckpointInstanceCmd = &cobra.Command{
 		sylog.Infof("Using checkpoint %q", e.Name())
 
 		a := append([]string{"/.singularity.d/actions/exec"}, dmtcp.CheckpointArgs(port)...)
-		execStarter(cmd, "instance://"+args[0], a, "")
+		if err := launchContainer(cmd, "instance://"+args[0], a, ""); err != nil {
+			sylog.Fatalf("%s", err)
+		}
 	},
 
 	Use:     docs.CheckpointInstanceUse,

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -93,7 +93,7 @@ var inspectAppsListFlag = cmdline.Flag{
 // --app
 var inspectAppNameFlag = cmdline.Flag{
 	ID:           "inspectAppNameFlag",
-	Value:        &AppName,
+	Value:        &appName,
 	DefaultValue: "",
 	Name:         "app",
 	Usage:        "inspect a specific app",
@@ -638,10 +638,10 @@ var InspectCmd = &cobra.Command{
 		if allData {
 			// display all data in JSON format only
 			jsonfmt = true
-			AppName = ""
+			appName = ""
 		}
 
-		inspectCmd := newCommand(allData, AppName, img)
+		inspectCmd := newCommand(allData, appName, img)
 
 		// Try to inspect the label partition, if not, then exec/shell
 		// the container to get the data.
@@ -669,7 +669,7 @@ var InspectCmd = &cobra.Command{
 		}
 
 		if startscript || allData {
-			if AppName == "" {
+			if appName == "" {
 				sylog.Debugf("Inspection of startscript selected.")
 				inspectCmd.addStartscriptCommand()
 			}
@@ -695,7 +695,7 @@ var InspectCmd = &cobra.Command{
 		}
 
 		for app := range inspectData.Data.Attributes.Apps {
-			if !listApps && !allData && AppName != app {
+			if !listApps && !allData && appName != app {
 				delete(inspectData.Data.Attributes.Apps, app)
 			}
 		}
@@ -708,7 +708,7 @@ var InspectCmd = &cobra.Command{
 			}
 			fmt.Printf("%s\n", string(jsonObj))
 		} else {
-			appAttr := inspectData.Data.Attributes.Apps[AppName]
+			appAttr := inspectData.Data.Attributes.Apps[appName]
 
 			if listApps {
 				printSortedApp(inspectData.Data.Attributes.Apps)

--- a/cmd/internal/cli/instance_start_linux.go
+++ b/cmd/internal/cli/instance_start_linux.go
@@ -48,12 +48,13 @@ var instanceStartCmd = &cobra.Command{
 
 		a := append([]string{"/.singularity.d/actions/start"}, args[2:]...)
 		setVM(cmd)
-		if VM {
+		if vm {
 			execVM(cmd, image, a)
 			return
 		}
-
-		execStarter(cmd, image, a, name)
+		if err := launchContainer(cmd, image, a, name); err != nil {
+			sylog.Fatalf("%s", err)
+		}
 
 		if instanceStartPidFile != "" {
 			err := apptainer.WriteInstancePidFile(name, instanceStartPidFile)

--- a/cmd/internal/cli/run_help_linux.go
+++ b/cmd/internal/cli/run_help_linux.go
@@ -26,7 +26,7 @@ import (
 // --app
 var runHelpAppNameFlag = cmdline.Flag{
 	ID:           "runHelpAppNameFlag",
-	Value:        &AppName,
+	Value:        &appName,
 	DefaultValue: "",
 	Name:         "app",
 	Usage:        "show the help for an app",
@@ -51,9 +51,9 @@ var RunHelpCmd = &cobra.Command{
 		}
 
 		cmdArgs := []string{"inspect", "--helpfile"}
-		if AppName != "" {
-			sylog.Debugf("App specified. Looking for help section of %s", AppName)
-			cmdArgs = append(cmdArgs, "--app", AppName)
+		if appName != "" {
+			sylog.Debugf("App specified. Looking for help section of %s", appName)
+			cmdArgs = append(cmdArgs, "--app", appName)
 		}
 		cmdArgs = append(cmdArgs, args[0])
 

--- a/cmd/internal/cli/startvm.go
+++ b/cmd/internal/cli/startvm.go
@@ -27,7 +27,7 @@ func getHypervisorArgs(sifImage, bzImage, initramfs, singAction, cliExtra string
 	// Setup some needed variables
 	appendArgs := fmt.Sprintf("root=/dev/ram0 console=ttyS0 quiet apptainer_action=%s apptainer_arguments=\"%s\"", singAction, cliExtra)
 
-	args := []string{"/usr/libexec/qemu-kvm", "-cpu", "host", "-smp", VMCPU, "-enable-kvm", "-device", "virtio-rng-pci", "-display", "none", "-realtime", "mlock=on", "-hda", sifImage, "-serial", "stdio", "-kernel", bzImage, "-initrd", initramfs, "-m", VMRAM, "-append", appendArgs}
+	args := []string{"/usr/libexec/qemu-kvm", "-cpu", "host", "-smp", vmCPU, "-enable-kvm", "-device", "virtio-rng-pci", "-display", "none", "-realtime", "mlock=on", "-hda", sifImage, "-serial", "stdio", "-kernel", bzImage, "-initrd", initramfs, "-m", vmRAM, "-append", appendArgs}
 
 	return args
 }
@@ -85,7 +85,7 @@ func startVM(sifImage, singAction, cliExtra string, isInternal bool) error {
 	cmd.Env = os.Environ()
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
-	if VMErr || debug {
+	if vmErr || debug {
 		cmd.Stderr = os.Stderr
 	}
 

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -861,7 +861,7 @@ func runActionScript(engineConfig *apptainerConfig.EngineConfig) ([]string, []st
 	// function to execute the command
 	shell.RegisterShellBuiltin("exec", execBuiltin)
 
-	err = shell.Run()
+	err = shell.Run(context.TODO())
 	if err != nil {
 		if shell.Status() != 0 {
 			os.Exit(int(shell.Status()))
@@ -879,7 +879,7 @@ func runActionScript(engineConfig *apptainerConfig.EngineConfig) ([]string, []st
 				return nil, nil, err
 			}
 			interp.RegisterShellBuiltin("exec", execBuiltin)
-			err = interp.Run()
+			err = interp.Run(context.TODO())
 			if err != nil {
 				if interp.Status() != 0 {
 					os.Exit(int(interp.Status()))

--- a/internal/pkg/runtime/launch/options.go
+++ b/internal/pkg/runtime/launch/options.go
@@ -1,0 +1,559 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// Package launcher is responsible for starting a container, with configuration
+// passed to it from the CLI layer.
+//
+// The package currently implements a single Launcher, with an Exec method that
+// constructs a runtime configuration and calls the Apptainer runtime starter
+// binary to start the container.
+//
+// TODO - the launcher package will be extended to support launching containers
+// via the OCI runc/crun runtime, in addition to the current Apptainer runtime
+// starter.
+package launch
+
+import (
+	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
+	apptainerConfig "github.com/apptainer/apptainer/pkg/runtime/engine/apptainer/config"
+	"github.com/apptainer/apptainer/pkg/util/cryptkey"
+)
+
+// launchOptions accumulates configuration from passed functional options. Note
+// that the launchOptions is modified heavily by logic during the Exec function
+// call.
+type launchOptions struct {
+	// Writable marks the container image itself as writable.
+	Writable bool
+	// WriteableTmpfs applies an ephemeral writable overlay to the container.
+	WritableTmpfs bool
+	// OverlayPaths holds paths to image or directory overlays to be applied.
+	OverlayPaths []string
+	// Scratchdir lists paths into the container to be mounted from a temporary location on the host.
+	ScratchDirs []string
+	// WorkDir is the parent path for scratch directories, and contained home/tmp on the host.
+	WorkDir string
+
+	// HomeDir is the home directory to mount into the container, or a src:dst pair.
+	HomeDir string
+	// CustomHome is a marker that HomeDir is user-supplied, and should not be
+	// modified by the logic used for fakeroot execution.
+	CustomHome bool
+	// NoHome disables automatic mounting of the home directory into the container.
+	NoHome bool
+
+	// BindPaths lists paths to bind from host to container, which may be <src>:<dest> pairs.
+	BindPaths []string
+	// FuseMount lists paths to be mounted into the container using a FUSE binary, and their options.
+	FuseMount []string
+	// Mounts lists paths to bind from host to container, from the docker compatible `--mount` flag (CSV format).
+	Mounts []string
+	// NoMount is a list of automatic / configured mounts to disable.
+	NoMount []string
+
+	// Nvidia enables NVIDIA GPU support.
+	Nvidia bool
+	// NcCCLI sets NVIDIA GPU support to use the nvidia-container-cli.
+	NvCCLI bool
+	// NoNvidia disables NVIDIA GPU support when set default in apptainer.conf.
+	NoNvidia bool
+	// Rocm enables Rocm GPU support.
+	Rocm bool
+	// NoRocm disable Rocm GPU support when set default in apptainer.conf.
+	NoRocm bool
+
+	// ContainLibs lists paths of libraries to bind mount into the container .singularity.d/libs dir.
+	ContainLibs []string
+
+	// Env is a map of name=value env vars to set in the container.
+	Env map[string]string
+	// EnvFile is a file to read container env vars from.
+	EnvFile string
+	// CleanEnv starts the container with a clean environment, excluding host env vars.
+	CleanEnv bool
+	// NoEval instructs Apptainer not to shell evaluate args and env vars.
+	NoEval bool
+
+	// Namespaces is the list of optional Namespaces requested for the container.
+	Namespaces Namespaces
+
+	// Network is the name of an optional CNI networking configuration to apply.
+	Network string
+	// NetworkArgs are argument to pass to the CNI plugin that will configure networking when Network is set.
+	NetworkArgs []string
+	// Hostname is the hostname to set in the container (infers/requires UTS namespace).
+	Hostname string
+	// DNS is the comma separated list of DNS servers to be set in the container's resolv.conf.
+	DNS string
+
+	// AddCaps is the list of capabilities to Add to the container process.
+	AddCaps string
+	// DropCaps is the list of capabilities to drop from the container process.
+	DropCaps string
+	// AllowSUID permits setuid executables inside a container started by the root user.
+	AllowSUID bool
+	// KeepPrivs keeps all privileges inside a container started by the root user.
+	KeepPrivs bool
+	// NoPrivs drops all privileges inside a container.
+	NoPrivs bool
+	// SecurityOpts is the list of security options (selinux, apparmor, seccomp) to apply.
+	SecurityOpts []string
+	// NoUmask disables propagation of the host umask into the container, using a default 0022.
+	NoUmask bool
+
+	// CGroupsJSON is a JSON format cgroups resource limit specification to apply.
+	CGroupsJSON string
+
+	// ConfigFile is an alternate apptainer.conf that will be used by unprivileged installations only.
+	ConfigFile string
+
+	// ShellPath is a custom shell executable to be launched in the container.
+	ShellPath string
+	// PwdPath is the initial working directory in the container.
+	PwdPath string
+
+	// Fakeroot enables the fake root mode, using user namespaces and subuid / subgid mapping.
+	Fakeroot bool
+	// Boot enables execution of /sbin/init on startup of an instance container.
+	Boot bool
+	// NoInit disables shim process when PID namespace is used.
+	NoInit bool
+	// Contain starts the container with minimal /dev and empty home/tmp mounts.
+	Contain bool
+	// ContainAll infers Contain, and adds PID, IPC namespaces, and CleanEnv.
+	ContainAll bool
+
+	// AppName sets a SCIF application name to run.
+	AppName string
+
+	// KeyInfo holds encryption key information for accessing encrypted containers.
+	KeyInfo *cryptkey.KeyInfo
+
+	// SIFFUSE enables mounting SIF container images using FUSE.
+	SIFFUSE bool
+	// CacheDisabled indicates caching of images was disabled in the CLI, as in
+	// userns flows we will need to delete the redundant temporary pulled image after
+	// conversion to sandbox.
+	CacheDisabled bool
+
+	DMTCPLaunch       string
+	DMTCPRestart      string
+	Unsquash          bool
+	IgnoreSubuid      bool
+	IgnoreFakerootCmd bool
+	IgnoreUserns      bool
+	UseBuildConfig    bool
+	TmpDir            string
+}
+
+type Launcher struct {
+	uid          uint32
+	gid          uint32
+	cfg          launchOptions
+	engineConfig *apptainerConfig.EngineConfig
+	generator    *generate.Generator
+}
+
+// Namespaces holds flags for the optional (non-mount) namespaces that can be
+// requested for a container launch.
+type Namespaces struct {
+	User bool
+	UTS  bool
+	PID  bool
+	IPC  bool
+	Net  bool
+}
+
+type Option func(co *launchOptions) error
+
+// OptWritable sets the container image to be writable.
+func OptWritable(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.Writable = b
+		return nil
+	}
+}
+
+// OptWritableTmpFs applies an ephemeral writable overlay to the container.
+func OptWritableTmpfs(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.WritableTmpfs = b
+		return nil
+	}
+}
+
+// OptOverlayPaths sets overlay images and directories to apply to the container.
+func OptOverlayPaths(op []string) Option {
+	return func(lo *launchOptions) error {
+		lo.OverlayPaths = op
+		return nil
+	}
+}
+
+// OptScratchDirs sets temporary host directories to create and bind into the container.
+func OptScratchDirs(sd []string) Option {
+	return func(lo *launchOptions) error {
+		lo.ScratchDirs = sd
+		return nil
+	}
+}
+
+// OptWorkDir sets the parent path for scratch directories, and contained home/tmp on the host.
+func OptWorkDir(wd string) Option {
+	return func(lo *launchOptions) error {
+		lo.WorkDir = wd
+		return nil
+	}
+}
+
+// OptHome sets the home directory configuration for the container.
+//
+// homeDir is the path or src:dst to bind mount.
+// custom is a marker that this is user supplied, and must not be overridden.
+// disable will disable the home mount entirely, ignoring other options.
+func OptHome(homeDir string, custom bool, disable bool) Option {
+	return func(lo *launchOptions) error {
+		lo.HomeDir = homeDir
+		lo.CustomHome = custom
+		lo.NoHome = disable
+		return nil
+	}
+}
+
+// OptMounts sets user-requested mounts to propagate into the container.
+//
+// binds lists bind mount specifications in Apptainer's <src>:<dst>[:<opts>] format.
+// mounts lists bind mount specifications in Docker CSV processed format.
+// fuseMounts list FUSE mounts in <type>:<fuse command> <mountpoint> format.
+func OptMounts(binds []string, mounts []string, fuseMounts []string) Option {
+	return func(lo *launchOptions) error {
+		lo.BindPaths = binds
+		lo.Mounts = mounts
+		lo.FuseMount = fuseMounts
+		return nil
+	}
+}
+
+// OptNoMount disables the specified bind mounts.
+func OptNoMount(nm []string) Option {
+	return func(lo *launchOptions) error {
+		lo.NoMount = nm
+		return nil
+	}
+}
+
+// OptNvidia enables NVIDIA GPU support.
+//
+// nvccli sets whether to use the nvidia-container-runtime (true), or legacy bind mounts (false).
+func OptNvidia(nv bool, nvccli bool) Option {
+	return func(lo *launchOptions) error {
+		lo.Nvidia = nv || nvccli
+		lo.NvCCLI = nvccli
+		return nil
+	}
+}
+
+// OptNoNvidia disables NVIDIA GPU support, even if enabled via apptainer.conf.
+func OptNoNvidia(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.NoNvidia = b
+		return nil
+	}
+}
+
+// OptRocm enable Rocm GPU support.
+func OptRocm(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.Rocm = b
+		return nil
+	}
+}
+
+// OptNoRocm disables Rocm GPU support, even if enabled via apptainer.conf.
+func OptNoRocm(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.NoRocm = b
+		return nil
+	}
+}
+
+// OptContainLibs mounts specified libraries into the container .singularity.d/libs dir.
+func OptContainLibs(cl []string) Option {
+	return func(lo *launchOptions) error {
+		lo.ContainLibs = cl
+		return nil
+	}
+}
+
+// OptEnv sets container environment
+//
+// envFile is a path to a file container environment variables to set.
+// env is a map of name=value env vars to set.
+// clean removes host variables from the container environment.
+func OptEnv(env map[string]string, envFile string, clean bool) Option {
+	return func(lo *launchOptions) error {
+		lo.Env = env
+		lo.EnvFile = envFile
+		lo.CleanEnv = clean
+		return nil
+	}
+}
+
+// OptNoEval disables shell evaluation of args and env vars.
+func OptNoEval(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.NoEval = b
+		return nil
+	}
+}
+
+// OptNamespaces enable the individual kernel-support namespaces for the container.
+func OptNamespaces(n Namespaces) Option {
+	return func(lo *launchOptions) error {
+		lo.Namespaces = n
+		return nil
+	}
+}
+
+// OptNetwork enables CNI networking.
+//
+// network is the name of the CNI configuration to enable.
+// args are arguments to pass to the CNI plugin.
+func OptNetwork(network string, args []string) Option {
+	return func(lo *launchOptions) error {
+		lo.Network = network
+		lo.NetworkArgs = args
+		return nil
+	}
+}
+
+// OptHostname sets a hostname for the container (infers/requires UTS namespace).
+func OptHostname(h string) Option {
+	return func(lo *launchOptions) error {
+		lo.Hostname = h
+		return nil
+	}
+}
+
+// OptDNS sets a DNS entry for the container resolv.conf.
+func OptDNS(d string) Option {
+	return func(lo *launchOptions) error {
+		lo.DNS = d
+		return nil
+	}
+}
+
+// OptCaps sets capabilities to add and drop.
+func OptCaps(add, drop string) Option {
+	return func(lo *launchOptions) error {
+		lo.AddCaps = add
+		lo.DropCaps = drop
+		return nil
+	}
+}
+
+// OptAllowSUID permits setuid executables inside a container started by the root user.
+func OptAllowSUID(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.AllowSUID = b
+		return nil
+	}
+}
+
+// OptKeepPrivs keeps all privileges inside a container started by the root user.
+func OptKeepPrivs(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.KeepPrivs = b
+		return nil
+	}
+}
+
+// OptNoPrivs drops all privileges inside a container.
+func OptNoPrivs(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.NoPrivs = b
+		return nil
+	}
+}
+
+// OptSecurity supplies a list of security options (selinux, apparmor, seccomp) to apply.
+func OptSecurity(s []string) Option {
+	return func(lo *launchOptions) error {
+		lo.SecurityOpts = s
+		return nil
+	}
+}
+
+// OptNoUmask disables propagation of the host umask into the container, using a default 0022.
+func OptNoUmask(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.NoUmask = b
+		return nil
+	}
+}
+
+// OptCgroupsJSON sets a Cgroups resource limit configuration to apply to the container.
+func OptCgroupsJSON(cj string) Option {
+	return func(lo *launchOptions) error {
+		lo.CGroupsJSON = cj
+		return nil
+	}
+}
+
+// OptConfigFile specifies an alternate apptainer.conf that will be used by unprivileged installations only.
+func OptConfigFile(c string) Option {
+	return func(lo *launchOptions) error {
+		lo.ConfigFile = c
+		return nil
+	}
+}
+
+// OptShellPath specifies a custom shell executable to be launched in the container.
+func OptShellPath(s string) Option {
+	return func(lo *launchOptions) error {
+		lo.ShellPath = s
+		return nil
+	}
+}
+
+// OptPwdPath specifies the initial working directory in the container.
+func OptPwdPath(p string) Option {
+	return func(lo *launchOptions) error {
+		lo.PwdPath = p
+		return nil
+	}
+}
+
+// OptFakeroot enables the fake root mode, using user namespaces and subuid / subgid mapping.
+func OptFakeroot(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.Fakeroot = b
+		return nil
+	}
+}
+
+// OptBoot enables execution of /sbin/init on startup of an instance container.
+func OptBoot(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.Boot = b
+		return nil
+	}
+}
+
+// OptNoInit disables shim process when PID namespace is used.
+func OptNoInit(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.NoInit = b
+		return nil
+	}
+}
+
+// OptContain starts the container with minimal /dev and empty home/tmp mounts.
+func OptContain(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.Contain = b
+		return nil
+	}
+}
+
+// OptContainAll infers Contain, and adds PID, IPC namespaces, and CleanEnv.
+func OptContainAll(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.ContainAll = b
+		return nil
+	}
+}
+
+// OptAppName sets a SCIF application name to run.
+func OptAppName(a string) Option {
+	return func(lo *launchOptions) error {
+		lo.AppName = a
+		return nil
+	}
+}
+
+// OptKeyInfo sets encryption key material to use when accessing an encrypted container image.
+func OptKeyInfo(ki *cryptkey.KeyInfo) Option {
+	return func(lo *launchOptions) error {
+		lo.KeyInfo = ki
+		return nil
+	}
+}
+
+// CacheDisabled indicates caching of images was disabled in the CLI.
+func OptCacheDisabled(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.CacheDisabled = b
+		return nil
+	}
+}
+
+// OptDMTCPLaunch
+func OptDMTCPLaunch(a string) Option {
+	return func(lo *launchOptions) error {
+		lo.DMTCPLaunch = a
+		return nil
+	}
+}
+
+// OptDMTCPRestart
+func OptDMTCPRestart(a string) Option {
+	return func(lo *launchOptions) error {
+		lo.DMTCPRestart = a
+		return nil
+	}
+}
+
+// OptUnsquash
+func OptUnsquash(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.Unsquash = b
+		return nil
+	}
+}
+
+// OptIgnoreSubuid
+func OptIgnoreSubuid(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.IgnoreSubuid = b
+		return nil
+	}
+}
+
+// OptIgnoreFakerootCmd
+func OptIgnoreFakerootCmd(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.IgnoreFakerootCmd = b
+		return nil
+	}
+}
+
+// OptIgnoreUserns
+func OptIgnoreUserns(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.IgnoreUserns = b
+		return nil
+	}
+}
+
+// OptUseBuildConfig
+func OptUseBuildConfig(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.UseBuildConfig = b
+		return nil
+	}
+}
+
+// OptTmpDir
+func OptTmpDir(a string) Option {
+	return func(lo *launchOptions) error {
+		lo.TmpDir = a
+		return nil
+	}
+}

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -225,9 +225,7 @@ func (s *Shell) LookPath(ctx context.Context, cmd string) (string, error) {
 }
 
 // Run runs the shell interpreter.
-func (s *Shell) Run() error {
-	ctx := context.TODO()
-
+func (s *Shell) Run(ctx context.Context) error {
 	parser := syntax.NewParser()
 	node, err := parser.Parse(s.reader, s.name)
 	if err != nil {
@@ -289,7 +287,7 @@ func (e nonExportedEnv) Each(fn func(name string, vr expand.Variable) bool) {
 // EvaluateEnv evaluates the environment variable script and returns
 // the list of variables set in the script. Command execution is disabled
 // along with redirection.
-func EvaluateEnv(script []byte, args []string, envs []string) ([]string, error) {
+func EvaluateEnv(ctx context.Context, script []byte, args []string, envs []string) ([]string, error) {
 	const stopBuiltin = "__stop__"
 
 	var env []string
@@ -324,7 +322,7 @@ func EvaluateEnv(script []byte, args []string, envs []string) ([]string, error) 
 	// set allexport option
 	interp.Params("-a")(shell.runner)
 
-	if err := shell.Run(); err != nil {
+	if err := shell.Run(ctx); err != nil {
 		return nil, fmt.Errorf("while evaluating environment script: %s", err)
 	}
 

--- a/internal/pkg/util/shell/interpreter/interpreter_test.go
+++ b/internal/pkg/util/shell/interpreter/interpreter_test.go
@@ -197,7 +197,7 @@ func TestInterpreter(t *testing.T) {
 			if tt.openHandler != nil {
 				shell.RegisterOpenHandler(tt.openHandler.path, tt.openHandler.fn(shell))
 			}
-			if err := shell.Run(); err != nil {
+			if err := shell.Run(context.Background()); err != nil {
 				if tt.expectExit != 0 && shell.Status() != tt.expectExit {
 					t.Fatalf("unexpected exit status for %s: got %d instead of %d", tt.name, shell.Status(), tt.expectExit)
 				} else if tt.expectExit == 0 {
@@ -312,7 +312,7 @@ func TestEvaluateEnv(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env, err := EvaluateEnv([]byte(tt.script), tt.argv, tt.env)
+			env, err := EvaluateEnv(context.Background(), []byte(tt.script), tt.argv, tt.env)
 			if !tt.expectErr && err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			} else if tt.expectErr && err == nil {


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1013

The original PR description was:
> This PR removes the execStarter code from the CLI layer. execStarter was responsible for assembling CLI flags/options into an engine configuration, and calling the Singularity runtime's starter executable to launch the container with that configuration.
> 
> execStarter has been replaced with a Launcher struct, which is passed configuration via functional options, and implements an Exec function that performs container launch.
>
> The intention of this PR is to remove the direct coupling of CLI and starter launch, so that next we can add a second OCI runtime launch method, with the CLI calling either the Singularity starter, or the OCI launch as appropriate.
>
> The functional options / Launcher configuration are currently a naive translation of the previous direct use of CLI flag variables in execStarter. The launch package is currently in internal/pkg. The intention is that the interface will develop as the OCI launch functionality is written. Eventually there will be a stable interface for container launch, which can be exposed in pkg, to allow code other than the Singularity CLI to call it to launch containers.
>
> Additionally, the PR makes the action flag variables private, and passes down a context into shell evaluation functions, where the other changes triggered a linter rule indicating this should be done.