### PR TITLE
feat: run action for OCI bundle, from sylabs 1093

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
           go-version: 1.19.2
 
       - name: Fetch deps
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup conmon runc
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup conmon crun
 
       - name: Build and install Apptainer
         run: |
@@ -199,7 +199,7 @@ jobs:
           go-version: 1.19.2
 
       - name: Fetch deps
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup conmon runc
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup conmon crun
 
       - name: Build and install Apptainer
         run: |
@@ -244,7 +244,7 @@ jobs:
 
       - name: Fetch deps
         if: env.run_tests
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential uidmap squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup conmon runc
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential uidmap squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup conmon crun
 
       - name: Build and install Apptainer
         if: env.run_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,12 @@ jobs:
           go-version: 1.19.2
 
       - name: Fetch deps
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup conmon crun
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup conmon
+
+      - name: Install crun
+        run: |
+          sudo curl -L -o /usr/local/bin/crun https://github.com/containers/crun/releases/download/1.6/crun-1.6-linux-amd64
+          sudo chmod +x /usr/local/bin/crun
 
       - name: Build and install Apptainer
         run: |
@@ -199,7 +204,12 @@ jobs:
           go-version: 1.19.2
 
       - name: Fetch deps
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup conmon crun
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup conmon
+
+      - name: Install crun
+        run: |
+          sudo curl -L -o /usr/local/bin/crun https://github.com/containers/crun/releases/download/1.6/crun-1.6-linux-amd64
+          sudo chmod +x /usr/local/bin/crun
 
       - name: Build and install Apptainer
         run: |
@@ -244,7 +254,12 @@ jobs:
 
       - name: Fetch deps
         if: env.run_tests
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential uidmap squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup conmon crun
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential uidmap squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup conmon
+
+      - name: Install crun
+        run: |
+          sudo curl -L -o /usr/local/bin/crun https://github.com/containers/crun/releases/download/1.6/crun-1.6-linux-amd64
+          sudo chmod +x /usr/local/bin/crun
 
       - name: Build and install Apptainer
         if: env.run_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - When the kernel supports unprivileged overlay mounts in a user
   namespace, the container will be constructed using an overlay
   instead of underlay layout.
-- The `apptainer oci` command group now uses `runc` to manage containers.
+- The `apptainer oci` command group now uses `crun`, when available, or otherwise
+  `runc` to manage containers.
 - The `apptainer oci` flags `--sync-socket`, `--empty-process`, and
   `--timeout` have been removed.
 

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -187,13 +187,21 @@ var ExecCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(2),
 	PreRun:                actionPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		a := append([]string{"/.singularity.d/actions/exec"}, args[1:]...)
+		// apptainer exec <image> <command> [args...]
+		image := args[0]
+		containerCmd := "/.singularity.d/actions/exec"
+		containerArgs := args[1:]
+		// OCI runtime does not use an action script
+		if ociRuntime {
+			containerCmd = args[1]
+			containerArgs = args[2:]
+		}
 		setVM(cmd)
 		if vm {
-			execVM(cmd, args[0], a)
+			execVM(cmd, image, containerCmd, containerArgs)
 			return
 		}
