### PR TITLE
e2e: close pipe to actions.fuseMount sshfs container, from sylabs 1113

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1678,7 +1678,10 @@ func (c actionTests) fuseMount(t *testing.T) {
 	}()
 
 	// terminate ssh server once done
-	defer stdinWriter.Write([]byte("bye"))
+	defer func() {
+		stdinWriter.Write([]byte("bye"))
+		stdinWriter.Close()
+	}()
 
 	// wait until ssh server is up and running
 	retry := 0


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1113
 which fixed
- sylabs/singularity# 1114

The original PR description was:
> In the actions.fuseMount test, don't just write to the STDIN pipe for the sshfs container, close it also. This ensures `cat > /dev/null` in the container will see EOF and exit.