### PR TITLE
feat: run OCI image sources via temporary bundle, from sylabs 1125

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -137,6 +137,14 @@ func replaceURIWithImage(ctx context.Context, cmd *cobra.Command, args []string)
 		sylog.Fatalf("failed to create a new image cache handle")
 	}
 
+	// The OCI runtime launcher will handle OCI image sources directly.
+	if ociRuntime {
+		if oci.IsSupported(t) != t {
+			sylog.Fatalf("OCI runtime only supports OCI image sources. %s is not supported.", t)
+		}
+		return
+	}
+
 	switch t {
 	case uri.Library:
 		image, err = handleLibrary(ctx, imgCache, args[0])

--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -322,7 +322,7 @@ var OciMountCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := apptainer.OciMount(args[0], args[1]); err != nil {
+		if err := apptainer.OciMount(cmd.Context(), args[0], args[1]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -10,73 +10,99 @@
 package actions
 
 import (
+	"io"
+	"log"
+	"net/http"
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
-	"github.com/apptainer/apptainer/internal/pkg/test/tool/require"
-	"github.com/pkg/errors"
 )
 
-func (c actionTests) ociBundle(t *testing.T) (string, func()) {
-	require.Seccomp(t)
-	require.Filesystem(t, "overlay")
+const (
+	dockerArchiveURI = "https://github.com/apptainer/apptainer/releases/download/v0.1.0/alpine-docker-save.tar"
+	ociArchiveURI    = "https://github.com/apptainer/apptainer/releases/download/v0.1.0/alpine-oci-archive.tar"
+)
 
-	bundleDir, err := os.MkdirTemp(c.env.TestDir, "bundle-")
+func getTestTar(url string) (path string, err error) {
+	dl, err := os.CreateTemp("", "oci-test")
 	if err != nil {
-		err = errors.Wrapf(err, "creating temporary bundle directory at %q", c.env.TestDir)
-		t.Fatalf("failed to create bundle directory: %+v", err)
+		log.Fatal(err)
 	}
-	c.env.RunApptainer(
-		t,
-		e2e.WithProfile(e2e.RootProfile),
-		e2e.WithCommand("oci mount"),
-		e2e.WithArgs(c.env.ImagePath, bundleDir),
-		e2e.ExpectExit(0),
-	)
+	defer dl.Close()
 
-	cleanup := func() {
-		c.env.RunApptainer(
-			t,
-			e2e.WithProfile(e2e.RootProfile),
-			e2e.WithCommand("oci umount"),
-			e2e.WithArgs(bundleDir),
-			e2e.ExpectExit(0),
-		)
-		os.RemoveAll(bundleDir)
+	r, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer r.Body.Close()
+
+	_, err = io.Copy(dl, r.Body)
+	if err != nil {
+		return "", err
 	}
 
-	return bundleDir, cleanup
+	return dl.Name(), nil
 }
 
 func (c actionTests) actionOciRun(t *testing.T) {
-	e2e.EnsureImage(t, c.env)
-
-	bundle, cleanup := c.ociBundle(t)
-	defer cleanup()
+	// Prepare docker-archive source
+	dockerArchive, err := getTestTar(dockerArchiveURI)
+	if err != nil {
+		t.Fatalf("Could not download docker archive test file: %v", err)
+	}
+	defer os.Remove(dockerArchive)
+	// Prepare oci-archive source
+	ociArchive, err := getTestTar(ociArchiveURI)
+	if err != nil {
+		t.Fatalf("Could not download oci archive test file: %v", err)
+	}
+	defer os.Remove(ociArchive)
+	// Prepare oci source (oci directory layout)
+	ociLayout := t.TempDir()
+	cmd := exec.Command("tar", "-C", ociLayout, "-xf", ociArchive)
+	err = cmd.Run()
+	if err != nil {
+		t.Fatalf("Error extracting oci archive to layout: %v", err)
+	}
 
 	tests := []struct {
-		name string
-		argv []string
-		exit int
+		name     string
+		imageRef string
+		exit     int
 	}{
 		{
-			name: "NoCommand",
-			argv: []string{bundle},
-			exit: 0,
+			name:     "docker-archive",
+			imageRef: "docker-archive:" + dockerArchive,
+			exit:     0,
+		},
+		{
+			name:     "oci-archive",
+			imageRef: "oci-archive:" + ociArchive,
+			exit:     0,
+		},
+		{
+			name:     "oci",
+			imageRef: "oci:" + ociLayout,
+			exit:     0,
 		},
 	}
 
-	for _, tt := range tests {
-		c.env.RunApptainer(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.OCIRootProfile),
-			e2e.WithCommand("run"),
-			// While we don't support args we are entering a /bin/sh interactively, so we need to exit.
-			e2e.ConsoleRun(e2e.ConsoleSendLine("exit")),
-			e2e.WithArgs(tt.argv...),
-			e2e.ExpectExit(tt.exit),
-		)
+	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIUserProfile} {
+		t.Run(profile.String(), func(t *testing.T) {
+			for _, tt := range tests {
+				c.env.RunApptainer(
+					t,
+					e2e.AsSubtest(tt.name),
+					e2e.WithProfile(e2e.OCIRootProfile),
+					e2e.WithCommand("run"),
+					// While we don't support args we are entering a /bin/sh interactively.
+					e2e.ConsoleRun(e2e.ConsoleSendLine("exit")),
+					e2e.WithArgs(tt.imageRef),
+					e2e.ExpectExit(tt.exit),
+				)
+			}
+		})
 	}
 }

--- a/internal/app/apptainer/oci_linux.go
+++ b/internal/app/apptainer/oci_linux.go
@@ -83,12 +83,12 @@ func OciUpdate(containerID string, args *OciArgs) error {
 }
 
 // OciMount mount a SIF image to create an OCI bundle
-func OciMount(image string, bundle string) error {
+func OciMount(ctx context.Context, image string, bundle string) error {
 	d, err := ocibundle.FromSif(image, bundle, true)
 	if err != nil {
 		return err
 	}
-	return d.Create(nil)
+	return d.Create(ctx, nil)
 }
 
 // OciUmount umount SIF and delete OCI bundle

--- a/pkg/ocibundle/bundle.go
+++ b/pkg/ocibundle/bundle.go
@@ -10,11 +10,14 @@
 package ocibundle
 
 import (
+	"context"
+
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // Bundle defines an OCI bundle interface to create/delete OCI bundles
 type Bundle interface {
-	Create(*specs.Spec) error
+	Create(context.Context, *specs.Spec) error
 	Delete() error
+	Path() string
 }

--- a/pkg/ocibundle/native/bundle_linux.go
+++ b/pkg/ocibundle/native/bundle_linux.go
@@ -1,0 +1,276 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package native
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	apexlog "github.com/apex/log"
+	"github.com/apptainer/apptainer/internal/pkg/build/oci"
+	"github.com/apptainer/apptainer/internal/pkg/cache"
+	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
+	"github.com/apptainer/apptainer/pkg/ocibundle"
+	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
+	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/docker"
+	dockerarchive "github.com/containers/image/v5/docker/archive"
+	dockerdaemon "github.com/containers/image/v5/docker/daemon"
+	ociarchive "github.com/containers/image/v5/oci/archive"
+	ocilayout "github.com/containers/image/v5/oci/layout"
+	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/types"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/umoci"
+	umocilayer "github.com/opencontainers/umoci/oci/layer"
+	"github.com/opencontainers/umoci/pkg/idtools"
+)
+
+// Bundle is a native OCI bundle, created from imageRef.
+type Bundle struct {
+	// imageRef is the reference to the OCI image source, e.g. docker://ubuntu:latest.
+	imageRef string
+	// imageSpec is the OCI image information, CMD, ENTRYPOINT, etc.
+	imageSpec *imgspecv1.Image
+	// bundlePath is the location where the OCI bundle will be created.
+	bundlePath string
+	// sysCtx provides containers/image transport configuration (auth etc.)
+	sysCtx *types.SystemContext
+	// imgCache is a Apptainer image cache, which OCI blobs are pulled through.
+	// Note that we only use the 'blob' cache section. The 'oci-tmp' cache section holds
+	// OCI->SIF conversions, which are not used here.
+	imgCache *cache.Handle
+	// Generic bundle properties
+	ocibundle.Bundle
+}
+
+func (b *Bundle) Path() string {
+	return b.bundlePath
+}
+
+func (b *Bundle) writeConfig(g *generate.Generator) error {
+	return tools.SaveBundleConfig(b.bundlePath, g)
+}
+
+func (b *Bundle) fetchImage(ctx context.Context, tmpDir string) error {
+	if b.sysCtx == nil {
+		return fmt.Errorf("sysctx must be provided")
+	}
+
+	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+	policyCtx, err := signature.NewPolicyContext(policy)
+	if err != nil {
+		return err
+	}
+
+	parts := strings.SplitN(b.imageRef, ":", 2)
+	if len(parts) < 2 {
+		return fmt.Errorf("could not parse image ref: %s", b.imageRef)
+	}
+	var srcRef types.ImageReference
+
+	switch parts[0] {
+	case "docker":
+		srcRef, err = docker.ParseReference(parts[1])
+	case "docker-archive":
+		srcRef, err = dockerarchive.ParseReference(parts[1])
+	case "docker-daemon":
+		srcRef, err = dockerdaemon.ParseReference(parts[1])
+	case "oci":
+		srcRef, err = ocilayout.ParseReference(parts[1])
+	case "oci-archive":
+		srcRef, err = ociarchive.ParseReference(parts[1])
+	default:
+		return fmt.Errorf("cannot create an OCI container from %s source", parts[0])
+	}
+
+	if err != nil {
+		return fmt.Errorf("invalid image source: %w", err)
+	}
+
+	if b.imgCache != nil {
+		// Grab the modified source ref from the cache
+		srcRef, err = oci.ConvertReference(ctx, b.imgCache, srcRef, b.sysCtx)
+		if err != nil {
+			return err
+		}
+	}
+
+	tmpfsRef, err := ocilayout.ParseReference(tmpDir + ":" + "tmp")
+	if err != nil {
+		return err
+	}
+
+	_, err = copy.Image(ctx, policyCtx, tmpfsRef, srcRef, &copy.Options{
+		ReportWriter: sylog.Writer(),
+		SourceCtx:    b.sysCtx,
+	})
+	if err != nil {
+		return err
+	}
+
+	img, err := srcRef.NewImage(ctx, b.sysCtx)
+	if err != nil {
+		return err
+	}
+	defer img.Close()
+
+	b.imageSpec, err = img.OCIConfig(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *Bundle) extractImage(ctx context.Context, tmpDir string) error {
+	var mapOptions umocilayer.MapOptions
+
+	loggerLevel := sylog.GetLevel()
+	// set the apex log level, for umoci
+	if loggerLevel <= int(sylog.ErrorLevel) {
+		// silent option
+		apexlog.SetLevel(apexlog.ErrorLevel)
+	} else if loggerLevel <= int(sylog.LogLevel) {
+		// quiet option
+		apexlog.SetLevel(apexlog.WarnLevel)
+	} else if loggerLevel < int(sylog.DebugLevel) {
+		// verbose option(s) or default
+		apexlog.SetLevel(apexlog.InfoLevel)
+	} else {
+		// debug option
+		apexlog.SetLevel(apexlog.DebugLevel)
+	}
+
+	// Allow unpacking as non-root
+	if os.Geteuid() != 0 {
+		mapOptions.Rootless = true
+
+		uidMap, err := idtools.ParseMapping(fmt.Sprintf("0:%d:1", os.Geteuid()))
+		if err != nil {
+			return fmt.Errorf("error parsing uidmap: %s", err)
+		}
+		mapOptions.UIDMappings = append(mapOptions.UIDMappings, uidMap)
+
+		gidMap, err := idtools.ParseMapping(fmt.Sprintf("0:%d:1", os.Getegid()))
+		if err != nil {
+			return fmt.Errorf("error parsing gidmap: %s", err)
+		}
+		mapOptions.GIDMappings = append(mapOptions.GIDMappings, gidMap)
+	}
+
+	engineExt, err := umoci.OpenLayout(tmpDir)
+	if err != nil {
+		return fmt.Errorf("error opening layout: %s", err)
+	}
+
+	// Obtain the manifest
+	tmpfsRef, err := ocilayout.ParseReference(tmpDir + ":" + "tmp")
+	if err != nil {
+		return err
+	}
+	imageSource, err := tmpfsRef.NewImageSource(ctx, b.sysCtx)
+	if err != nil {
+		return fmt.Errorf("error creating image source: %s", err)
+	}
+	manifestData, mediaType, err := imageSource.GetManifest(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("error obtaining manifest source: %s", err)
+	}
+	if mediaType != imgspecv1.MediaTypeImageManifest {
+		return fmt.Errorf("error verifying manifest media type: %s", mediaType)
+	}
+	var manifest imgspecv1.Manifest
+	json.Unmarshal(manifestData, &manifest)
+
+	// UnpackRootfs from umoci v0.4.2 expects a path to a non-existing directory
+	os.RemoveAll(tools.RootFs(b.bundlePath).Path())
+
+	// Unpack root filesystem
+	unpackOptions := umocilayer.UnpackOptions{MapOptions: mapOptions}
+	err = umocilayer.UnpackRootfs(ctx, engineExt, tools.RootFs(b.bundlePath).Path(), manifest, &unpackOptions)
+	if err != nil {
+		return fmt.Errorf("error unpacking rootfs: %s", err)
+	}
+
+	return nil
+}
+
+// Create will created the on-disk structures for the OCI bundle, so that it is ready for execution.
+func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
+	// generate OCI bundle directory and config
+	g, err := tools.GenerateBundleConfig(b.bundlePath, ociConfig)
+	if err != nil {
+		return fmt.Errorf("failed to generate OCI bundle/config: %s", err)
+	}
+	// Due to our caching approach for OCI blobs, we need to pull blobs for the image
+	// out into a separate oci-layout directory.
+	tmpDir, err := os.MkdirTemp("", "oci-tmp")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	// Fetch into temp oci layout (will pull through cache if enabled)
+	if err := b.fetchImage(ctx, tmpDir); err != nil {
+		return err
+	}
+	// Extract from temp oci layout into bundle rootfs
+	if err := b.extractImage(ctx, tmpDir); err != nil {
+		return err
+	}
+	// Remove the temp oci layout.
+	if err := os.RemoveAll(tmpDir); err != nil {
+		return err
+	}
+
+	// Set non-root uid/gid per Apptainer defaults
+	uid := uint32(os.Getuid())
+	if uid != 0 {
+		gid := uint32(os.Getgid())
+		g.Config.Process.User.UID = uid
+		g.Config.Process.User.GID = gid
+	}
+	// Set default ENV from image
+	g.Config.Process.Env = append(g.Config.Process.Env, b.imageSpec.Config.Env...)
+	// Set default exec from image CMD & Entrypoint
+	if b.imageSpec == nil {
+		return fmt.Errorf("imageSpec cannot be nil")
+	}
+	args := append(b.imageSpec.Config.Entrypoint, b.imageSpec.Config.Cmd...)
+	g.SetProcessArgs(args)
+	return b.writeConfig(g)
+}
+
+// Delete erases OCI bundle created an OCI image ref
+func (b *Bundle) Delete() error {
+	return tools.DeleteBundle(b.bundlePath)
+}
+
+// FromImageRef returns a bundle interface to create/delete an OCI bundle from an OCI image ref.
+func FromImageRef(imageRef, bundle string, sysCtx *types.SystemContext, imgCache *cache.Handle) (ocibundle.Bundle, error) {
+	var err error
+
+	b := &Bundle{
+		imageRef: imageRef,
+		sysCtx:   sysCtx,
+		imgCache: imgCache,
+	}
+	b.bundlePath, err = filepath.Abs(bundle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine bundle path: %s", err)
+	}
+
+	return b, nil
+}

--- a/pkg/ocibundle/native/bundle_linux_test.go
+++ b/pkg/ocibundle/native/bundle_linux_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package native
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/apptainer/apptainer/internal/pkg/cache"
+	"github.com/containers/image/v5/types"
+	"github.com/opencontainers/runtime-tools/validate"
+)
+
+const (
+	dockerURI         = "docker://alpine"
+	dockerArchiveURI  = "https://github.com/apptainer/apptainer/releases/download/v0.1.0/alpine-docker-save.tar"
+	ociArchiveURI     = "https://github.com/apptainer/apptainer/releases/download/v0.1.0/alpine-oci-archive.tar"
+	dockerDaemonImage = "alpine:latest"
+)
+
+func setupCache(t *testing.T) *cache.Handle {
+	dir := t.TempDir()
+	h, err := cache.New(cache.Config{ParentDir: dir})
+	if err != nil {
+		t.Fatalf("failed to create an image cache handle: %s", err)
+	}
+	return h
+}
+
+func getTestTar(url string) (path string, err error) {
+	dl, err := os.CreateTemp("", "oci-test")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer dl.Close()
+
+	r, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer r.Body.Close()
+
+	_, err = io.Copy(dl, r.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return dl.Name(), nil
+}
+
+func validateBundle(t *testing.T, bundlePath string) {
+	v, err := validate.NewValidatorFromPath(bundlePath, false, "linux")
+	if err != nil {
+		t.Errorf("Could not create bundle validator: %v", err)
+	}
+	if err := v.CheckAll(); err != nil {
+		t.Errorf("Bundle not valid: %v", err)
+	}
+}
+
+func TestFromImageRef(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// Prepare docker-archive source
+	dockerArchive, err := getTestTar(dockerArchiveURI)
+	if err != nil {
+		t.Fatalf("Could not download docker archive test file: %v", err)
+	}
+	defer os.Remove(dockerArchive)
+	// Prepare docker-daemon source
+	hasDocker := false
+	cmd := exec.Command("docker", "ps")
+	err = cmd.Run()
+	if err == nil {
+		hasDocker = true
+		cmd = exec.Command("docker", "pull", dockerDaemonImage)
+		err = cmd.Run()
+		if err != nil {
+			t.Fatalf("could not docker pull %s %v", dockerDaemonImage, err)
+			return
+		}
+	}
+	// Prepare oci-archive source
+	ociArchive, err := getTestTar(ociArchiveURI)
+	if err != nil {
+		t.Fatalf("Could not download oci archive test file: %v", err)
+	}
+	defer os.Remove(ociArchive)
+	// Prepare oci source (oci directory layout)
+	ociLayout := t.TempDir()
+	cmd = exec.Command("tar", "-C", ociLayout, "-xf", ociArchive)
+	err = cmd.Run()
+	if err != nil {
+		t.Fatalf("Error extracting oci archive to layout: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		imageRef    string
+		needsDocker bool
+	}{
+		{"docker", dockerURI, false},
+		{"docker-archive", "docker-archive:" + dockerArchive, false},
+		{"docker-daemon", "docker-daemon:" + dockerDaemonImage, true},
+		{"oci-archive", "oci-archive:" + ociArchive, false},
+		{"oci", "oci:" + ociLayout, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.needsDocker && !hasDocker {
+				t.Skipf("docker not available")
+			}
+			bundleDir := t.TempDir()
+			b, err := FromImageRef(tt.imageRef, bundleDir, &types.SystemContext{}, setupCache(t))
+			if err != nil {
+				t.Fatalf("While initializing bundle: %s", err)
+			}
+
+			if err := b.Create(context.Background(), nil); err != nil {
+				t.Fatalf("While creating bundle: %s", err)
+			}
+
+			validateBundle(t, bundleDir)
+		})
+	}
+}

--- a/pkg/ocibundle/sif/bundle_linux.go
+++ b/pkg/ocibundle/sif/bundle_linux.go
@@ -10,6 +10,7 @@
 package sifbundle
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -92,7 +93,7 @@ func (s *sifBundle) writeConfig(img *image.Image, g *generate.Generator) error {
 }
 
 // Create creates an OCI bundle from a SIF image
-func (s *sifBundle) Create(ociConfig *specs.Spec) error {
+func (s *sifBundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 	if s.image == "" {
 		return fmt.Errorf("image wasn't set, need one to create bundle")
 	}
@@ -170,6 +171,10 @@ func (s *sifBundle) Delete() error {
 	}
 	// delete bundle directory
 	return tools.DeleteBundle(s.bundlePath)
+}
+
+func (s *sifBundle) Path() string {
+	return s.bundlePath
 }
 
 // FromSif returns a bundle interface to create/delete OCI bundle from SIF image

--- a/pkg/ocibundle/sif/bundle_linux_test.go
+++ b/pkg/ocibundle/sif/bundle_linux_test.go
@@ -10,6 +10,7 @@
 package sifbundle
 
 import (
+	"context"
 	"os"
 	"runtime"
 	"testing"
@@ -48,7 +49,7 @@ func TestFromSif(t *testing.T) {
 		t.Errorf("unexpected success while opening non existent image")
 	}
 	// create OCI bundle from SIF
-	if err := bundle.Create(nil); err == nil {
+	if err := bundle.Create(context.Background(), nil); err == nil {
 		// check if cleanup occurred
 		t.Errorf("unexpected success while creating OCI bundle")
 	}
@@ -80,7 +81,7 @@ func TestFromSif(t *testing.T) {
 			g.Config.Linux.Seccomp = nil
 			g.SetProcessArgs([]string{tools.RunScript, "id"})
 
-			if err := bundle.Create(g.Config); err != nil {
+			if err := bundle.Create(context.Background(), g.Config); err != nil {
 				// check if cleanup occurred
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1125
 which fixed
- sylabs/singularity# 1036

The original PR description was:
> When running containers in `--oci` mode, the argument to run is now an image reference corresponding to a native OCI format handled by containers/image, i.e.
> 
> * docker://
> * docker-archive:
> * docker-daemon:
> * oci-archive:
> * oci:
> 
> The source image is extracted into a temporary OCI bundle, with a minimally valid configuration that:
> 
> * Runs the process specified by CMD & ENTRYPOINT only.
> * Sets the environment specified by the image ENV only.
> 
> 
> The approach is very naive - we pull through Singularity's OCI blob cache into a temporary oci layout dir, before creating the bundle from it. Auth handling for registries is not yet wired up. There is duplication of various pieces of code from the build / SIF OCI flows as these are not easily exposed to the area we are working in.
> 
> The intent of the PR, at this stage, is simply to allow e.g.
> 
> ```
> singularity run --oci docker://sylabsio/lolcow
> ```
> 
> _Note_ - the next PR will refactor the code to use functional options.