### PR TITLE
feat: enable shell for --oci mode, from sylabs 1133 & 1143 & 1145

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,6 +31,12 @@ sudo apt-get install -y \
     conmon crun
 ```
 
+_Note_: on Ubuntu 18.04 or Debian 10 leave out `conmon`, `crun`, and
+`fuse-overlayfs` because they are not available, or install them from another
+source. Leaving out the first two will prevent the `--oci` option from working
+and leaving out the third will prevent `--overlay` and `--writable-tmpfs`
+options from working without suid mode.
+
 On CentOS/RHEL:
 
 ```sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -51,6 +51,8 @@ sudo yum install -y \
     conmon crun
 ```
 
+_Note - use `runc` instead of `crun` on CentOS/RHEL 7._
+
 On SLE/openSUSE
 
 ```sh
@@ -64,7 +66,7 @@ sudo zypper install -y \
   conmon crun
 ```
 
-_Note - `crun` can be ommitted if you will not use the `apptainer oci`
+_Note - `crun` / `runc` can be ommitted if you will not use the `apptainer oci`
 commands, or the `--oci` execution mode._
 
 ## Install Go

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,8 @@ sudo apt-get install -y \
     fuse-overlayfs \
     fakeroot \
     cryptsetup \
-    curl wget git
+    curl wget git \
+    conmon crun
 ```
 
 On CentOS/RHEL:
@@ -46,7 +47,8 @@ sudo yum install -y \
     fakeroot \
     /usr/*bin/fuse2fs \
     cryptsetup \
-    wget git
+    wget git \
+    conmon crun
 ```
 
 On SLE/openSUSE
@@ -58,8 +60,12 @@ sudo zypper install -y \
   libuuid-devel \
   openssl-devel \
   cryptsetup sysuser-tools \
-  gcc go
+  gcc go \
+  conmon crun
 ```
+
+_Note - `crun` can be ommitted if you will not use the `apptainer oci`
+commands, or the `--oci` execution mode._
 
 ## Install Go
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,7 +66,7 @@ sudo zypper install -y \
   conmon crun
 ```
 
-_Note - `crun` / `runc` can be ommitted if you will not use the `apptainer oci`
+_Note - `crun` / `runc` can be omitted if you will not use the `apptainer oci`
 commands, or the `--oci` execution mode._
 
 ## Install Go

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -231,10 +231,19 @@ var ShellCmd = &cobra.Command{
 		image := args[0]
 		containerCmd := "/.singularity.d/actions/shell"
 		containerArgs := []string{}
-		// OCI runtime does not use an action script
+		// OCI runtime does not use an action script, but must match behavior.
+		// See - internal/pkg/util/fs/files/action_scripts.go (case shell).
 		if ociRuntime {
-			// TODO - needs to have bash -> sh fallback logic implemented somewhere.
-			containerCmd = "/bin/sh"
+			// APPTAINER_SHELL or --shell has priority
+			if shellPath != "" {
+				containerCmd = shellPath
+				// Clear the shellPath - not handled internally by the OCI runtime, as we exec directly without an action script.
+				shellPath = ""
+			} else {
+				// Otherwise try to exec /bin/bash --norc, falling back to /bin/sh
+				containerCmd = "/bin/sh"
+				containerArgs = []string{"-c", "test -x /bin/bash && PS1='Apptainer> ' exec /bin/bash --norc || PS1='Apptainer> ' exec /bin/sh"}
+			}
 		}
 		setVM(cmd)
 		if vm {

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -22,6 +22,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/build"
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
+	"github.com/apptainer/apptainer/internal/pkg/fakefake"
 	"github.com/apptainer/apptainer/internal/pkg/fakeroot"
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 	fakerootConfig "github.com/apptainer/apptainer/internal/pkg/runtime/engine/fakeroot/config"
@@ -89,7 +90,7 @@ func fakerootExec(isDeffile bool) {
 		if buildArgs.ignoreUserns {
 			err = errors.New("could not start root-mapped namesapce because of --ignore-userns is set")
 		} else {
-			err = fakeroot.UnshareRootMapped(args)
+			err = fakefake.UnshareRootMapped(args)
 		}
 		if err == nil {
 			// All the work has been done by the child process
@@ -149,7 +150,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 		if buildArgs.ignoreFakerootCmd {
 			err = errors.New("fakeroot command is ignored because of --ignore-fakeroot-command")
 		} else {
-			fakerootPath, err = fakeroot.FindFake()
+			fakerootPath, err = fakefake.FindFake()
 		}
 		if err != nil {
 			sylog.Infof("fakeroot command not found")

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -36,7 +36,9 @@ Depends:
  squashfuse,
  fuse2fs,
  fuse-overlayfs,
- fakeroot
+ fakeroot,
+ conmon,
+ crun
 Conflicts: singularity-container
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -38,7 +38,7 @@ Depends:
  fuse-overlayfs,
  fakeroot,
  conmon,
- crun
+ crun | runc
 Conflicts: singularity-container
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model

--- a/dist/rpm/apptainer.rpmlintrc
+++ b/dist/rpm/apptainer.rpmlintrc
@@ -1,0 +1,7 @@
+addFilter(r'setuid-binary /usr/libexec/apptainer/bin/starter-suid')
+addFilter(r'non-standard-executable-perm /usr/libexec/apptainer/bin/starter-suid')
+addFilter(r'zero-length /etc/apptainer/capability.json')
+addFilter(r'zero-length /etc/apptainer/global-pgp-public')
+addFilter(r'readelf-failed /usr/bin/apptainer 'utf-8' codec can't decode byte 0xc2')
+addFilter(r'readelf-failed /usr/libexec/apptainer/bin/starter 'utf-8' codec can't decode byte 0xc2')
+addFilter(r'readelf-failed /usr/libexec/apptainer/bin/starter-suid 'utf-8' codec can't decode byte 0xc2')

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -76,6 +76,7 @@ BuildRequires: libseccomp-devel
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs
 %else
+Requires: shadow-utils
 Requires: squashfs-tools
 %endif
 BuildRequires: cryptsetup
@@ -87,6 +88,8 @@ BuildRequires: pkgconfig
 BuildRequires: fuse3-devel
 BuildRequires: zlib-devel
 %endif
+Requires: conmon
+Requires: crun
 Requires: squashfuse
 Requires: fakeroot
 Requires: fuse-overlayfs

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -36,15 +36,17 @@
 # Uncomment this to include a multithreaded version of squashfuse_ll
 # %%global squashfuse_version 0.1.105
 
-Summary: Application and environment virtualization
 Name: apptainer
 Version: @PACKAGE_RPM_VERSION@
 Release: @PACKAGE_RELEASE@%{?dist}
+Summary: Application and environment virtualization
+
 # See LICENSE.md for first party code (BSD-3-Clause and LBNL BSD)
 # See LICENSE_THIRD_PARTY.md for incorporated code (ASL 2.0)
 # See LICENSE_DEPENDENCIES.md for dependencies
 # License identifiers taken from: https://fedoraproject.org/wiki/Licensing
 License: BSD and LBNL BSD and ASL 2.0
+
 URL: https://apptainer.org
 Source: https://github.com/%{name}/%{name}/releases/download/v%{package_version}/%{name}-%{package_version}.tar.gz
 @PACKAGE_GOLANG_SOURCE@
@@ -69,17 +71,31 @@ Obsoletes: singularity-runtime < 3.0
 BuildRequires: binutils-gold
 %endif
 BuildRequires: golang
-BuildRequires: git
 BuildRequires: gcc
 BuildRequires: make
+# Paths to runtime dependencies detected by mconfig, so must be present at build time.
+BuildRequires: cryptsetup
+%if "%{_target_vendor}" == "suse"
+Requires: squashfs
+%else
+Requires: squashfs-tools
+%endif
+# Required for building bundled conmon
 BuildRequires: libseccomp-devel
+Requires: conmon
+# crun requirement not satisfied on EL7 or SLES default repos - use runc there.
+%if "%{_target_vendor}" == "suse" || 0%{?rhel} > 7
+Requires: crun
+%else
+Requires: runc
+%endif
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs
 %else
 Requires: shadow-utils
 Requires: squashfs-tools
 %endif
-BuildRequires: cryptsetup
+Requires: cryptsetup
 %if "%{?squashfuse_version}" != ""
 BuildRequires: autoconf
 BuildRequires: automake
@@ -88,8 +104,6 @@ BuildRequires: pkgconfig
 BuildRequires: fuse3-devel
 BuildRequires: zlib-devel
 %endif
-Requires: conmon
-Requires: crun
 Requires: squashfuse
 Requires: fakeroot
 Requires: fuse-overlayfs
@@ -201,6 +215,7 @@ rmdir %{_sysconfdir}/singularity/* %{_sysconfdir}/singularity 2>/dev/null || tru
 %dir %{_libexecdir}/%{name}
 %dir %{_libexecdir}/%{name}/bin
 %{_libexecdir}/%{name}/bin/starter
+%dir %{_libexecdir}/%{name}/cni
 %if "%{?squashfuse_version}" != ""
 %{_libexecdir}/%{name}/bin/squashfuse_ll
 %endif
@@ -208,6 +223,9 @@ rmdir %{_sysconfdir}/singularity/* %{_sysconfdir}/singularity 2>/dev/null || tru
 %{_libexecdir}/%{name}/lib
 %dir %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/*
+%dir %{_sysconfdir}/%{name}/cgroups
+%dir %{_sysconfdir}/%{name}/network
+%dir %{_sysconfdir}/%{name}/seccomp-profiles
 %{_datadir}/bash-completion/completions/*
 %dir %{_localstatedir}/%{name}
 %dir %{_localstatedir}/%{name}/mnt
@@ -219,9 +237,9 @@ rmdir %{_sysconfdir}/singularity/* %{_sysconfdir}/singularity 2>/dev/null || tru
 %license LICENSE_DEPENDENCIES.md
 %doc README.md
 %doc CHANGELOG.md
+%doc CONTRIBUTING.md
 
 %files suid
 %attr(4755, root, root) %{_libexecdir}/%{name}/bin/starter-suid
 
 %changelog
-

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2559,7 +2559,8 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		//
 		// OCI Runtime Mode
 		//
-		"ociRun":  c.actionOciRun,  // apptainer run --oci
-		"ociExec": c.actionOciExec, // apptainer exec --oci
+		"ociRun":   c.actionOciRun,   // apptainer run --oci
+		"ociExec":  c.actionOciExec,  // apptainer exec --oci
+		"ociShell": c.actionOciShell, // apptainer shell --oci
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -84,7 +84,7 @@ func (c actionTests) actionOciRun(t *testing.T) {
 				c.env.RunApptainer(
 					t,
 					e2e.AsSubtest(tt.name),
-					e2e.WithProfile(e2e.OCIUserProfile),
+					e2e.WithProfile(profile),
 					e2e.WithCommand("run"),
 					// While we don't support args we are entering a /bin/sh interactively.
 					e2e.ConsoleRun(e2e.ConsoleSendLine("exit")),
@@ -184,15 +184,19 @@ func (c actionTests) actionOciShell(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		c.env.RunApptainer(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.OCIUserProfile),
-			e2e.WithCommand("shell"),
-			e2e.WithArgs(tt.argv...),
-			e2e.ConsoleRun(tt.consoleOps...),
-			e2e.ExpectExit(tt.exit),
-		)
+	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIUserProfile} {
+		t.Run(profile.String(), func(t *testing.T) {
+			for _, tt := range tests {
+				c.env.RunApptainer(
+					t,
+					e2e.AsSubtest(tt.name),
+					e2e.WithProfile(profile),
+					e2e.WithCommand("shell"),
+					e2e.WithArgs(tt.argv...),
+					e2e.ConsoleRun(tt.consoleOps...),
+					e2e.ExpectExit(tt.exit),
+				)
+			}
+		})
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -146,3 +146,53 @@ func (c actionTests) actionOciExec(t *testing.T) {
 		)
 	}
 }
+
+// Shell interaction tests
+func (c actionTests) actionOciShell(t *testing.T) {
+	e2e.EnsureOCIImage(t, c.env)
+
+	tests := []struct {
+		name       string
+		argv       []string
+		consoleOps []e2e.ApptainerConsoleOp
+		exit       int
+	}{
+		{
+			name: "ShellExit",
+			argv: []string{"oci-archive:" + c.env.OCIImagePath},
+			consoleOps: []e2e.ApptainerConsoleOp{
+				// "cd /" to work around issue where a long
+				// working directory name causes the test
+				// to fail because the "Apptainer" that
+				// we are looking for is chopped from the
+				// front.
+				// TODO(mem): This test was added back in 491a71716013654acb2276e4b37c2e015d2dfe09
+				e2e.ConsoleSendLine("cd /"),
+				e2e.ConsoleExpect("Apptainer"),
+				e2e.ConsoleSendLine("exit"),
+			},
+			exit: 0,
+		},
+		{
+			name: "ShellBadCommand",
+			argv: []string{"oci-archive:" + c.env.OCIImagePath},
+			consoleOps: []e2e.ApptainerConsoleOp{
+				e2e.ConsoleSendLine("_a_fake_command"),
+				e2e.ConsoleSendLine("exit"),
+			},
+			exit: 127,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.OCIUserProfile),
+			e2e.WithCommand("shell"),
+			e2e.WithArgs(tt.argv...),
+			e2e.ConsoleRun(tt.consoleOps...),
+			e2e.ExpectExit(tt.exit),
+		)
+	}
+}

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -84,7 +84,7 @@ func (c actionTests) actionOciRun(t *testing.T) {
 				c.env.RunApptainer(
 					t,
 					e2e.AsSubtest(tt.name),
-					e2e.WithProfile(e2e.OCIRootProfile),
+					e2e.WithProfile(e2e.OCIUserProfile),
 					e2e.WithCommand("run"),
 					// While we don't support args we are entering a /bin/sh interactively.
 					e2e.ConsoleRun(e2e.ConsoleSendLine("exit")),

--- a/internal/app/apptainer/overlay_create.go
+++ b/internal/app/apptainer/overlay_create.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/apptainer/apptainer/internal/pkg/fakefake"
 	"github.com/apptainer/apptainer/internal/pkg/fakeroot"
 	"github.com/apptainer/apptainer/internal/pkg/util/bin"
 	"github.com/apptainer/apptainer/pkg/image"
@@ -232,7 +233,7 @@ func OverlayCreate(size int, imgPath string, overlaySparse bool, isFakeroot bool
 			//  the fakeroot command (in suid flow with no user
 			//  namespaces), using the --fakeroot option here
 			//  prevents overlay from working, most unfortunately.
-			err = fakeroot.UnshareRootMapped([]string{"/bin/true"})
+			err = fakefake.UnshareRootMapped([]string{"/bin/true"})
 			if err != nil {
 				sylog.Debugf("UnshareRootMapped failed: %v", err)
 				if isFakeroot {
@@ -248,7 +249,7 @@ func OverlayCreate(size int, imgPath string, overlaySparse bool, isFakeroot bool
 
 		if isFakeroot {
 			sylog.Debugf("Trying root-mapped namespace")
-			err = fakeroot.UnshareRootMapped(os.Args)
+			err = fakefake.UnshareRootMapped(os.Args)
 			if err == nil {
 				// everything was done by the child
 				os.Exit(0)

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/apptainer/apptainer/internal/pkg/build/files"
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
-	"github.com/apptainer/apptainer/internal/pkg/fakeroot"
+	"github.com/apptainer/apptainer/internal/pkg/fakefake"
 	"github.com/apptainer/apptainer/pkg/build/types"
 	"github.com/apptainer/apptainer/pkg/sylog"
 )
@@ -99,7 +99,7 @@ func (s *stage) runPostScript(sessionResolv, sessionHosts string) error {
 			//  the nested apptainer will run fakeroot if it isn't
 			//  started and pass down the components and environment
 			//  to nested apptainers.
-			fakerootBinds, err = fakeroot.GetFakeBinds(s.b.Opts.FakerootPath)
+			fakerootBinds, err = fakefake.GetFakeBinds(s.b.Opts.FakerootPath)
 			if err != nil {
 				return fmt.Errorf("while getting fakeroot bindpoints: %v", err)
 			}

--- a/internal/pkg/fakefake/fakefake.go
+++ b/internal/pkg/fakefake/fakefake.go
@@ -9,7 +9,7 @@
 // This file is for "fake fakeroot", that is, root-mapped unprivileged
 //   user namespaces (unshare -r) and the fakeroot command
 
-package fakeroot
+package fakefake
 
 import (
 	"bufio"

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/cgroups"
+	"github.com/apptainer/apptainer/internal/pkg/fakefake"
 	fakerootutil "github.com/apptainer/apptainer/internal/pkg/fakeroot"
 	"github.com/apptainer/apptainer/internal/pkg/image/driver"
 	"github.com/apptainer/apptainer/internal/pkg/instance"
@@ -97,7 +98,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 		if fakerootPath := e.EngineConfig.GetFakerootPath(); fakerootPath != "" {
 			// look for fakeroot again because the PATH used is
 			//  more restricted at this point than it was earlier
-			newPath, err := fakerootutil.FindFake()
+			newPath, err := fakefake.FindFake()
 			if err != nil {
 				return fmt.Errorf("error finding fakeroot in privileged PATH: %v", err)
 			}

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -32,7 +32,7 @@ import (
 	"unsafe"
 
 	"github.com/apptainer/apptainer/internal/pkg/checkpoint/dmtcp"
-	"github.com/apptainer/apptainer/internal/pkg/fakeroot"
+	"github.com/apptainer/apptainer/internal/pkg/fakefake"
 	"github.com/apptainer/apptainer/internal/pkg/instance"
 	"github.com/apptainer/apptainer/internal/pkg/plugin"
 	"github.com/apptainer/apptainer/internal/pkg/security"
@@ -889,7 +889,7 @@ func runActionScript(engineConfig *apptainerConfig.EngineConfig) ([]string, []st
 		}
 	}
 
-	fakeargs := fakeroot.GetFakeArgs()
+	fakeargs := fakefake.GetFakeArgs()
 	fakerootPath := fakeargs[0]
 	_, err = os.Stat(fakerootPath)
 	if err == nil && getEnvVal(penv, "FAKEROOTKEY") == "" {
@@ -906,7 +906,7 @@ func runActionScript(engineConfig *apptainerConfig.EngineConfig) ([]string, []st
 		if engineConfig.GetFakerootPath() == "" {
 			// Must be joining an instance, so also set BIND
 			//  variables for nesting
-			fakebinds, _ := fakeroot.GetFakeBinds(fakerootPath)
+			fakebinds, _ := fakefake.GetFakeBinds(fakerootPath)
 			bindval := strings.Join(fakebinds, ",")
 			for _, pfx := range env.ApptainerPrefixes {
 				bindvar := pfx + "BIND="

--- a/internal/pkg/runtime/launcher/launcher.go
+++ b/internal/pkg/runtime/launcher/launcher.go
@@ -27,7 +27,7 @@ import "context"
 type Launcher interface {
 	// Exec will execute the container image 'image', starting 'process', and
 	// passing arguments 'args'. If instanceName is specified, the container
-	// must be launched as a background instance, otherwist it must run
+	// must be launched as a background instance, otherwise it must run
 	// interactively, attached to the console.
 	Exec(ctx context.Context, image string, process string, args []string, instanceName string) error
 }

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/cgroups"
 	"github.com/apptainer/apptainer/internal/pkg/checkpoint/dmtcp"
+	"github.com/apptainer/apptainer/internal/pkg/fakefake"
 	"github.com/apptainer/apptainer/internal/pkg/fakeroot"
 	"github.com/apptainer/apptainer/internal/pkg/image/driver"
 	"github.com/apptainer/apptainer/internal/pkg/image/unpacker"
@@ -117,7 +118,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 			if l.cfg.IgnoreFakerootCmd {
 				err = errors.New("fakeroot command is ignored because of --ignore-fakeroot-command")
 			} else {
-				fakerootPath, err = fakeroot.FindFake()
+				fakerootPath, err = fakefake.FindFake()
 			}
 			if err != nil {
 				sylog.Infof("fakeroot command not found, using only root-mapped namespace")
@@ -131,7 +132,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 			if l.cfg.IgnoreUserns {
 				err = errors.New("could not start root-mapped namespace because of --ignore-userns is set")
 			} else {
-				err = fakeroot.UnshareRootMapped(os.Args)
+				err = fakefake.UnshareRootMapped(os.Args)
 			}
 			if err == nil {
 				// All good
@@ -141,7 +142,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 			if l.cfg.IgnoreFakerootCmd {
 				err = errors.New("fakeroot command is ignored because of --ignore-fakeroot-command")
 			} else {
-				fakerootPath, err = fakeroot.FindFake()
+				fakerootPath, err = fakefake.FindFake()
 			}
 			if err != nil {
 				sylog.Fatalf("--fakeroot requires either being in %v, unprivileged user namespaces, or the fakeroot command", fakeroot.SubUIDFile)
@@ -627,7 +628,7 @@ func (l *Launcher) setBinds(fakerootPath string) error {
 	if fakerootPath != "" {
 		l.engineConfig.SetFakerootPath(fakerootPath)
 		// Add binds for fakeroot command
-		fakebindPaths, err := fakeroot.GetFakeBinds(fakerootPath)
+		fakebindPaths, err := fakefake.GetFakeBinds(fakerootPath)
 		if err != nil {
 			return fmt.Errorf("while getting fakeroot bindpoints: %w", err)
 		}

--- a/pkg/ocibundle/native/bundle_linux.go
+++ b/pkg/ocibundle/native/bundle_linux.go
@@ -20,6 +20,7 @@ import (
 	apexlog "github.com/apex/log"
 	"github.com/apptainer/apptainer/internal/pkg/build/oci"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
+	"github.com/apptainer/apptainer/internal/pkg/fakeroot"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/apptainer/apptainer/pkg/ocibundle"
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
@@ -160,7 +161,9 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 	b.setProcessArgs(g)
 	// TODO - Handle custom env and user
 	b.setProcessEnv(g)
-	b.setProcessUser(g)
+	if err := b.setProcessUser(g); err != nil {
+		return err
+	}
 
 	return b.writeConfig(g)
 }
@@ -170,14 +173,100 @@ func (b *Bundle) Path() string {
 	return b.bundlePath
 }
 
-func (b *Bundle) setProcessUser(g *generate.Generator) {
+func (b *Bundle) setProcessUser(g *generate.Generator) error {
 	// Set non-root uid/gid per Apptainer defaults
 	uid := uint32(os.Getuid())
 	if uid != 0 {
 		gid := uint32(os.Getgid())
 		g.Config.Process.User.UID = uid
 		g.Config.Process.User.GID = gid
+		// Get user's configured subuid & subgid ranges
+		subuidRange, err := fakeroot.GetIDRange(fakeroot.SubUIDFile, uid)
+		if err != nil {
+			return err
+		}
+		// We must be able to map at least 0->65535 inside the container
+		if subuidRange.Size < 65536 {
+			return fmt.Errorf("subuid range size (%d) must be at least 65536", subuidRange.Size)
+		}
+		subgidRange, err := fakeroot.GetIDRange(fakeroot.SubGIDFile, uid)
+		if err != nil {
+			return err
+		}
+		if subgidRange.Size <= gid {
+			return fmt.Errorf("subuid range size (%d) must be at least 65536", subgidRange.Size)
+		}
+
+		// Preserve own uid container->host, map everything else to subuid range.
+		if uid < 65536 {
+			g.Config.Linux.UIDMappings = []specs.LinuxIDMapping{
+				{
+					ContainerID: 0,
+					HostID:      subuidRange.HostID,
+					Size:        uid,
+				},
+				{
+					ContainerID: uid,
+					HostID:      uid,
+					Size:        1,
+				},
+				{
+					ContainerID: uid + 1,
+					HostID:      subuidRange.HostID + uid,
+					Size:        subuidRange.Size - uid,
+				},
+			}
+		} else {
+			g.Config.Linux.UIDMappings = []specs.LinuxIDMapping{
+				{
+					ContainerID: 0,
+					HostID:      subuidRange.HostID,
+					Size:        65536,
+				},
+				{
+					ContainerID: uid,
+					HostID:      uid,
+					Size:        1,
+				},
+			}
+		}
+
+		// Preserve own gid container->host, map everything else to subgid range.
+		if gid < 65536 {
+			g.Config.Linux.GIDMappings = []specs.LinuxIDMapping{
+				{
+					ContainerID: 0,
+					HostID:      subgidRange.HostID,
+					Size:        gid,
+				},
+				{
+					ContainerID: gid,
+					HostID:      gid,
+					Size:        1,
+				},
+				{
+					ContainerID: gid + 1,
+					HostID:      subgidRange.HostID + gid,
+					Size:        subgidRange.Size - gid,
+				},
+			}
+		} else {
+			g.Config.Linux.GIDMappings = []specs.LinuxIDMapping{
+				{
+					ContainerID: 0,
+					HostID:      subgidRange.HostID,
+					Size:        65536,
+				},
+				{
+					ContainerID: gid,
+					HostID:      gid,
+					Size:        1,
+				},
+			}
+		}
+		g.Config.Linux.Namespaces = append(g.Config.Linux.Namespaces, specs.LinuxNamespace{Type: "user"})
 	}
+	return nil
 }
 
 func (b *Bundle) setProcessEnv(g *generate.Generator) {

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -30,7 +30,9 @@ apt-get install -y \
     libssl-dev \
     python2 \
     uuid-dev \
-    golang-go
+    golang-go \
+    conmon \
+    crun
 # for squashfuse_ll build
 apt-get install -y autoconf automake libtool pkg-config libfuse-dev zlib1g-dev
 


### PR DESCRIPTION
This pulls in sylabs PRs

- sylabs/singularity# 1133
- sylabs/singularity# 1143
- sylabs/singularity# 1145
 which fixed
- sylabs/singularity# 1025
- sylabs/singularity# 1041
- sylabs/singularity# 1042
- sylabs/singularity# 1044

The original PR descriptions were:
> Enable `singularity shell --oci ...` with behavior matching native runtime, i.e.
> 
> * Run shell set with SINGULARITY_SHELL or --shell 
> * If not set, try /bin/bash --norc 
> * If not available, use /bin/sh

> Tidy up the rpm spec file.
> * Remove the manual handling of build root, GOPATH etc. Not needed as we are using go modules now.
> * Remove redundant explicit deps.
> * Fix crun -> runc dep for EL7, SLES.
> * Use rpm make_xxx macros instead of direct make calls.
> * Ensure all directories created are owned by package.

> If `crun` is not available, require `runc`.