### PR TITLE
e2e: always use UserProfile for ImageVerify, from sylabs 1104

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -123,7 +123,7 @@ func (c ctx) testDockerPulls(t *testing.T) {
 					if path == tmpContainerFile {
 						path = filepath.Join(tmpPath, tmpContainerFile)
 					}
-					c.env.ImageVerify(t, path, e2e.UserProfile)
+					c.env.ImageVerify(t, path)
 				}
 			}),
 			e2e.ExpectExit(tt.exit),
@@ -371,7 +371,7 @@ func (c ctx) testDockerWhiteoutSymlink(t *testing.T) {
 			if t.Failed() {
 				return
 			}
-			c.env.ImageVerify(t, imagePath, e2e.UserProfile)
+			c.env.ImageVerify(t, imagePath)
 		}),
 		e2e.ExpectExit(0),
 	)
@@ -472,7 +472,7 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 					return
 				}
 
-				c.env.ImageVerify(t, imagePath, e2e.RootProfile)
+				c.env.ImageVerify(t, imagePath)
 			}),
 			e2e.ExpectExit(0),
 		)
@@ -534,7 +534,7 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 					return
 				}
 
-				c.env.ImageVerify(t, imagePath, e2e.RootProfile)
+				c.env.ImageVerify(t, imagePath)
 			}),
 			e2e.ExpectExit(tt.exit),
 		)

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -160,7 +160,7 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 						}
 
 						defer os.RemoveAll(imagePath)
-						c.env.ImageVerify(t, imagePath, profile)
+						c.env.ImageVerify(t, imagePath)
 					}),
 					e2e.ExpectExit(0),
 				)
@@ -222,7 +222,7 @@ func (c imgBuildTests) nonRootBuild(t *testing.T) {
 			}),
 
 			e2e.PostRun(func(t *testing.T) {
-				c.env.ImageVerify(t, imagePath, e2e.UserProfile)
+				c.env.ImageVerify(t, imagePath)
 			}),
 			e2e.ExpectExit(0),
 		)
@@ -259,7 +259,7 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 		e2e.WithCommand("build"),
 		e2e.WithArgs("--sandbox", sandboxImage, c.env.ImagePath),
 		e2e.PostRun(func(t *testing.T) {
-			c.env.ImageVerify(t, sandboxImage, e2e.UserProfile)
+			c.env.ImageVerify(t, sandboxImage)
 		}),
 		e2e.ExpectExit(0),
 	)
@@ -300,7 +300,7 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 							return
 						}
 						defer os.RemoveAll(imagePath)
-						c.env.ImageVerify(t, imagePath, profile)
+						c.env.ImageVerify(t, imagePath)
 					}),
 					e2e.ExpectExit(0),
 				)

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -105,7 +105,7 @@ func (c *imgBuildTests) issue4407(t *testing.T) {
 
 				defer os.RemoveAll(imagePath)
 
-				c.env.ImageVerify(t, imagePath, e2e.RootProfile)
+				c.env.ImageVerify(t, imagePath)
 			}),
 			e2e.ExpectExit(0),
 		)

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -23,7 +23,7 @@ import (
 )
 
 // ImageVerify checks for an image integrity.
-func (env TestEnv) ImageVerify(t *testing.T, imagePath string, profile Profile) {
+func (env TestEnv) ImageVerify(t *testing.T, imagePath string) {
 	tt := []struct {
 		name string
 		argv []string
@@ -75,7 +75,7 @@ func (env TestEnv) ImageVerify(t *testing.T, imagePath string, profile Profile) 
 		env.RunApptainer(
 			t,
 			AsSubtest(tc.name),
-			WithProfile(profile),
+			WithProfile(UserProfile),
 			WithCommand("exec"),
 			WithArgs(tc.argv...),
 			ExpectExit(tc.exit),


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1104
 which fixed
- sylabs/singularity# 1103

The original PR description was:
> The e2e ImageVerify function is currently running under a passed-in profile. When the profile is userns, or fakeroot, this will require extraction of a SIF image to sandbox before inspection.
>
> Builds should always create an image that is executable by a normal user, so we can always use the UserProfile and avoid the extractions.