### PR TITLE
oci: move some code to launcher, use explicit config, from sylabs 1134

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -132,18 +132,36 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			argv: []string{imageRef, "/bin/false"},
 			exit: 1,
 		},
+		{
+			name: "TouchTmp",
+			argv: []string{imageRef, "/bin/touch", "/tmp/test"},
+			exit: 0,
+		},
+		{
+			name: "TouchVarTmp",
+			argv: []string{imageRef, "/bin/touch", "/var/tmp/test"},
+			exit: 0,
+		},
+		{
+			name: "TouchHome",
+			argv: []string{imageRef, "/bin/sh", "-c", "touch $HOME"},
+			exit: 0,
+		},
 	}
-
-	for _, tt := range tests {
-		c.env.RunApptainer(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
-			e2e.WithCommand("exec"),
-			e2e.WithDir("/tmp"),
-			e2e.WithArgs(tt.argv...),
-			e2e.ExpectExit(tt.exit),
-		)
+	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIUserProfile} {
+		t.Run(profile.String(), func(t *testing.T) {
+			for _, tt := range tests {
+				c.env.RunApptainer(
+					t,
+					e2e.AsSubtest(tt.name),
+					e2e.WithProfile(e2e.UserProfile),
+					e2e.WithCommand("exec"),
+					e2e.WithDir("/tmp"),
+					e2e.WithArgs(tt.argv...),
+					e2e.ExpectExit(tt.exit),
+				)
+			}
+		})
 	}
 }
 

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -285,6 +285,30 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		}
 	}
 
+	spec, err := MinimalSpec()
+	if err != nil {
+		return err
+	}
+
+	spec.Process.User = l.getProcessUser()
+	uidMap, gidMap, err := l.getIDMaps()
+	if err != nil {
+		return err
+	}
+	spec.Linux.UIDMappings = uidMap
+	spec.Linux.GIDMappings = gidMap
+	cwd, err := l.getProcessCwd()
+	if err != nil {
+		return err
+	}
+	spec.Process.Cwd = cwd
+
+	mounts, err := l.getMounts()
+	if err != nil {
+		return err
+	}
+	spec.Mounts = mounts
+
 	b, err := native.New(
 		native.OptBundlePath(bundleDir),
 		native.OptImageRef(image),
@@ -296,7 +320,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		return err
 	}
 
