### PR TITLE
actions: Add --oci flag to call OCI launcher, from sylabs 1042

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -93,6 +93,8 @@ var (
 	ignoreSubuid      bool
 	ignoreFakerootCmd bool
 	ignoreUserns      bool
+
+	ociRuntime bool
 )
 
 // --app
@@ -850,6 +852,16 @@ var actionIgnoreUsernsFlag = cmdline.Flag{
 	Hidden:       true,
 }
 
+// --oci
+var actionOCIFlag = cmdline.Flag{
+	ID:           "actionOCI",
+	Value:        &ociRuntime,
+	DefaultValue: false,
+	Name:         "oci",
+	Usage:        "Launch container with OCI runtime (experimental)",
+	EnvKeys:      []string{"OCI"},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -945,5 +957,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionIgnoreSubuidFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionIgnoreFakerootCommand, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionIgnoreUsernsFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionOCIFlag, actionsCmd...)
 	})
 }

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/client/shub"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher/native"
+	ocilauncher "github.com/apptainer/apptainer/internal/pkg/runtime/launcher/oci"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/uri"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -346,12 +347,20 @@ func launchContainer(cmd *cobra.Command, image string, args []string, instanceNa
 		launcher.OptTmpDir(tmpDir),
 	}
 
-	// Explicitly use the interface type here, as we will add alternative launchers later...
 	var l launcher.Launcher
 
-	l, err = native.NewLauncher(opts...)
-	if err != nil {
-		return fmt.Errorf("while configuring container: %s", err)
+	if ociRuntime {
+		sylog.Debugf("Using OCI runtime launcher.")
+		l, err = ocilauncher.NewLauncher(opts...)
+		if err != nil {
+			return fmt.Errorf("while configuring container: %s", err)
+		}
+	} else {
+		sylog.Debugf("Using native runtime launcher.")
+		l, err = native.NewLauncher(opts...)
+		if err != nil {
+			return fmt.Errorf("while configuring container: %s", err)
+		}
 	}
 
 	return l.Exec(cmd.Context(), image, args, instanceName)

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -917,7 +917,7 @@ func (c actionTests) actionBasicProfiles(t *testing.T) {
 		},
 	}
 