-		if err := launchContainer(cmd, args[0], a, ""); err != nil {
+		if err := launchContainer(cmd, image, containerCmd, containerArgs, ""); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -211,13 +219,21 @@ var ShellCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	PreRun:                actionPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		a := []string{"/.singularity.d/actions/shell"}
+		// apptainer shell <image>
+		image := args[0]
+		containerCmd := "/.singularity.d/actions/shell"
+		containerArgs := []string{}
+		// OCI runtime does not use an action script
+		if ociRuntime {
+			// TODO - needs to have bash -> sh fallback logic implemented somewhere.
+			containerCmd = "/bin/sh"
+		}
 		setVM(cmd)
 		if vm {
-			execVM(cmd, args[0], a)
+			execVM(cmd, image, containerCmd, containerArgs)
 			return
 		}
-		if err := launchContainer(cmd, args[0], a, ""); err != nil {
+		if err := launchContainer(cmd, image, containerCmd, containerArgs, ""); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -235,13 +251,20 @@ var RunCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	PreRun:                actionPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		a := append([]string{"/.singularity.d/actions/run"}, args[1:]...)
+		// apptainer run <image> [args...]
+		image := args[0]
+		containerCmd := "/.singularity.d/actions/run"
+		containerArgs := args[1:]
+		// OCI runtime does not use an action script
+		if ociRuntime {
+			containerCmd = ""
+		}
 		setVM(cmd)
 		if vm {
-			execVM(cmd, args[0], a)
+			execVM(cmd, args[0], containerCmd, containerArgs)
 			return
 		}
-		if err := launchContainer(cmd, args[0], a, ""); err != nil {
+		if err := launchContainer(cmd, image, containerCmd, containerArgs, ""); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -259,13 +282,15 @@ var TestCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	PreRun:                actionPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
-		a := append([]string{"/.singularity.d/actions/test"}, args[1:]...)
-		setVM(cmd)
+		// apptainer test <image> [args...]
+		image := args[0]
+		containerCmd := "/.singularity.d/actions/test"
+		containerArgs := args[1:]
 		if vm {
-			execVM(cmd, args[0], a)
+			execVM(cmd, image, containerCmd, containerArgs)
 			return
 		}
-		if err := launchContainer(cmd, args[0], a, ""); err != nil {
+		if err := launchContainer(cmd, image, containerCmd, containerArgs, ""); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -276,7 +301,7 @@ var TestCmd = &cobra.Command{
 	Example: docs.RunTestExample,
 }
 
-func launchContainer(cmd *cobra.Command, image string, args []string, instanceName string) error {
+func launchContainer(cmd *cobra.Command, image string, containerCmd string, containerArgs []string, instanceName string) error {
 	ns := launcher.Namespaces{
 		User: userNamespace,
 		UTS:  utsNamespace,
@@ -363,5 +388,5 @@ func launchContainer(cmd *cobra.Command, image string, args []string, instanceNa
 		}
 	}
 
-	return l.Exec(cmd.Context(), image, args, instanceName)
+	return l.Exec(cmd.Context(), image, containerCmd, containerArgs, instanceName)
 }

--- a/cmd/internal/cli/checkpoint.go
+++ b/cmd/internal/cli/checkpoint.go
@@ -166,8 +166,9 @@ var CheckpointInstanceCmd = &cobra.Command{
 
 		sylog.Infof("Using checkpoint %q", e.Name())
 
-		a := append([]string{"/.singularity.d/actions/exec"}, dmtcp.CheckpointArgs(port)...)
-		if err := launchContainer(cmd, "instance://"+args[0], a, ""); err != nil {
+		containerCmd := "/.singularity.d/actions/exec"
+		containerArgs := dmtcp.CheckpointArgs(port)
+		if err := launchContainer(cmd, "instance://"+args[0], containerCmd, containerArgs, ""); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/cmd/internal/cli/instance_start_linux.go
+++ b/cmd/internal/cli/instance_start_linux.go
@@ -45,14 +45,14 @@ var instanceStartCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		image := args[0]
 		name := args[1]
-
-		a := append([]string{"/.singularity.d/actions/start"}, args[2:]...)
+		containerCmd := "/.singularity.d/actions/start"
+		containerArgs := args[2:]
 		setVM(cmd)
 		if vm {
-			execVM(cmd, image, a)
+			execVM(cmd, image, containerCmd, containerArgs)
 			return
 		}
-		if err := launchContainer(cmd, image, a, name); err != nil {
+		if err := launchContainer(cmd, image, containerCmd, containerArgs, name); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 

--- a/cmd/internal/cli/startvm.go
+++ b/cmd/internal/cli/startvm.go
@@ -32,7 +32,7 @@ func getHypervisorArgs(sifImage, bzImage, initramfs, singAction, cliExtra string
 	return args
 }
 
-func execVM(cmd *cobra.Command, image string, args []string) {
+func execVM(cmd *cobra.Command, image string, containerCmd string, containerArgs []string) {
 	// SIF image we are running
 	sifImage := image
 
@@ -46,8 +46,8 @@ func execVM(cmd *cobra.Command, image string, args []string) {
 		isInternal = true
 	} else {
 		// Get our "action" (run, exec, shell) based on the action script being called
-		singAction = filepath.Base(args[0])
-		cliExtra = strings.Join(args[1:], " ")
+		singAction = filepath.Base(containerCmd)
+		cliExtra = strings.Join(containerArgs, " ")
 	}
 
 	if err := startVM(sifImage, singAction, cliExtra, isInternal); err != nil {

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2504,24 +2504,6 @@ func (c actionTests) actionFakerootHome(t *testing.T) {
 	}
 }
 
-func (c actionTests) ociRuntime(t *testing.T) {
-	e2e.EnsureImage(t, c.env)
-
-	for _, p := range []e2e.Profile{e2e.OCIUserProfile, e2e.OCIRootProfile} {
-		c.env.RunApptainer(
-			t,
-			e2e.AsSubtest(p.String()),
-			e2e.WithProfile(p),
-			e2e.WithCommand("exec"),
-			e2e.WithArgs(c.env.ImagePath, "/bin/true"),
-			e2e.ExpectExit(
-				255,
-				e2e.ExpectError(e2e.ContainMatch, "not implemented"),
-			),
-		)
-	}
-}
-
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := actionTests{
@@ -2567,8 +2549,11 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"unsquash":                  c.actionUnsquash,          // test --unsquash
 		"no-mount":                  c.actionNoMount,           // test --no-mount
 		"compat":                    c.actionCompat,            // test --compat
-		"ociRuntime":                c.ociRuntime,              // test --oci (unimplemented)
 		"invalidRemote":             np(c.invalidRemote),       // GHSA-5mv9-q7fq-9394
 		"fakeroot home":             c.actionFakerootHome,      // test home dir in fakeroot
+		//
+		// OCI Runtime Mode
+		//
+		"ociRun": c.actionOciRun, // apptainer run --oci
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1,0 +1,82 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package actions
+
+import (
+	"os"
+	"testing"
+
+	"github.com/apptainer/apptainer/e2e/internal/e2e"
+	"github.com/apptainer/apptainer/internal/pkg/test/tool/require"
+	"github.com/pkg/errors"
+)
+
+func (c actionTests) ociBundle(t *testing.T) (string, func()) {
+	require.Seccomp(t)
+	require.Filesystem(t, "overlay")
+
+	bundleDir, err := os.MkdirTemp(c.env.TestDir, "bundle-")
+	if err != nil {
+		err = errors.Wrapf(err, "creating temporary bundle directory at %q", c.env.TestDir)
+		t.Fatalf("failed to create bundle directory: %+v", err)
+	}
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("oci mount"),
+		e2e.WithArgs(c.env.ImagePath, bundleDir),
+		e2e.ExpectExit(0),
+	)
+
+	cleanup := func() {
+		c.env.RunApptainer(
+			t,
+			e2e.WithProfile(e2e.RootProfile),
+			e2e.WithCommand("oci umount"),
+			e2e.WithArgs(bundleDir),
+			e2e.ExpectExit(0),
+		)
+		os.RemoveAll(bundleDir)
+	}
+
+	return bundleDir, cleanup
+}
+
+func (c actionTests) actionOciRun(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	bundle, cleanup := c.ociBundle(t)
+	defer cleanup()
+
+	tests := []struct {
+		name string
+		argv []string
+		exit int
+	}{
+		{
+			name: "NoCommand",
+			argv: []string{bundle},
+			exit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.OCIRootProfile),
+			e2e.WithCommand("run"),
+			// While we don't support args we are entering a /bin/sh interactively, so we need to exit.
+			e2e.ConsoleRun(e2e.ConsoleSendLine("exit")),
+			e2e.WithArgs(tt.argv...),
+			e2e.ExpectExit(tt.exit),
+		)
+	}
+}

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -70,6 +70,7 @@ func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 	}
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("mount"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci mount"),
 		e2e.WithArgs(c.env.ImagePath, bundleDir),
@@ -79,6 +80,7 @@ func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 	cleanup := func() {
 		c.env.RunApptainer(
 			t,
+			e2e.AsSubtest("umount"),
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("oci umount"),
 			e2e.WithArgs(bundleDir),
@@ -135,6 +137,7 @@ func (c ctx) testOciAttach(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("create"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci create"),
 		e2e.WithArgs("-b", bundleDir, containerID),
@@ -153,6 +156,7 @@ func (c ctx) testOciAttach(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("start"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci start"),
 		e2e.WithArgs(containerID),
@@ -166,6 +170,7 @@ func (c ctx) testOciAttach(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("attach"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci attach"),
 		e2e.WithArgs(containerID),
@@ -184,6 +189,7 @@ func (c ctx) testOciAttach(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("delete"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci delete"),
 		e2e.WithArgs(containerID),
@@ -202,6 +208,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("create"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci create"),
 		e2e.WithArgs("-b", bundleDir, containerID),
@@ -220,6 +227,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("start"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci start"),
 		e2e.WithArgs(containerID),
@@ -233,6 +241,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("pause"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci pause"),
 		e2e.WithArgs(containerID),
@@ -250,6 +259,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("resume"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci resume"),
 		e2e.WithArgs(containerID),
@@ -267,6 +277,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("start again"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci start"),
 		e2e.WithArgs(containerID),
@@ -275,6 +286,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("exec"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci exec"),
 		e2e.WithArgs(containerID, "hostname"),
@@ -284,6 +296,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("kill"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci kill"),
 		e2e.WithArgs(containerID, "KILL"),
@@ -297,6 +310,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("delete"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci delete"),
 		e2e.WithArgs(containerID),
@@ -305,6 +319,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("state fail"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci state"),
 		e2e.WithArgs(containerID),
@@ -312,6 +327,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 	)
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("kill fail"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci kill"),
 		e2e.WithArgs(containerID),
@@ -319,6 +335,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 	)
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("start fail"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci start"),
 		e2e.WithArgs(containerID),
@@ -410,7 +427,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 				t.Run("basic", c.testOciBasic)
 				t.Run("attach", c.testOciAttach)
 				t.Run("run", c.testOciRun)
-				t.Run("help", c.testOciHelp)
 			})),
+		"help": c.testOciHelp,
 	}
 }

--- a/internal/pkg/runtime/launcher/launcher.go
+++ b/internal/pkg/runtime/launcher/launcher.go
@@ -29,5 +29,5 @@ type Launcher interface {
 	// the container#s initial process. If instanceName is specified, the
 	// container must be launched as a background instance, otherwist it must
 	// run interactively, attached to the console.
-	Exec(ctx context.Context, image string, args []string, instanceName string) error
+	Exec(ctx context.Context, image string, cmd string, args []string, instanceName string) error
 }

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -104,7 +104,7 @@ func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
 // This includes interactive containers, instances, and joining an existing instance.
 //
 //nolint:maintidx
-func (l *Launcher) Exec(ctx context.Context, image string, args []string, instanceName string) error {
+func (l *Launcher) Exec(ctx context.Context, image string, cmd string, args []string, instanceName string) error {
 	var err error
 
 	var fakerootPath string
@@ -164,6 +164,9 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 			sylog.Infof("No user namespaces available, using only the fakeroot command")
 		}
 	}
+
+	// Native runtime expects command to execute as arg[0]
+	args = append([]string{cmd}, args...)
 
 	// Set arguments to pass to contained process.
 	l.generator.SetProcessArgs(args)

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
+	"github.com/google/uuid"
 )
 
 var (
@@ -233,7 +234,23 @@ func checkOpts(lo launcher.Options) error {
 	return nil
 }
 
-// Exec is not yet implemented.
-func (l *Launcher) Exec(ctx context.Context, image string, args []string, instanceName string) error {
-	return ErrNotImplemented
+// Exec will interactively execute a container via the runc low-level runtime.
+func (l *Launcher) Exec(ctx context.Context, image string, cmd string, args []string, instanceName string) error {
+	if instanceName != "" {
+		return fmt.Errorf("%w: instanceName", ErrNotImplemented)
+	}
+
+	if cmd != "" {
+		return fmt.Errorf("%w: cmd %v", ErrNotImplemented, cmd)
+	}
+
+	if len(args) > 0 {
+		return fmt.Errorf("%w: args %v", ErrNotImplemented, args)
+	}
+
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return fmt.Errorf("while generating container id: %w", err)
+	}
+	return Run(ctx, id.String(), image, "")
 }

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -10,7 +10,6 @@
 package oci
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -56,16 +55,5 @@ func TestNewLauncher(t *testing.T) {
 				t.Errorf("NewLauncher() = %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestExec(t *testing.T) {
-	l, err := NewLauncher([]launcher.Option{}...)
-	if err != nil {
-		t.Errorf("Couldn't initialize launcher: %s", err)
-	}
-
-	if err := l.Exec(context.Background(), "", []string{}, ""); err != ErrNotImplemented {
-		t.Errorf("Expected %v, got %v", ErrNotImplemented, err)
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/oci_conmon_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_conmon_linux.go
@@ -43,7 +43,7 @@ func Create(containerID, bundlePath string) error {
 	if err != nil {
 		return err
 	}
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
@@ -96,12 +96,12 @@ func Create(containerID, bundlePath string) error {
 		"--cid", containerID,
 		"--name", containerID,
 		"--cuuid", containerUUID.String(),
-		"--runtime", runc,
+		"--runtime", runtimeBin,
 		"--conmon-pidfile", path.Join(sd, conmonPidFile),
 		"--container-pidfile", path.Join(sd, containerPidFile),
 		"--log-path", path.Join(sd, containerLogFile),
 		"--runtime-arg", "--root",
-		"--runtime-arg", runcStateDir,
+		"--runtime-arg", runtimeStateDir(),
 		"--runtime-arg", "--log",
 		"--runtime-arg", path.Join(sd, runcLogFile),
 		"--full-attach",

--- a/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
@@ -25,21 +25,21 @@ import (
 
 // Delete deletes container resources
 func Delete(ctx context.Context, containerID string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"delete",
 		containerID,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	err = cmd.Run()
 	if err != nil {
 		return fmt.Errorf("while calling runc delete: %w", err)
@@ -67,88 +67,88 @@ func Delete(ctx context.Context, containerID string) error {
 
 // Exec executes a command in a container
 func Exec(containerID string, cmdArgs []string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"exec",
 		containerID,
 	}
-	runcArgs = append(runcArgs, cmdArgs...)
-	cmd := exec.Command(runc, runcArgs...)
+	runtimeArgs = append(runtimeArgs, cmdArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // Kill kills container process
 func Kill(containerID string, killSignal string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"kill",
 		containerID,
 		killSignal,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // Pause pauses processes in a container
 func Pause(containerID string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"pause",
 		containerID,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // Resume pauses processes in a container
 func Resume(containerID string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"resume",
 		containerID,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // Run runs a container (equivalent to create/start/delete)
 func Run(ctx context.Context, containerID, bundlePath, pidFile string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
@@ -161,80 +161,80 @@ func Run(ctx context.Context, containerID, bundlePath, pidFile string) error {
 		return fmt.Errorf("failed to change directory to %s: %s", absBundle, err)
 	}
 
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"run",
 		"-b", absBundle,
 	}
 	if pidFile != "" {
-		runcArgs = append(runcArgs, "--pid-file="+pidFile)
+		runtimeArgs = append(runtimeArgs, "--pid-file="+pidFile)
 	}
-	runcArgs = append(runcArgs, containerID)
-	cmd := exec.Command(runc, runcArgs...)
+	runtimeArgs = append(runtimeArgs, containerID)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // Start starts a previously created container
 func Start(containerID string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := bin.FindBin("crun")
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"start",
 		containerID,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // State queries container state
 func State(containerID string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"state",
 		containerID,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // Update updates container cgroups resources
 func Update(containerID, cgFile string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"update",
 		"-r", cgFile,
 		containerID,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -48,6 +48,7 @@ func FindBin(name string) (path string, err error) {
 	// All other executables
 	// We will always search the user's PATH first for these
 	case "conmon",
+		"crun",
 		"curl",
 		"debootstrap",
 		"dnf",


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1093
 which fixed
- sylabs/singularity# 598

The original PR description was:
> As a first step toward run/shell/exec actions on native OCI images, implement a minimal `singularity run --oci mybundle` which:
> 
> * Requires an on-disk bundle with appropriate `config.json`.
> * Runs this bundle using `crun` or `runc`.
> * Makes no attempt to handle any arguments or options.
> * Does not modify the `config.json` - i.e. it must match namespace / mapping requirements for rootless execution etc.
> 
> At this stage, the functionality is essentially equivalent to `singularity oci run` and is not yet useful.
> 
> The primary purpose of the PR is to refactor some of the code that passes args for launching a container.
> 
> In addition, we now use `crun` in preference to `runc` if available. `crun` supports e.g. single uid->uid mapping in a usernamespace (without root mapping).