### PR TITLE
launcher: refactor and add OCI placeholder launcher, from sylabs 1039

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -24,7 +24,8 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/client/oci"
 	"github.com/apptainer/apptainer/internal/pkg/client/oras"
 	"github.com/apptainer/apptainer/internal/pkg/client/shub"
-	"github.com/apptainer/apptainer/internal/pkg/runtime/launch"
+	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
+	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher/native"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/uri"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -275,7 +276,7 @@ var TestCmd = &cobra.Command{
 }
 
 func launchContainer(cmd *cobra.Command, image string, args []string, instanceName string) error {
-	ns := launch.Namespaces{
+	ns := launcher.Namespaces{
 		User: userNamespace,
 		UTS:  utsNamespace,
 		PID:  pidNamespace,
@@ -293,59 +294,62 @@ func launchContainer(cmd *cobra.Command, image string, args []string, instanceNa
 		return err
 	}
 
-	opts := []launch.Option{
-		launch.OptWritable(isWritable),
-		launch.OptWritableTmpfs(isWritableTmpfs),
-		launch.OptOverlayPaths(overlayPath),
-		launch.OptScratchDirs(scratchPath),
-		launch.OptWorkDir(workdirPath),
-		launch.OptHome(
+	opts := []launcher.Option{
+		launcher.OptWritable(isWritable),
+		launcher.OptWritableTmpfs(isWritableTmpfs),
+		launcher.OptOverlayPaths(overlayPath),
+		launcher.OptScratchDirs(scratchPath),
+		launcher.OptWorkDir(workdirPath),
+		launcher.OptHome(
 			homePath,
 			cmd.Flag(actionHomeFlag.Name).Changed,
 			noHome,
 		),
-		launch.OptMounts(bindPaths, mounts, fuseMount),
-		launch.OptNoMount(noMount),
-		launch.OptNvidia(nvidia, nvCCLI),
-		launch.OptNoNvidia(noNvidia),
-		launch.OptRocm(rocm),
-		launch.OptNoRocm(noRocm),
-		launch.OptContainLibs(containLibsPath),
-		launch.OptEnv(apptainerEnv, apptainerEnvFile, isCleanEnv),
-		launch.OptNoEval(noEval),
-		launch.OptNamespaces(ns),
-		launch.OptNetwork(network, networkArgs),
-		launch.OptHostname(hostname),
-		launch.OptDNS(dns),
-		launch.OptCaps(addCaps, dropCaps),
-		launch.OptAllowSUID(allowSUID),
-		launch.OptKeepPrivs(keepPrivs),
-		launch.OptNoPrivs(noPrivs),
-		launch.OptSecurity(security),
-		launch.OptNoUmask(noUmask),
-		launch.OptCgroupsJSON(cgJSON),
-		launch.OptConfigFile(configurationFile),
-		launch.OptShellPath(shellPath),
-		launch.OptPwdPath(pwdPath),
-		launch.OptFakeroot(isFakeroot),
-		launch.OptBoot(isBoot),
-		launch.OptNoInit(noInit),
-		launch.OptContain(isContained),
-		launch.OptContainAll(isContainAll),
-		launch.OptAppName(appName),
-		launch.OptKeyInfo(ki),
-		launch.OptCacheDisabled(disableCache),
-		launch.OptDMTCPLaunch(dmtcpLaunch),
-		launch.OptDMTCPRestart(dmtcpRestart),
-		launch.OptUnsquash(unsquash),
-		launch.OptIgnoreSubuid(ignoreSubuid),
-		launch.OptIgnoreFakerootCmd(ignoreFakerootCmd),
-		launch.OptIgnoreUserns(ignoreUserns),
-		launch.OptUseBuildConfig(useBuildConfig),
-		launch.OptTmpDir(tmpDir),
+		launcher.OptMounts(bindPaths, mounts, fuseMount),
+		launcher.OptNoMount(noMount),
+		launcher.OptNvidia(nvidia, nvCCLI),
+		launcher.OptNoNvidia(noNvidia),
+		launcher.OptRocm(rocm),
+		launcher.OptNoRocm(noRocm),
+		launcher.OptContainLibs(containLibsPath),
+		launcher.OptEnv(apptainerEnv, apptainerEnvFile, isCleanEnv),
+		launcher.OptNoEval(noEval),
+		launcher.OptNamespaces(ns),
+		launcher.OptNetwork(network, networkArgs),
+		launcher.OptHostname(hostname),
+		launcher.OptDNS(dns),
+		launcher.OptCaps(addCaps, dropCaps),
+		launcher.OptAllowSUID(allowSUID),
+		launcher.OptKeepPrivs(keepPrivs),
+		launcher.OptNoPrivs(noPrivs),
+		launcher.OptSecurity(security),
+		launcher.OptNoUmask(noUmask),
+		launcher.OptCgroupsJSON(cgJSON),
+		launcher.OptConfigFile(configurationFile),
+		launcher.OptShellPath(shellPath),
+		launcher.OptPwdPath(pwdPath),
+		launcher.OptFakeroot(isFakeroot),
+		launcher.OptBoot(isBoot),
+		launcher.OptNoInit(noInit),
+		launcher.OptContain(isContained),
+		launcher.OptContainAll(isContainAll),
+		launcher.OptAppName(appName),
+		launcher.OptKeyInfo(ki),
+		launcher.OptCacheDisabled(disableCache),
+		launcher.OptDMTCPLaunch(dmtcpLaunch),
+		launcher.OptDMTCPRestart(dmtcpRestart),
+		launcher.OptUnsquash(unsquash),
+		launcher.OptIgnoreSubuid(ignoreSubuid),
+		launcher.OptIgnoreFakerootCmd(ignoreFakerootCmd),
+		launcher.OptIgnoreUserns(ignoreUserns),
+		launcher.OptUseBuildConfig(useBuildConfig),
+		launcher.OptTmpDir(tmpDir),
 	}
 
-	l, err := launch.NewLauncher(opts...)
+	// Explicitly use the interface type here, as we will add alternative launchers later...
+	var l launcher.Launcher
+
+	l, err = native.NewLauncher(opts...)
 	if err != nil {
 		return fmt.Errorf("while configuring container: %s", err)
 	}

--- a/internal/pkg/runtime/launcher/launcher.go
+++ b/internal/pkg/runtime/launcher/launcher.go
@@ -1,0 +1,33 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// Package launcher is responsible for implementing launchers, which can start a
+// container, with configuration passed from the CLI layer.
+//
+// The package currently implements a single native.Launcher, with an Exec
+// method that constructs a runtime configuration and calls the Apptainer
+// runtime starter binary to start the container.
+//
+// TODO - the launcher package will be extended to support launching containers
+// via the OCI runc/crun runtime, in addition to the current Apptainer runtime
+// starter, by adding an oci.Launcher.
+package launcher
+
+import "context"
+
+// Launcher is responsible for configuring and launching a container image.
+// It will execute a runtime, such as Apptainer's native runtime (via the starter
+// binary), or an external OCI runtime (e.g. runc).
+type Launcher interface {
+	// Exec will execute the container image 'image', passing arguments 'args'
+	// the container#s initial process. If instanceName is specified, the
+	// container must be launched as a background instance, otherwist it must
+	// run interactively, attached to the console.
+	Exec(ctx context.Context, image string, args []string, instanceName string) error
+}

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -7,7 +7,9 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package launch
+// Package native implements a Launcher that will configure and launch a
+// container with Apptainer's own (native) runtime.
+package native
 
 import (
 	"context"
@@ -31,6 +33,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/plugin"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
+	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
 	"github.com/apptainer/apptainer/internal/pkg/security"
 	"github.com/apptainer/apptainer/internal/pkg/util/bin"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
@@ -49,14 +52,24 @@ import (
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
 	"github.com/apptainer/apptainer/pkg/util/capabilities"
 	"github.com/apptainer/apptainer/pkg/util/cryptkey"
-	"github.com/apptainer/apptainer/pkg/util/fs/proc"
 	"github.com/apptainer/apptainer/pkg/util/namespaces"
 	"github.com/apptainer/apptainer/pkg/util/rlimit"
 	"golang.org/x/sys/unix"
 )
 
-func NewLauncher(opts ...Option) (*Launcher, error) {
-	lo := launchOptions{}
+// Launcher will holds configuration for, and will launch a container using
+// Apptainer's own (native) runtime.
+type Launcher struct {
+	uid          uint32
+	gid          uint32
+	cfg          launcher.Options
+	engineConfig *apptainerConfig.EngineConfig
+	generator    *generate.Generator
+}
+
+// NewLauncher returns a native.Launcher with an initial configuration set by opts.
+func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
+	lo := launcher.Options{}
 	for _, opt := range opts {
 		if err := opt(&lo); err != nil {
 			return nil, fmt.Errorf("%w", err)
@@ -268,7 +281,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 	l.engineConfig.SetUseBuildConfig(l.cfg.UseBuildConfig)
 
 	// When running as root, the user can optionally allow setuid with container.
-	err = withPrivilege(l.uid, l.cfg.AllowSUID, "--allow-setuid", func() error {
+	err = launcher.WithPrivilege(l.uid, l.cfg.AllowSUID, "--allow-setuid", func() error {
 		l.engineConfig.SetAllowSUID(l.cfg.AllowSUID)
 		return nil
 	})
@@ -277,7 +290,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 	}
 
 	// When running as root, the user can optionally keep all privs in the container.
-	err = withPrivilege(l.uid, l.cfg.KeepPrivs, "--keep-privs", func() error {
+	err = launcher.WithPrivilege(l.uid, l.cfg.KeepPrivs, "--keep-privs", func() error {
 		l.engineConfig.SetKeepPrivs(l.cfg.KeepPrivs)
 		return nil
 	})
@@ -315,7 +328,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 	l.engineConfig.SetCgroupsJSON(l.cfg.CGroupsJSON)
 
 	// --boot flag requires privilege, so check for this.
-	err = withPrivilege(l.uid, l.cfg.Boot, "--boot", func() error { return nil })
+	err = launcher.WithPrivilege(l.uid, l.cfg.Boot, "--boot", func() error { return nil })
 	if err != nil {
 		sylog.Fatalf("Could not configure --boot: %s", err)
 	}
@@ -337,7 +350,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 		l.engineConfig.SetInstance(true)
 		l.engineConfig.SetBootInstance(l.cfg.Boot)
 
-		if useSuid && !l.cfg.Namespaces.User && hidepidProc() {
+		if useSuid && !l.cfg.Namespaces.User && launcher.HidepidProc() {
 			return fmt.Errorf("hidepid option set on /proc mount, require 'hidepid=0' to start instance with setuid workflow")
 		}
 
@@ -426,7 +439,7 @@ func (l *Launcher) setTargetIDs() (err error) {
 	targetGID := make([]int, 0)
 
 	// If a target uid was requested, and we are root, handle that.
-	err = withPrivilege(l.uid, uidParam != "", "uid security feature", func() error {
+	err = launcher.WithPrivilege(l.uid, uidParam != "", "uid security feature", func() error {
 		u, err := strconv.ParseUint(uidParam, 10, 32)
 		if err != nil {
 			return fmt.Errorf("failed to parse provided UID: %w", err)
@@ -442,7 +455,7 @@ func (l *Launcher) setTargetIDs() (err error) {
 	}
 
 	// If any target gids were requested, and we are root, handle that.
-	err = withPrivilege(l.uid, gidParam != "", "gid security feature", func() error {
+	err = launcher.WithPrivilege(l.uid, gidParam != "", "gid security feature", func() error {
 		gids := strings.Split(gidParam, ":")
 		for _, id := range gids {
 			g, err := strconv.ParseUint(id, 10, 32)
@@ -1147,38 +1160,6 @@ func runPluginCallbacks(cfg *config.Common) error {
 		c.(clicallback.ApptainerEngineConfig)(cfg)
 	}
 	return nil
-}
-
-// withPrivilege calls fn if cond is satisfied, and we are uid 0
-func withPrivilege(uid uint32, cond bool, desc string, fn func() error) error {
-	if !cond {
-		return nil
-	}
-	if uid != 0 {
-		return fmt.Errorf("%s requires root privileges", desc)
-	}
-	return fn()
-}
-
-// hidepidProc checks if hidepid is set on /proc mount point, when this
-// option is an instance started with setuid workflow could not even be
-// joined later or stopped correctly.
-func hidepidProc() bool {
-	entries, err := proc.GetMountInfoEntry("/proc/self/mountinfo")
-	if err != nil {
-		sylog.Warningf("while reading /proc/self/mountinfo: %s", err)
-		return false
-	}
-	for _, e := range entries {
-		if e.Point == "/proc" {
-			for _, o := range e.SuperOptions {
-				if strings.HasPrefix(o, "hidepid=") {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }
 
 // convertImage extracts the image found at filename to directory dir within a temporary directory

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -1,0 +1,234 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// Package oci implements a Launcher that will configure and launch a container
+// with an OCI runtime.
+package oci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
+)
+
+var (
+	ErrUnsupportedOption = errors.New("not supported by OCI launcher")
+	ErrNotImplemented    = errors.New("not implemented")
+)
+
+// Launcher will holds configuration for, and will launch a container using an
+// OCI runtime.
+type Launcher struct {
+	cfg launcher.Options
+}
+
+// NewLauncher returns a oci.Launcher with an initial configuration set by opts.
+func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
+	lo := launcher.Options{}
+	for _, opt := range opts {
+		if err := opt(&lo); err != nil {
+			return nil, fmt.Errorf("%w", err)
+		}
+	}
+
+	if err := checkOpts(lo); err != nil {
+		return nil, err
+	}
+	return &Launcher{lo}, nil
+}
+
+// checkOpts ensures that options set are supported by the oci.Launcher.
+//
+// nolint:maintidx
+func checkOpts(lo launcher.Options) error {
+	badOpt := []string{}
+
+	if lo.Writable {
+		badOpt = append(badOpt, "Writable")
+	}
+	if lo.WritableTmpfs {
+		badOpt = append(badOpt, "WritableTmpfs")
+	}
+	if lo.OverlayPaths != nil {
+		badOpt = append(badOpt, "OverlayPaths")
+	}
+	if lo.ScratchDirs != nil {
+		badOpt = append(badOpt, "ScratchDirs")
+	}
+	if lo.WorkDir != "" {
+		badOpt = append(badOpt, "WorkDir")
+	}
+
+	// Home is always sent from the CLI, and must be valid as an option, but
+	// CustomHome signifies if it was a user specified value which we don't
+	// support (yet).
+	if lo.CustomHome {
+		badOpt = append(badOpt, "CustomHome")
+	}
+	if lo.NoHome {
+		badOpt = append(badOpt, "NoHome")
+	}
+
+	if lo.BindPaths != nil {
+		badOpt = append(badOpt, "BindPaths")
+	}
+	if lo.FuseMount != nil {
+		badOpt = append(badOpt, "FuseMount")
+	}
+	if lo.Mounts != nil {
+		badOpt = append(badOpt, "Mounts")
+	}
+	if lo.NoMount != nil {
+		badOpt = append(badOpt, "NoMount")
+	}
+
+	if lo.Nvidia {
+		badOpt = append(badOpt, "Nvidia")
+	}
+	if lo.NvCCLI {
+		badOpt = append(badOpt, "NvCCLI")
+	}
+	if lo.NoNvidia {
+		badOpt = append(badOpt, "NoNvidia")
+	}
+	if lo.Rocm {
+		badOpt = append(badOpt, "Rocm")
+	}
+	if lo.NoRocm {
+		badOpt = append(badOpt, "NoRocm")
+	}
+
+	if lo.ContainLibs != nil {
+		badOpt = append(badOpt, "ContainLibs")
+	}
+
+	if lo.Env != nil {
+		badOpt = append(badOpt, "Env")
+	}
+	if lo.EnvFile != "" {
+		badOpt = append(badOpt, "EnvFile")
+	}
+	if lo.CleanEnv {
+		badOpt = append(badOpt, "CleanEnv")
+	}
+	if lo.NoEval {
+		badOpt = append(badOpt, "NoEval")
+	}
+
+	if lo.Namespaces.IPC {
+		badOpt = append(badOpt, "Namespaces.IPC")
+	}
+	if lo.Namespaces.Net {
+		badOpt = append(badOpt, "Namespaces.Net")
+	}
+	if lo.Namespaces.PID {
+		badOpt = append(badOpt, "Namespaces.PID")
+	}
+	if lo.Namespaces.UTS {
+		badOpt = append(badOpt, "Namespaces.UTS")
+	}
+	if lo.Namespaces.User {
+		badOpt = append(badOpt, "Namespaces.User")
+	}
+
+	if lo.Network != "" {
+		badOpt = append(badOpt, "Network")
+	}
+	if lo.NetworkArgs != nil {
+		badOpt = append(badOpt, "NetworkArgs")
+	}
+	if lo.Hostname != "" {
+		badOpt = append(badOpt, "Hostname")
+	}
+	if lo.DNS != "" {
+		badOpt = append(badOpt, "DNS")
+	}
+
+	if lo.AddCaps != "" {
+		badOpt = append(badOpt, "AddCaps")
+	}
+	if lo.DropCaps != "" {
+		badOpt = append(badOpt, "DropCaps")
+	}
+	if lo.AllowSUID {
+		badOpt = append(badOpt, "AllowSUID")
+	}
+	if lo.KeepPrivs {
+		badOpt = append(badOpt, "KeepPrivs")
+	}
+	if lo.NoPrivs {
+		badOpt = append(badOpt, "NoPrivs")
+	}
+	if lo.SecurityOpts != nil {
+		badOpt = append(badOpt, "SecurityOpts")
+	}
+	if lo.NoUmask {
+		badOpt = append(badOpt, "NoUmask")
+	}
+
+	if lo.CGroupsJSON != "" {
+		badOpt = append(badOpt, "CGroupsJSON")
+	}
+
+	if lo.ConfigFile != "" {
+		badOpt = append(badOpt, "ConfigFile")
+	}
+
+	if lo.ShellPath != "" {
+		badOpt = append(badOpt, "ShellPath")
+	}
+	if lo.PwdPath != "" {
+		badOpt = append(badOpt, "PwdPath")
+	}
+
+	if lo.Fakeroot {
+		badOpt = append(badOpt, "Fakeroot")
+	}
+	if lo.Boot {
+		badOpt = append(badOpt, "Boot")
+	}
+	if lo.NoInit {
+		badOpt = append(badOpt, "NoInit")
+	}
+	if lo.Contain {
+		badOpt = append(badOpt, "Contain")
+	}
+	if lo.ContainAll {
+		badOpt = append(badOpt, "ContainAll")
+	}
+
+	if lo.AppName != "" {
+		badOpt = append(badOpt, "AppName")
+	}
+
+	if lo.KeyInfo != nil {
+		badOpt = append(badOpt, "KeyInfo")
+	}
+
+	if lo.SIFFUSE {
+		badOpt = append(badOpt, "SIFFUSE")
+	}
+	if lo.CacheDisabled {
+		badOpt = append(badOpt, "CacheDisabled")
+	}
+
+	if len(badOpt) > 0 {
+		return fmt.Errorf("%w: %s", ErrUnsupportedOption, strings.Join(badOpt, ","))
+	}
+
+	return nil
+}
+
+// Exec is not yet implemented.
+func (l *Launcher) Exec(ctx context.Context, image string, args []string, instanceName string) error {
+	return ErrNotImplemented
+}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
+)
+
+func TestNewLauncher(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []launcher.Option
+		want    *Launcher
+		wantErr bool
+	}{
+		{
+			name:    "default",
+			want:    &Launcher{},
+			wantErr: false,
+		},
+		{
+			name: "validOption",
+			opts: []launcher.Option{
+				launcher.OptHome("/home/test", false, false),
+			},
+			want: &Launcher{cfg: launcher.Options{HomeDir: "/home/test"}},
+		},
+		{
+			name: "unsupportedOption",
+			opts: []launcher.Option{
+				launcher.OptCacheDisabled(true),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewLauncher(tt.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewLauncher() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewLauncher() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExec(t *testing.T) {
+	l, err := NewLauncher([]launcher.Option{}...)
+	if err != nil {
+		t.Errorf("Couldn't initialize launcher: %s", err)
+	}
+
+	if err := l.Exec(context.Background(), "", []string{}, ""); err != ErrNotImplemented {
+		t.Errorf("Expected %v, got %v", ErrNotImplemented, err)
+	}
+}

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -7,28 +7,25 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-// Package launcher is responsible for starting a container, with configuration
-// passed to it from the CLI layer.
-//
-// The package currently implements a single Launcher, with an Exec method that
-// constructs a runtime configuration and calls the Apptainer runtime starter
-// binary to start the container.
-//
-// TODO - the launcher package will be extended to support launching containers
-// via the OCI runc/crun runtime, in addition to the current Apptainer runtime
-// starter.
-package launch
+package launcher
 
 import (
-	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
-	apptainerConfig "github.com/apptainer/apptainer/pkg/runtime/engine/apptainer/config"
 	"github.com/apptainer/apptainer/pkg/util/cryptkey"
 )
 
-// launchOptions accumulates configuration from passed functional options. Note
-// that the launchOptions is modified heavily by logic during the Exec function
-// call.
-type launchOptions struct {
+// Namespaces holds flags for the optional (non-mount) namespaces that can be
+// requested for a container launch.
+type Namespaces struct {
+	User bool
+	UTS  bool
+	PID  bool
+	IPC  bool
+	Net  bool
+}
+
+// Options accumulates launch configuration from passed functional options. Note
+// that the Options is modified heavily by logic during the Exec function call.
+type Options struct {
 	// Writable marks the container image itself as writable.
 	Writable bool
 	// WriteableTmpfs applies an ephemeral writable overlay to the container.
@@ -152,29 +149,11 @@ type launchOptions struct {
 	TmpDir            string
 }
 
-type Launcher struct {
-	uid          uint32
-	gid          uint32
-	cfg          launchOptions
-	engineConfig *apptainerConfig.EngineConfig
-	generator    *generate.Generator
-}
-
-// Namespaces holds flags for the optional (non-mount) namespaces that can be
-// requested for a container launch.
-type Namespaces struct {
-	User bool
-	UTS  bool
-	PID  bool
-	IPC  bool
-	Net  bool
-}
-
-type Option func(co *launchOptions) error
+type Option func(co *Options) error
 
 // OptWritable sets the container image to be writable.
 func OptWritable(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.Writable = b
 		return nil
 	}
@@ -182,7 +161,7 @@ func OptWritable(b bool) Option {
 
 // OptWritableTmpFs applies an ephemeral writable overlay to the container.
 func OptWritableTmpfs(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.WritableTmpfs = b
 		return nil
 	}
@@ -190,7 +169,7 @@ func OptWritableTmpfs(b bool) Option {
 
 // OptOverlayPaths sets overlay images and directories to apply to the container.
 func OptOverlayPaths(op []string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.OverlayPaths = op
 		return nil
 	}
@@ -198,7 +177,7 @@ func OptOverlayPaths(op []string) Option {
 
 // OptScratchDirs sets temporary host directories to create and bind into the container.
 func OptScratchDirs(sd []string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.ScratchDirs = sd
 		return nil
 	}
@@ -206,7 +185,7 @@ func OptScratchDirs(sd []string) Option {
 
 // OptWorkDir sets the parent path for scratch directories, and contained home/tmp on the host.
 func OptWorkDir(wd string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.WorkDir = wd
 		return nil
 	}
@@ -218,7 +197,7 @@ func OptWorkDir(wd string) Option {
 // custom is a marker that this is user supplied, and must not be overridden.
 // disable will disable the home mount entirely, ignoring other options.
 func OptHome(homeDir string, custom bool, disable bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.HomeDir = homeDir
 		lo.CustomHome = custom
 		lo.NoHome = disable
@@ -232,7 +211,7 @@ func OptHome(homeDir string, custom bool, disable bool) Option {
 // mounts lists bind mount specifications in Docker CSV processed format.
 // fuseMounts list FUSE mounts in <type>:<fuse command> <mountpoint> format.
 func OptMounts(binds []string, mounts []string, fuseMounts []string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.BindPaths = binds
 		lo.Mounts = mounts
 		lo.FuseMount = fuseMounts
@@ -242,7 +221,7 @@ func OptMounts(binds []string, mounts []string, fuseMounts []string) Option {
 
 // OptNoMount disables the specified bind mounts.
 func OptNoMount(nm []string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.NoMount = nm
 		return nil
 	}
@@ -252,7 +231,7 @@ func OptNoMount(nm []string) Option {
 //
 // nvccli sets whether to use the nvidia-container-runtime (true), or legacy bind mounts (false).
 func OptNvidia(nv bool, nvccli bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.Nvidia = nv || nvccli
 		lo.NvCCLI = nvccli
 		return nil
@@ -261,7 +240,7 @@ func OptNvidia(nv bool, nvccli bool) Option {
 
 // OptNoNvidia disables NVIDIA GPU support, even if enabled via apptainer.conf.
 func OptNoNvidia(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.NoNvidia = b
 		return nil
 	}
@@ -269,7 +248,7 @@ func OptNoNvidia(b bool) Option {
 
 // OptRocm enable Rocm GPU support.
 func OptRocm(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.Rocm = b
 		return nil
 	}
@@ -277,7 +256,7 @@ func OptRocm(b bool) Option {
 
 // OptNoRocm disables Rocm GPU support, even if enabled via apptainer.conf.
 func OptNoRocm(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.NoRocm = b
 		return nil
 	}
@@ -285,7 +264,7 @@ func OptNoRocm(b bool) Option {
 
 // OptContainLibs mounts specified libraries into the container .singularity.d/libs dir.
 func OptContainLibs(cl []string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.ContainLibs = cl
 		return nil
 	}
@@ -297,7 +276,7 @@ func OptContainLibs(cl []string) Option {
 // env is a map of name=value env vars to set.
 // clean removes host variables from the container environment.
 func OptEnv(env map[string]string, envFile string, clean bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.Env = env
 		lo.EnvFile = envFile
 		lo.CleanEnv = clean
@@ -307,7 +286,7 @@ func OptEnv(env map[string]string, envFile string, clean bool) Option {
 
 // OptNoEval disables shell evaluation of args and env vars.
 func OptNoEval(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.NoEval = b
 		return nil
 	}
@@ -315,7 +294,7 @@ func OptNoEval(b bool) Option {
 
 // OptNamespaces enable the individual kernel-support namespaces for the container.
 func OptNamespaces(n Namespaces) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.Namespaces = n
 		return nil
 	}
@@ -326,7 +305,7 @@ func OptNamespaces(n Namespaces) Option {
 // network is the name of the CNI configuration to enable.
 // args are arguments to pass to the CNI plugin.
 func OptNetwork(network string, args []string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.Network = network
 		lo.NetworkArgs = args
 		return nil
@@ -335,7 +314,7 @@ func OptNetwork(network string, args []string) Option {
 
 // OptHostname sets a hostname for the container (infers/requires UTS namespace).
 func OptHostname(h string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.Hostname = h
 		return nil
 	}
@@ -343,7 +322,7 @@ func OptHostname(h string) Option {
 
 // OptDNS sets a DNS entry for the container resolv.conf.
 func OptDNS(d string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.DNS = d
 		return nil
 	}
@@ -351,7 +330,7 @@ func OptDNS(d string) Option {
 
 // OptCaps sets capabilities to add and drop.
 func OptCaps(add, drop string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.AddCaps = add
 		lo.DropCaps = drop
 		return nil
@@ -360,7 +339,7 @@ func OptCaps(add, drop string) Option {
 
 // OptAllowSUID permits setuid executables inside a container started by the root user.
 func OptAllowSUID(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.AllowSUID = b
 		return nil
 	}
@@ -368,7 +347,7 @@ func OptAllowSUID(b bool) Option {
 
 // OptKeepPrivs keeps all privileges inside a container started by the root user.
 func OptKeepPrivs(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.KeepPrivs = b
 		return nil
 	}
@@ -376,7 +355,7 @@ func OptKeepPrivs(b bool) Option {
 
 // OptNoPrivs drops all privileges inside a container.
 func OptNoPrivs(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.NoPrivs = b
 		return nil
 	}
@@ -384,7 +363,7 @@ func OptNoPrivs(b bool) Option {
 
 // OptSecurity supplies a list of security options (selinux, apparmor, seccomp) to apply.
 func OptSecurity(s []string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.SecurityOpts = s
 		return nil
 	}
@@ -392,7 +371,7 @@ func OptSecurity(s []string) Option {
 
 // OptNoUmask disables propagation of the host umask into the container, using a default 0022.
 func OptNoUmask(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.NoUmask = b
 		return nil
 	}
@@ -400,7 +379,7 @@ func OptNoUmask(b bool) Option {
 
 // OptCgroupsJSON sets a Cgroups resource limit configuration to apply to the container.
 func OptCgroupsJSON(cj string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.CGroupsJSON = cj
 		return nil
 	}
@@ -408,7 +387,7 @@ func OptCgroupsJSON(cj string) Option {
 
 // OptConfigFile specifies an alternate apptainer.conf that will be used by unprivileged installations only.
 func OptConfigFile(c string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.ConfigFile = c
 		return nil
 	}
@@ -416,7 +395,7 @@ func OptConfigFile(c string) Option {
 
 // OptShellPath specifies a custom shell executable to be launched in the container.
 func OptShellPath(s string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.ShellPath = s
 		return nil
 	}
@@ -424,7 +403,7 @@ func OptShellPath(s string) Option {
 
 // OptPwdPath specifies the initial working directory in the container.
 func OptPwdPath(p string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.PwdPath = p
 		return nil
 	}
@@ -432,7 +411,7 @@ func OptPwdPath(p string) Option {
 
 // OptFakeroot enables the fake root mode, using user namespaces and subuid / subgid mapping.
 func OptFakeroot(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.Fakeroot = b
 		return nil
 	}
@@ -440,7 +419,7 @@ func OptFakeroot(b bool) Option {
 
 // OptBoot enables execution of /sbin/init on startup of an instance container.
 func OptBoot(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.Boot = b
 		return nil
 	}
@@ -448,7 +427,7 @@ func OptBoot(b bool) Option {
 
 // OptNoInit disables shim process when PID namespace is used.
 func OptNoInit(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.NoInit = b
 		return nil
 	}
@@ -456,7 +435,7 @@ func OptNoInit(b bool) Option {
 
 // OptContain starts the container with minimal /dev and empty home/tmp mounts.
 func OptContain(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.Contain = b
 		return nil
 	}
@@ -464,7 +443,7 @@ func OptContain(b bool) Option {
 
 // OptContainAll infers Contain, and adds PID, IPC namespaces, and CleanEnv.
 func OptContainAll(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.ContainAll = b
 		return nil
 	}
@@ -472,7 +451,7 @@ func OptContainAll(b bool) Option {
 
 // OptAppName sets a SCIF application name to run.
 func OptAppName(a string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.AppName = a
 		return nil
 	}
@@ -480,7 +459,7 @@ func OptAppName(a string) Option {
 
 // OptKeyInfo sets encryption key material to use when accessing an encrypted container image.
 func OptKeyInfo(ki *cryptkey.KeyInfo) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.KeyInfo = ki
 		return nil
 	}
@@ -488,7 +467,7 @@ func OptKeyInfo(ki *cryptkey.KeyInfo) Option {
 
 // CacheDisabled indicates caching of images was disabled in the CLI.
 func OptCacheDisabled(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.CacheDisabled = b
 		return nil
 	}
@@ -496,7 +475,7 @@ func OptCacheDisabled(b bool) Option {
 
 // OptDMTCPLaunch
 func OptDMTCPLaunch(a string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.DMTCPLaunch = a
 		return nil
 	}
@@ -504,7 +483,7 @@ func OptDMTCPLaunch(a string) Option {
 
 // OptDMTCPRestart
 func OptDMTCPRestart(a string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.DMTCPRestart = a
 		return nil
 	}
@@ -512,7 +491,7 @@ func OptDMTCPRestart(a string) Option {
 
 // OptUnsquash
 func OptUnsquash(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.Unsquash = b
 		return nil
 	}
@@ -520,7 +499,7 @@ func OptUnsquash(b bool) Option {
 
 // OptIgnoreSubuid
 func OptIgnoreSubuid(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.IgnoreSubuid = b
 		return nil
 	}
@@ -528,7 +507,7 @@ func OptIgnoreSubuid(b bool) Option {
 
 // OptIgnoreFakerootCmd
 func OptIgnoreFakerootCmd(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.IgnoreFakerootCmd = b
 		return nil
 	}
@@ -536,7 +515,7 @@ func OptIgnoreFakerootCmd(b bool) Option {
 
 // OptIgnoreUserns
 func OptIgnoreUserns(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.IgnoreUserns = b
 		return nil
 	}
@@ -544,7 +523,7 @@ func OptIgnoreUserns(b bool) Option {
 
 // OptUseBuildConfig
 func OptUseBuildConfig(b bool) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.UseBuildConfig = b
 		return nil
 	}
@@ -552,7 +531,7 @@ func OptUseBuildConfig(b bool) Option {
 
 // OptTmpDir
 func OptTmpDir(a string) Option {
-	return func(lo *launchOptions) error {
+	return func(lo *Options) error {
 		lo.TmpDir = a
 		return nil
 	}

--- a/internal/pkg/runtime/launcher/util.go
+++ b/internal/pkg/runtime/launcher/util.go
@@ -1,0 +1,50 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package launcher
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/apptainer/apptainer/pkg/util/fs/proc"
+)
+
+// WithPrivilege calls fn if cond is satisfied, and we are uid 0
+func WithPrivilege(uid uint32, cond bool, desc string, fn func() error) error {
+	if !cond {
+		return nil
+	}
+	if uid != 0 {
+		return fmt.Errorf("%s requires root privileges", desc)
+	}
+	return fn()
+}
+
+// HidepidProc checks if hidepid is set on the /proc mount point.
+//
+// If this is set then an instance started in the with setuid workflow cannot be
+func HidepidProc() bool {
+	entries, err := proc.GetMountInfoEntry("/proc/self/mountinfo")
+	if err != nil {
+		sylog.Warningf("while reading /proc/self/mountinfo: %s", err)
+		return false
+	}
+	for _, e := range entries {
+		if e.Point == "/proc" {
+			for _, o := range e.SuperOptions {
+				if strings.HasPrefix(o, "hidepid=") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1039
 which fixed
- sylabs/singularity# 1021

The original PR description was:
> Refactor the existing code so that:
> 
> * The internal/pkg/runtime/launcher package contains common option handling, utility functions, and a Launcher interface.
> 
> * There is a launcher.native package containing the existing launch code for the native singularity runtime.
> 
> 
> Add placeholder OCI launcher
> 
> * Accepts no options, fails if options provided.
> 
> * Implements an Exec method which does nothing.