-	for _, profile := range e2e.Profiles {
+	for _, profile := range e2e.NativeProfiles {
 		profile := profile
 
 		t.Run(profile.String(), func(t *testing.T) {
@@ -1551,7 +1551,7 @@ func (c actionTests) actionBinds(t *testing.T) {
 		},
 	}
 
-	for _, profile := range e2e.Profiles {
+	for _, profile := range e2e.NativeProfiles {
 		profile := profile
 		createWorkspaceDirs(t)
 
@@ -2504,6 +2504,24 @@ func (c actionTests) actionFakerootHome(t *testing.T) {
 	}
 }
 
+func (c actionTests) ociRuntime(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	for _, p := range []e2e.Profile{e2e.OCIUserProfile, e2e.OCIRootProfile} {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(p.String()),
+			e2e.WithProfile(p),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(c.env.ImagePath, "/bin/true"),
+			e2e.ExpectExit(
+				255,
+				e2e.ExpectError(e2e.ContainMatch, "not implemented"),
+			),
+		)
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := actionTests{
@@ -2549,6 +2567,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"unsquash":                  c.actionUnsquash,          // test --unsquash
 		"no-mount":                  c.actionNoMount,           // test --no-mount
 		"compat":                    c.actionCompat,            // test --compat
+		"ociRuntime":                c.ociRuntime,              // test --oci (unimplemented)
 		"invalidRemote":             np(c.invalidRemote),       // GHSA-5mv9-q7fq-9394
 		"fakeroot home":             c.actionFakerootHome,      // test home dir in fakeroot
 	}

--- a/e2e/internal/e2e/apptainercmd.go
+++ b/e2e/internal/e2e/apptainercmd.go
@@ -496,8 +496,8 @@ func (env TestEnv) RunApptainer(t *testing.T, cmdOps ...ApptainerCmdOp) {
 	// a profile is required
 	if s.profile.name == "" {
 		i := 0
-		availableProfiles := make([]string, len(Profiles))
-		for profile := range Profiles {
+		availableProfiles := make([]string, len(NativeProfiles))
+		for profile := range NativeProfiles {
 			availableProfiles[i] = profile
 			i++
 		}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -17,12 +17,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
 )
 
 var (
 	ErrUnsupportedOption = errors.New("not supported by OCI launcher")
-	ErrNotImplemented    = errors.New("not implemented")
+	ErrNotImplemented    = errors.New("not implemented by OCI launcher")
 )
 
 // Launcher will holds configuration for, and will launch a container using an
@@ -58,10 +59,10 @@ func checkOpts(lo launcher.Options) error {
 	if lo.WritableTmpfs {
 		badOpt = append(badOpt, "WritableTmpfs")
 	}
-	if lo.OverlayPaths != nil {
+	if len(lo.OverlayPaths) > 0 {
 		badOpt = append(badOpt, "OverlayPaths")
 	}
-	if lo.ScratchDirs != nil {
+	if len(lo.ScratchDirs) > 0 {
 		badOpt = append(badOpt, "ScratchDirs")
 	}
 	if lo.WorkDir != "" {
@@ -78,16 +79,16 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "NoHome")
 	}
 
-	if lo.BindPaths != nil {
+	if len(lo.BindPaths) > 0 {
 		badOpt = append(badOpt, "BindPaths")
 	}
-	if lo.FuseMount != nil {
+	if len(lo.FuseMount) > 0 {
 		badOpt = append(badOpt, "FuseMount")
 	}
-	if lo.Mounts != nil {
+	if len(lo.Mounts) > 0 {
 		badOpt = append(badOpt, "Mounts")
 	}
-	if lo.NoMount != nil {
+	if len(lo.NoMount) > 0 {
 		badOpt = append(badOpt, "NoMount")
 	}
 
@@ -107,11 +108,11 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "NoRocm")
 	}
 
-	if lo.ContainLibs != nil {
+	if len(lo.ContainLibs) > 0 {
 		badOpt = append(badOpt, "ContainLibs")
 	}
 
-	if lo.Env != nil {
+	if len(lo.Env) > 0 {
 		badOpt = append(badOpt, "Env")
 	}
 	if lo.EnvFile != "" {
@@ -140,10 +141,12 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "Namespaces.User")
 	}
 
-	if lo.Network != "" {
+	// Network always set in CLI layer even if network namespace not requested.
+	if lo.Namespaces.Net && lo.Network != "" {
 		badOpt = append(badOpt, "Network")
 	}
-	if lo.NetworkArgs != nil {
+
+	if len(lo.NetworkArgs) > 0 {
 		badOpt = append(badOpt, "NetworkArgs")
 	}
 	if lo.Hostname != "" {
@@ -168,7 +171,7 @@ func checkOpts(lo launcher.Options) error {
 	if lo.NoPrivs {
 		badOpt = append(badOpt, "NoPrivs")
 	}
-	if lo.SecurityOpts != nil {
+	if len(lo.SecurityOpts) > 0 {
 		badOpt = append(badOpt, "SecurityOpts")
 	}
 	if lo.NoUmask {
@@ -179,7 +182,8 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "CGroupsJSON")
 	}
 
-	if lo.ConfigFile != "" {
+	// ConfigFile always set by CLI. We should support only the default from build time.
+	if lo.ConfigFile != "" && lo.ConfigFile != buildcfg.APPTAINER_CONF_FILE {
 		badOpt = append(badOpt, "ConfigFile")
 	}
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1042
 which fixed
- sylabs/singularity# 1022

The original PR description was:
> Depends on sylabs/singularity# 1021
> 
> Add an `--oci` flag to actions (run/shell/exec) that calls the (no-op) OCI launcher instead of the singularity native runtime launcher.
> 
> Fix OCI launcher supported option checks for empty structs (not just nils), and always set options.
> 
> Add E2E profiles and a test for unimplemented error on the --oci option.