### PR TITLE
e2e: remove pull concurrency 3 check, from sylabs 1119

### DIFF
--- a/e2e/pull/concurrency.go
+++ b/e2e/pull/concurrency.go
@@ -78,14 +78,11 @@ func (c ctx) testConcurrentPulls(t *testing.T) {
 	}{
 		// test traditional sequential download
 		{"Concurrency1Cfg", map[string]string{"download concurrency": "1"}, nil, 0},
-		// test concurrency 3
-		{"Concurrency3Cfg", map[string]string{"download concurrency": "3"}, nil, 0},
 		// test concurrency 10
 		{"Concurrency10Cfg", map[string]string{"download concurrency": "10"}, nil, 0},
 
-		// test 1/3/10 goroutines (set via env vars)
+		// test 1/10 goroutines (set via env vars)
 		{"Concurrency1Env", nil, []string{"APPTAINER_DOWNLOAD_CONCURRENCY=1"}, 0},
-		{"Concurrency3Env", nil, []string{"APPTAINER_DOWNLOAD_CONCURRENCY=3"}, 0},
 		{"Concurrency10Env", nil, []string{"APPTAINER_DOWNLOAD_CONCURRENCY=10"}, 0},
 
 		// test concurrent download with 1 MiB and 8 MiB part size


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1119

The original PR description was:
> The default download concurrency is 3, so it is exercised in all other library pull operations. We don't need to explicitly test it.