-	if err := b.Create(ctx, nil); err != nil {
+	if err := b.Create(ctx, spec); err != nil {
 		return err
 	}
 

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -1,0 +1,146 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// Package oci implements a Launcher that will configure and launch a container
+// with an OCI runtime. It also provides implementations of OCI state
+// transitions that can be called directly, Create/Start/Kill etc.
+package oci
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/apptainer/apptainer/internal/pkg/util/user"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// getMounts returns a mount list for the container's OCI runtime spec.
+func (l *Launcher) getMounts() ([]specs.Mount, error) {
+	mounts := &[]specs.Mount{}
+	l.addProcMount(mounts)
+	l.addSysMount(mounts)
+	err := addDevMounts(mounts)
+	if err != nil {
+		return nil, fmt.Errorf("while configuring devpts mount: %w", err)
+	}
+	l.addTmpMounts(mounts)
+	err = l.addHomeMount(mounts)
+	if err != nil {
+		return nil, fmt.Errorf("while configuring home mount: %w", err)
+	}
+	return *mounts, nil
+}
+
+// addBindMount adds a bind mount from src on host, to dst in container.
+func (l *Launcher) addBindMount(mounts *[]specs.Mount, src, dst string) {
+	*mounts = append(*mounts,
+		specs.Mount{
+			Source:      src,
+			Destination: dst,
+			Type:        "none",
+			Options:     []string{"rbind", "nosuid", "nodev"},
+		})
+}
+
+// addTmpMounts adds tmpfs mounts for /tmp and /var/tmp in the container.
+func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) {
+	*mounts = append(*mounts,
+		specs.Mount{
+			Destination: "/tmp",
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"nosuid", "relatime", "mode=777", "size=65536k"},
+		},
+		specs.Mount{
+			Destination: "/tmp",
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"nosuid", "relatime", "mode=777", "size=65536k"},
+		})
+}
+
+// addDevMounts adds mounts to assemble a minimal /dev in the container.
+func addDevMounts(mounts *[]specs.Mount) error {
+	group, err := user.GetGrNam("tty")
+	if err != nil {
+		return fmt.Errorf("while identifying tty gid: %w", err)
+	}
+
+	*mounts = append(*mounts,
+		specs.Mount{
+			Destination: "/dev",
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+		},
+		specs.Mount{
+			Destination: "/dev/pts",
+			Type:        "devpts",
+			Source:      "devpts",
+			Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=" + strconv.Itoa(int(group.GID))},
+		},
+		specs.Mount{
+			Destination: "/dev/shm",
+			Type:        "tmpfs",
+			Source:      "shm",
+			Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
+		},
+		specs.Mount{
+			Destination: "/dev/mqueue",
+			Type:        "mqueue",
+			Source:      "mqueue",
+			Options:     []string{"nosuid", "noexec", "nodev"},
+		},
+	)
+
+	return nil
+}
+
+// addProcMount adds the /proc tree in the container.
+func (l *Launcher) addProcMount(mounts *[]specs.Mount) {
+	if l.cfg.Namespaces.PID {
+		*mounts = append(*mounts,
+			specs.Mount{
+				Source:      "proc",
+				Destination: "/proc",
+				Type:        "proc",
+			})
+	} else {
+		l.addBindMount(mounts, "/proc", "/proc")
+	}
+}
+
+// addSysMount adds the /sys tree in the container.
+func (l *Launcher) addSysMount(mounts *[]specs.Mount) {
+	*mounts = append(*mounts,
+		specs.Mount{
+			Source:      "sysfs",
+			Destination: "/sys",
+			Type:        "sysfs",
+			Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+		})
+}
+
+// addHomeMount adds a user home directory as a tmpfs mount. We are currently
+// emulating `--compat` / `--containall`, so the user must specifically bind in
+// their home directory from the host for it to be available.
+func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
+	pw, err := user.CurrentOriginal()
+	if err != nil {
+		return err
+	}
+	*mounts = append(*mounts,
+		specs.Mount{
+			Destination: pw.Dir,
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"nosuid", "relatime", "mode=755", "size=65536k", "uid=" + strconv.Itoa(int(pw.UID)), "gid=" + strconv.Itoa(int(pw.GID))},
+		})
+	return nil
+}

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -1,0 +1,150 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/apptainer/apptainer/internal/pkg/fakeroot"
+	"github.com/apptainer/apptainer/internal/pkg/util/user"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// getProcessUser computes the uid/gid(s) to be set on process execution.
+// Currently this only supports the same uid / primary gid as on the host.
+// TODO - expand for fakeroot, and arbitrary mapped user.
+func (l *Launcher) getProcessUser() specs.User {
+	return specs.User{
+		UID: uint32(os.Getuid()),
+		GID: uint32(os.Getgid()),
+	}
+}
+
+// getProcessCwd computes the Cwd that the container process should start in.
+// Currently this is the user's tmpfs home directory (see --containall).
+func (l *Launcher) getProcessCwd() (dir string, err error) {
+	pw, err := user.CurrentOriginal()
+	if err != nil {
+		return "", err
+	}
+	return pw.Dir, nil
+}
+
+// getIDMaps returns uid and gid mappings appropriate for a non-root user, if required.
+func (l *Launcher) getIDMaps() (uidMap, gidMap []specs.LinuxIDMapping, err error) {
+	uid := uint32(os.Getuid())
+	// Root user gets pass-through mapping
+	if uid == 0 {
+		uidMap = []specs.LinuxIDMapping{
+			{
+				ContainerID: 0,
+				HostID:      0,
+				Size:        65536,
+			},
+		}
+		gidMap = []specs.LinuxIDMapping{
+			{
+				ContainerID: 0,
+				HostID:      0,
+				Size:        65536,
+			},
+		}
+		return uidMap, gidMap, nil
+	}
+	// Set non-root uid/gid per Apptainer defaults
+	gid := uint32(os.Getgid())
+	// Get user's configured subuid & subgid ranges
+	subuidRange, err := fakeroot.GetIDRange(fakeroot.SubUIDFile, uid)
+	if err != nil {
+		return nil, nil, err
+	}
+	// We must be able to map at least 0->65535 inside the container
+	if subuidRange.Size < 65536 {
+		return nil, nil, fmt.Errorf("subuid range size (%d) must be at least 65536", subuidRange.Size)
+	}
+	subgidRange, err := fakeroot.GetIDRange(fakeroot.SubGIDFile, uid)
+	if err != nil {
+		return nil, nil, err
+	}
+	if subgidRange.Size <= gid {
+		return nil, nil, fmt.Errorf("subuid range size (%d) must be at least 65536", subgidRange.Size)
+	}
+
+	// Preserve own uid container->host, map everything else to subuid range.
+	if uid < 65536 {
+		uidMap = []specs.LinuxIDMapping{
+			{
+				ContainerID: 0,
+				HostID:      subuidRange.HostID,
+				Size:        uid,
+			},
+			{
+				ContainerID: uid,
+				HostID:      uid,
+				Size:        1,
+			},
+			{
+				ContainerID: uid + 1,
+				HostID:      subuidRange.HostID + uid,
+				Size:        subuidRange.Size - uid,
+			},
+		}
+	} else {
+		uidMap = []specs.LinuxIDMapping{
+			{
+				ContainerID: 0,
+				HostID:      subuidRange.HostID,
+				Size:        65536,
+			},
+			{
+				ContainerID: uid,
+				HostID:      uid,
+				Size:        1,
+			},
+		}
+	}
+
+	// Preserve own gid container->host, map everything else to subgid range.
+	if gid < 65536 {
+		gidMap = []specs.LinuxIDMapping{
+			{
+				ContainerID: 0,
+				HostID:      subgidRange.HostID,
+				Size:        gid,
+			},
+			{
+				ContainerID: gid,
+				HostID:      gid,
+				Size:        1,
+			},
+			{
+				ContainerID: gid + 1,
+				HostID:      subgidRange.HostID + gid,
+				Size:        subgidRange.Size - gid,
+			},
+		}
+	} else {
+		gidMap = []specs.LinuxIDMapping{
+			{
+				ContainerID: 0,
+				HostID:      subgidRange.HostID,
+				Size:        65536,
+			},
+			{
+				ContainerID: gid,
+				HostID:      gid,
+				Size:        1,
+			},
+		}
+	}
+
+	return uidMap, gidMap, nil
+}

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -1,0 +1,88 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// MinimalSpec returns an OCI runtime spec with a minimal OCI configuration that
+// is a starting point for compatibility with Apptainer's native launcher in
+// `--compat` mode.
+func MinimalSpec() (*specs.Spec, error) {
+	config := specs.Spec{
+		Version: specs.Version,
+	}
+	config.Root = &specs.Root{
+		Path: "rootfs",
+		// TODO - support writable-tmpfs / writable
+		Readonly: true,
+	}
+	config.Process = &specs.Process{
+		Terminal: true,
+		// Default fallback to a shell at / - will generally be overwritten by
+		// the launcher.
+		Args: []string{"sh"},
+		Cwd:  "/",
+	}
+	config.Process.User = specs.User{}
+	config.Process.Env = []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	}
+
+	// TODO - these are appropriate minimum for rootless. We need to tie into
+	// Apptainer's cap-add / cap-drop mechanism.
+	config.Process.Capabilities = &specs.LinuxCapabilities{
+		Bounding: []string{
+			"CAP_NET_BIND_SERVICE",
+			"CAP_KILL",
+			"CAP_AUDIT_WRITE",
+		},
+		Permitted: []string{
+			"CAP_NET_BIND_SERVICE",
+			"CAP_KILL",
+			"CAP_AUDIT_WRITE",
+		},
+		Inheritable: []string{},
+		Effective: []string{
+			"CAP_NET_BIND_SERVICE",
+			"CAP_KILL",
+			"CAP_AUDIT_WRITE",
+		},
+		Ambient: []string{
+			"CAP_NET_BIND_SERVICE",
+			"CAP_KILL",
+			"CAP_AUDIT_WRITE",
+		},
+	}
+
+	// All mounts are added by the launcher, as it must handle flags.
+	config.Mounts = []specs.Mount{}
+
+	config.Linux = &specs.Linux{
+		// Minimum namespaces matching native runtime with --compat / --containall.
+		// TODO: ßAdditional namespaces can be added by launcher.
+		Namespaces: []specs.LinuxNamespace{
+			{
+				Type: "ipc",
+			},
+			{
+				Type: "pid",
+			},
+			{
+				Type: "mount",
+			},
+			{
+				Type: "user",
+			},
+		},
+	}
+	return &config, nil
+}

--- a/pkg/ocibundle/native/bundle_linux.go
+++ b/pkg/ocibundle/native/bundle_linux.go
@@ -20,7 +20,6 @@ import (
 	apexlog "github.com/apex/log"
 	"github.com/apptainer/apptainer/internal/pkg/build/oci"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
-	"github.com/apptainer/apptainer/internal/pkg/fakeroot"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/apptainer/apptainer/pkg/ocibundle"
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
@@ -157,13 +156,10 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 	if err := os.RemoveAll(tmpDir); err != nil {
 		return err
 	}
-
+	// ProcessArgs are set here, rather than in the launcher spec generation, as we need to
+	// consult the image Config to handle combining ENTRYPOINT/CMD with user
+	// provided args.
 	b.setProcessArgs(g)
-	// TODO - Handle custom env and user
-	b.setProcessEnv(g)
-	if err := b.setProcessUser(g); err != nil {
-		return err
-	}
 
 	return b.writeConfig(g)
 }
@@ -171,107 +167,6 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 // Path returns the bundle's path on disk.
 func (b *Bundle) Path() string {
 	return b.bundlePath
-}
-
-func (b *Bundle) setProcessUser(g *generate.Generator) error {
-	// Set non-root uid/gid per Apptainer defaults
-	uid := uint32(os.Getuid())
-	if uid != 0 {
-		gid := uint32(os.Getgid())
-		g.Config.Process.User.UID = uid
-		g.Config.Process.User.GID = gid
-		// Get user's configured subuid & subgid ranges
-		subuidRange, err := fakeroot.GetIDRange(fakeroot.SubUIDFile, uid)
-		if err != nil {
-			return err
-		}
-		// We must be able to map at least 0->65535 inside the container
-		if subuidRange.Size < 65536 {
-			return fmt.Errorf("subuid range size (%d) must be at least 65536", subuidRange.Size)
-		}
-		subgidRange, err := fakeroot.GetIDRange(fakeroot.SubGIDFile, uid)
-		if err != nil {
-			return err
-		}
-		if subgidRange.Size <= gid {
-			return fmt.Errorf("subuid range size (%d) must be at least 65536", subgidRange.Size)
-		}
-
-		// Preserve own uid container->host, map everything else to subuid range.
-		if uid < 65536 {
-			g.Config.Linux.UIDMappings = []specs.LinuxIDMapping{
-				{
-					ContainerID: 0,
-					HostID:      subuidRange.HostID,
-					Size:        uid,
-				},
-				{
-					ContainerID: uid,
-					HostID:      uid,
-					Size:        1,
-				},
-				{
-					ContainerID: uid + 1,
-					HostID:      subuidRange.HostID + uid,
-					Size:        subuidRange.Size - uid,
-				},
-			}
-		} else {
-			g.Config.Linux.UIDMappings = []specs.LinuxIDMapping{
-				{
-					ContainerID: 0,
-					HostID:      subuidRange.HostID,
-					Size:        65536,
-				},
-				{
-					ContainerID: uid,
-					HostID:      uid,
-					Size:        1,
-				},
-			}
-		}
-
-		// Preserve own gid container->host, map everything else to subgid range.
-		if gid < 65536 {
-			g.Config.Linux.GIDMappings = []specs.LinuxIDMapping{
-				{
-					ContainerID: 0,
-					HostID:      subgidRange.HostID,
-					Size:        gid,
-				},
-				{
-					ContainerID: gid,
-					HostID:      gid,
-					Size:        1,
-				},
-				{
-					ContainerID: gid + 1,
-					HostID:      subgidRange.HostID + gid,
-					Size:        subgidRange.Size - gid,
-				},
-			}
-		} else {
-			g.Config.Linux.GIDMappings = []specs.LinuxIDMapping{
-				{
-					ContainerID: 0,
-					HostID:      subgidRange.HostID,
-					Size:        65536,
-				},
-				{
-					ContainerID: gid,
-					HostID:      gid,
-					Size:        1,
-				},
-			}
-		}
-		g.Config.Linux.Namespaces = append(g.Config.Linux.Namespaces, specs.LinuxNamespace{Type: "user"})
-	}
-	return nil
-}
-
-func (b *Bundle) setProcessEnv(g *generate.Generator) {
-	// Set default ENV values from image
-	g.Config.Process.Env = append(g.Config.Process.Env, b.imageSpec.Config.Env...)
 }
 
 func (b *Bundle) setProcessArgs(g *generate.Generator) {


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1134

The original PR description was:
> Move ID mapping and process setup code to the launcher, out of the oci bundle package.
> Add a minimal config for `--oci` mode, rather than starting with the default OCI config.
> Add explicit configuration of mounts, with `tmpfs` mount locations matching the native runtime with `--containall / --compat`.
> Ensure ID mapping is always explicit (including for root).