### PR TITLE
oci: Add --fakeroot support to --oci mode, from sylabs 1135

### DIFF
--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -10,6 +10,10 @@
 package cli
 
 import (
+	"errors"
+	"os"
+	"os/exec"
+
 	"github.com/apptainer/apptainer/docs"
 	"github.com/apptainer/apptainer/internal/app/apptainer"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher/oci"
@@ -154,6 +158,10 @@ var OciRunCmd = &cobra.Command{
 	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := apptainer.OciRun(cmd.Context(), args[0], &ociArgs); err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				os.Exit(exitErr.ExitCode())
+			}
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -76,7 +76,7 @@ func (c actionTests) actionOciRun(t *testing.T) {
 		},
 	}
 
-	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIUserProfile} {
+	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tt := range tests {
 				cmdArgs := []string{tt.imageRef}
@@ -148,7 +148,7 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			exit: 0,
 		},
 	}
-	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIUserProfile} {
+	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tt := range tests {
 				c.env.RunApptainer(
@@ -202,7 +202,7 @@ func (c actionTests) actionOciShell(t *testing.T) {
 		},
 	}
 
-	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIUserProfile} {
+	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tt := range tests {
 				c.env.RunApptainer(

--- a/internal/pkg/runtime/engine/fakeroot/config/config.go
+++ b/internal/pkg/runtime/engine/fakeroot/config/config.go
@@ -19,4 +19,5 @@ type EngineConfig struct {
 	Envs     []string `json:"envs"`
 	Home     string   `json:"home"`
 	BuildEnv bool     `json:"buildEnv"`
+	NoPIDNS  bool     `json:"NoPIDNS"`
 }

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -101,7 +101,11 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 
 	g.AddOrReplaceLinuxNamespace(specs.UserNamespace, "")
 	g.AddOrReplaceLinuxNamespace(specs.MountNamespace, "")
-	g.AddOrReplaceLinuxNamespace(specs.PIDNamespace, "")
+
+	// If we enter a PID NS in the --oci action -> oci run flow, then crun / runc will fail.
+	if !e.EngineConfig.NoPIDNS {
+		g.AddOrReplaceLinuxNamespace(specs.PIDNamespace, "")
+	}
 
 	uid := uint32(os.Getuid())
 	gid := uint32(os.Getgid())

--- a/internal/pkg/runtime/launcher/oci/README.md
+++ b/internal/pkg/runtime/launcher/oci/README.md
@@ -1,0 +1,141 @@
+# internal/pkg/runtime/launcher/oci
+
+This package contains routines that configure and launch a container in an OCI
+bundle format, using a low-level OCI runtime, either `crun` or `runc` at this
+time. `crun` is currently preferred. `runc` is used where `crun` is not
+available.
+
+**Note** - at present, all functionality works with either `crun` or `runc`.
+However, in future `crun` may be required for all functionality, as `runc` does
+not support some limited ID mappings etc. that may be beneficial in an HPC
+scenario.
+
+The package contrasts with `internal/pkg/runtime/launcher/native` which executes
+Apptainer format containers (SIF/Sandbox/squashfs/ext3), using one of our own
+runtime engines (`internal/pkg/runtime/engine/*`).
+
+There are two flows that are implemented here.
+
+* Basic OCI runtime operations agains an existing bundle, which will be executed
+  via the `apptainer oci` command group. These are not widely used by
+  end-users of apptainer.
+* A `Launcher`, that implements an `Exec` function that will be called by
+  'actions' (run/shell/exec) in `--oci` mode, and will:
+  * Prepare an OCI bundle according to `launcher.Options` passed through from
+    the CLI layer.
+  * Execute the bundle, interactively, via the OCI Run operation.
+
+**Note** - this area of code is under heavy development for experimental.
+It is likely that it will be heavily refactored, and split, in future.
+
+## Basic OCI Operations
+
+The following files implement basic OCI operations on a runtime bundle:
+
+### `oci_linux.go`
+
+Defines constants, path resolution, and minimal bundle locking functions.
+
+### `oci_runc_linux.go`
+
+Holds implementations of the Run / Start / Exec / Kill / Delete / Pause / Resume
+/ State OCI runtime operations.
+
+See
+<https://github.com/opencontainers/runtime-spec/blob/main/runtime.md#operations>
+
+These functions are thin wrappers around the `runc`/`crun` operations of the
+same name.
+
+### `oci_conmon_linux.go`
+
+Hold an implementation of the Create OCI runtime operation. This calls out to
+`conmon`, which in turn calls `crun` or `runc`.
+
+`conmon` is used to manage logging and console streams for containers that are
+started backgrounded, so we don't have to do that ourselves.
+
+### `oci_attach_linux.go`
+
+Implements an `Attach` function, which can attach the user's console to the
+streams of a container running in the background, which is being monitored by
+conmon.
+
+### Testing
+
+End-to-end flows of basic OCI operations on an existing bundle are tested in the
+OCI group of the e2e suite, `e2e/oci`.
+
+## Launcher Flow
+
+The `Launcher` type connects the standard apptainer CLI actions
+(run/shell/exec), to execution of an OCI container in a native bundle. Invoked
+with the `--oci` flag, this is in contrast to running a Apptainer format
+container, with Apptainer's own runtime engine.
+
+### `spec_linux.go`
+
+Provides a minimal OCI runtime spec, that will form the basis of container
+execution that is roughly comparable to running a native apptainer container
+with `--compat` (`--containall`).
+
+### `mounts_linux.go`
+
+Provides code handling the addition of required mounts to the OCI runtime spec.
+
+### `process_linux.go`
+
+Provides code handling configuration of container process execution, including
+user mapping.
+
+### `launcher_linux.go`
+
+Implements `Launcher.Exec`, which is called from the CLI layer. It will:
+
+* Create a temporary bundle directory.
+* Use `pkg/ocibundle/native` to retrieve the specified image, and extract it in
+  the temporary bundle.
+* Configure the container by creating an appropriate runtime spec.
+* Call the interactive OCI Run function to execute the container with `crun` or
+  `runc`.
+
+### Namespace Considerations
+
+An OCI container started via `Launch.Exec` as a non-root user always uses at
+least one user namespace.
+
+The user namespace is created *prior to* calling `runc` or `crun`, so we'll call
+it an *outer* user namespace.
+
+Creation of this outer user namespace is via using the `RunNS` function, instead
+of `Run`. The `RunNS` function executes the Apptainer `starter` binary, with a
+minimal configuration of the fakeroot engine (
+`internal/pkg/runtime/engine/fakeroot/config`).
+
+The `starter` will create a user namespace and ID mapping, and will then execute
+`apptainer oci run` to perform the basic OCI Run operation against the bundle
+that the `Launcher.Exec` function has prepared.
+
+The outer user namespace from which `runc` or `crun` is called *always* maps the
+host user id to root inside the userns.
+
+When a container is run in `--fakeroot` mode, the outer user namespace is the
+only user namespace. The OCI runtime config does not request any additional
+userns or ID mapping be performed by `crun` / `runc`.
+
+When a container is **not** run in `--fakeroot` mode, the OCI runtime config for
+the bundle requests that `crun` / `runc`:
+
+* Create another, inner, user namespace for the container.
+* Apply an ID mapping which reverses the 'fakeroot' outer ID mapping.
+
+I.E. when a container runs without `--fakeroot`, the ID mapping is:
+
+* User ID on host (1001)
+* Root in outer user namespace (0)
+* User ID in container (1001)
+
+### Testing
+
+End-to-end testing of the launcher flow is via the `e2e/actions` suite. Tests
+prefixed `oci`.

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -14,6 +14,7 @@ package oci
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/apptainer/apptainer/internal/pkg/util/user"
@@ -37,17 +38,6 @@ func (l *Launcher) getMounts() ([]specs.Mount, error) {
 	return *mounts, nil
 }
 
-// addBindMount adds a bind mount from src on host, to dst in container.
-func (l *Launcher) addBindMount(mounts *[]specs.Mount, src, dst string) {
-	*mounts = append(*mounts,
-		specs.Mount{
-			Source:      src,
-			Destination: dst,
-			Type:        "none",
-			Options:     []string{"rbind", "nosuid", "nodev"},
-		})
-}
-
 // addTmpMounts adds tmpfs mounts for /tmp and /var/tmp in the container.
 func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) {
 	*mounts = append(*mounts,
@@ -67,9 +57,19 @@ func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) {
 
 // addDevMounts adds mounts to assemble a minimal /dev in the container.
 func addDevMounts(mounts *[]specs.Mount) error {
-	group, err := user.GetGrNam("tty")
-	if err != nil {
-		return fmt.Errorf("while identifying tty gid: %w", err)
+	ptsMount := specs.Mount{
+		Destination: "/dev/pts",
+		Type:        "devpts",
+		Source:      "devpts",
+		Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620"},
+	}
+
+	if os.Getuid() == 0 {
+		group, err := user.GetGrNam("tty")
+		if err != nil {
+			return fmt.Errorf("while identifying tty gid: %w", err)
+		}
+		ptsMount.Options = append(ptsMount.Options, fmt.Sprintf("gid=%d", group.GID))
 	}
 
 	*mounts = append(*mounts,
@@ -79,12 +79,7 @@ func addDevMounts(mounts *[]specs.Mount) error {
 			Source:      "tmpfs",
 			Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
 		},
-		specs.Mount{
-			Destination: "/dev/pts",
-			Type:        "devpts",
-			Source:      "devpts",
-			Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=" + strconv.Itoa(int(group.GID))},
-		},
+		ptsMount,
 		specs.Mount{
 			Destination: "/dev/shm",
 			Type:        "tmpfs",
@@ -104,33 +99,50 @@ func addDevMounts(mounts *[]specs.Mount) error {
 
 // addProcMount adds the /proc tree in the container.
 func (l *Launcher) addProcMount(mounts *[]specs.Mount) {
-	if l.cfg.Namespaces.PID {
-		*mounts = append(*mounts,
-			specs.Mount{
-				Source:      "proc",
-				Destination: "/proc",
-				Type:        "proc",
-			})
-	} else {
-		l.addBindMount(mounts, "/proc", "/proc")
-	}
+	*mounts = append(*mounts,
+		specs.Mount{
+			Source:      "proc",
+			Destination: "/proc",
+			Type:        "proc",
+		})
 }
 
 // addSysMount adds the /sys tree in the container.
 func (l *Launcher) addSysMount(mounts *[]specs.Mount) {
-	*mounts = append(*mounts,
-		specs.Mount{
-			Source:      "sysfs",
-			Destination: "/sys",
-			Type:        "sysfs",
-			Options:     []string{"nosuid", "noexec", "nodev", "ro"},
-		})
+	if os.Getuid() == 0 {
+		*mounts = append(*mounts,
+			specs.Mount{
+				Source:      "sysfs",
+				Destination: "/sys",
+				Type:        "sysfs",
+				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+			})
+	} else {
+		*mounts = append(*mounts,
+			specs.Mount{
+				Source:      "/sys",
+				Destination: "/sys",
+				Type:        "none",
+				Options:     []string{"rbind", "nosuid", "noexec", "nodev", "ro"},
+			})
+	}
 }
 
 // addHomeMount adds a user home directory as a tmpfs mount. We are currently
 // emulating `--compat` / `--containall`, so the user must specifically bind in
 // their home directory from the host for it to be available.
 func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
+	if l.cfg.Fakeroot {
+		*mounts = append(*mounts,
+			specs.Mount{
+				Destination: "/root",
+				Type:        "tmpfs",
+				Source:      "tmpfs",
+				Options:     []string{"nosuid", "relatime", "mode=755", "size=65536k"},
+			})
+		return nil
+	}
+
 	pw, err := user.CurrentOriginal()
 	if err != nil {
 		return err

--- a/internal/pkg/runtime/launcher/oci/oci_conmon_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_conmon_linux.go
@@ -91,6 +91,12 @@ func Create(containerID, bundlePath string) error {
 	defer startParent.Close()
 
 	apptainerBin := filepath.Join(buildcfg.BINDIR, "apptainer")
+
+	rsd, err := runtimeStateDir()
+	if err != nil {
+		return err
+	}
+
 	cmdArgs := []string{
 		"--api-version", "1",
 		"--cid", containerID,
@@ -101,7 +107,7 @@ func Create(containerID, bundlePath string) error {
 		"--container-pidfile", path.Join(sd, containerPidFile),
 		"--log-path", path.Join(sd, containerLogFile),
 		"--runtime-arg", "--root",
-		"--runtime-arg", runtimeStateDir(),
+		"--runtime-arg", rsd,
 		"--runtime-arg", "--log",
 		"--runtime-arg", path.Join(sd, runcLogFile),
 		"--full-attach",

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -22,6 +22,12 @@ import (
 // Currently this only supports the same uid / primary gid as on the host.
 // TODO - expand for fakeroot, and arbitrary mapped user.
 func (l *Launcher) getProcessUser() specs.User {
+	if l.cfg.Fakeroot {
+		return specs.User{
+			UID: 0,
+			GID: 0,
+		}
+	}
 	return specs.User{
 		UID: uint32(os.Getuid()),
 		GID: uint32(os.Getgid()),
@@ -31,6 +37,10 @@ func (l *Launcher) getProcessUser() specs.User {
 // getProcessCwd computes the Cwd that the container process should start in.
 // Currently this is the user's tmpfs home directory (see --containall).
 func (l *Launcher) getProcessCwd() (dir string, err error) {
+	if l.cfg.Fakeroot {
+		return "/root", nil
+	}
+
 	pw, err := user.CurrentOriginal()
 	if err != nil {
 		return "", err
@@ -38,35 +48,20 @@ func (l *Launcher) getProcessCwd() (dir string, err error) {
 	return pw.Dir, nil
 }
 
-// getIDMaps returns uid and gid mappings appropriate for a non-root user, if required.
-func (l *Launcher) getIDMaps() (uidMap, gidMap []specs.LinuxIDMapping, err error) {
+// getReverseUserMaps returns uid and gid mappings that re-map container uid to host
+// uid. This 'reverses' the host user to container root mapping in the initial
+// userns from which the OCI runtime is launched.
+//
+//	host 1001 -> fakeroot userns 0 -> container 1001
+func (l *Launcher) getReverseUserMaps() (uidMap, gidMap []specs.LinuxIDMapping, err error) {
 	uid := uint32(os.Getuid())
-	// Root user gets pass-through mapping
-	if uid == 0 {
-		uidMap = []specs.LinuxIDMapping{
-			{
-				ContainerID: 0,
-				HostID:      0,
-				Size:        65536,
-			},
-		}
-		gidMap = []specs.LinuxIDMapping{
-			{
-				ContainerID: 0,
-				HostID:      0,
-				Size:        65536,
-			},
-		}
-		return uidMap, gidMap, nil
-	}
-	// Set non-root uid/gid per Apptainer defaults
 	gid := uint32(os.Getgid())
 	// Get user's configured subuid & subgid ranges
 	subuidRange, err := fakeroot.GetIDRange(fakeroot.SubUIDFile, uid)
 	if err != nil {
 		return nil, nil, err
 	}
-	// We must be able to map at least 0->65535 inside the container
+	// We must always be able to map at least 0->65535 inside the container, so we cover 'nobody'.
 	if subuidRange.Size < 65536 {
 		return nil, nil, fmt.Errorf("subuid range size (%d) must be at least 65536", subuidRange.Size)
 	}
@@ -74,26 +69,25 @@ func (l *Launcher) getIDMaps() (uidMap, gidMap []specs.LinuxIDMapping, err error
 	if err != nil {
 		return nil, nil, err
 	}
-	if subgidRange.Size <= gid {
+	if subgidRange.Size < 65536 {
 		return nil, nil, fmt.Errorf("subuid range size (%d) must be at least 65536", subgidRange.Size)
 	}
 
-	// Preserve own uid container->host, map everything else to subuid range.
-	if uid < 65536 {
+	if uid < subuidRange.Size {
 		uidMap = []specs.LinuxIDMapping{
 			{
 				ContainerID: 0,
-				HostID:      subuidRange.HostID,
+				HostID:      1,
 				Size:        uid,
 			},
 			{
 				ContainerID: uid,
-				HostID:      uid,
+				HostID:      0,
 				Size:        1,
 			},
 			{
 				ContainerID: uid + 1,
-				HostID:      subuidRange.HostID + uid,
+				HostID:      uid + 1,
 				Size:        subuidRange.Size - uid,
 			},
 		}
@@ -101,33 +95,32 @@ func (l *Launcher) getIDMaps() (uidMap, gidMap []specs.LinuxIDMapping, err error
 		uidMap = []specs.LinuxIDMapping{
 			{
 				ContainerID: 0,
-				HostID:      subuidRange.HostID,
-				Size:        65536,
+				HostID:      1,
+				Size:        subuidRange.Size,
 			},
 			{
 				ContainerID: uid,
-				HostID:      uid,
+				HostID:      0,
 				Size:        1,
 			},
 		}
 	}
 
-	// Preserve own gid container->host, map everything else to subgid range.
-	if gid < 65536 {
+	if gid < subgidRange.Size {
 		gidMap = []specs.LinuxIDMapping{
 			{
 				ContainerID: 0,
-				HostID:      subgidRange.HostID,
+				HostID:      1,
 				Size:        gid,
 			},
 			{
 				ContainerID: gid,
-				HostID:      gid,
+				HostID:      0,
 				Size:        1,
 			},
 			{
 				ContainerID: gid + 1,
-				HostID:      subgidRange.HostID + gid,
+				HostID:      gid + 1,
 				Size:        subgidRange.Size - gid,
 			},
 		}
@@ -135,12 +128,12 @@ func (l *Launcher) getIDMaps() (uidMap, gidMap []specs.LinuxIDMapping, err error
 		gidMap = []specs.LinuxIDMapping{
 			{
 				ContainerID: 0,
-				HostID:      subgidRange.HostID,
-				Size:        65536,
+				HostID:      1,
+				Size:        subgidRange.Size,
 			},
 			{
 				ContainerID: gid,
-				HostID:      gid,
+				HostID:      0,
 				Size:        1,
 			},
 		}

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -41,25 +41,17 @@ func MinimalSpec() (*specs.Spec, error) {
 	// Apptainer's cap-add / cap-drop mechanism.
 	config.Process.Capabilities = &specs.LinuxCapabilities{
 		Bounding: []string{
-			"CAP_NET_BIND_SERVICE",
+			"CAP_CHOWN",
+			"CAP_DAC_OVERRIDE",
+			"CAP_FOWNER",
+			"CAP_FSETID",
 			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Permitted: []string{
 			"CAP_NET_BIND_SERVICE",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Inheritable: []string{},
-		Effective: []string{
-			"CAP_NET_BIND_SERVICE",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Ambient: []string{
-			"CAP_NET_BIND_SERVICE",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
+			"CAP_SETFCAP",
+			"CAP_SETGID",
+			"CAP_SETPCAP",
+			"CAP_SETUID",
+			"CAP_SYS_CHROOT",
 		},
 	}
 
@@ -68,19 +60,16 @@ func MinimalSpec() (*specs.Spec, error) {
 
 	config.Linux = &specs.Linux{
 		// Minimum namespaces matching native runtime with --compat / --containall.
-		// TODO: ßAdditional namespaces can be added by launcher.
+		// TODO: Additional namespaces to be added by launcher.
 		Namespaces: []specs.LinuxNamespace{
 			{
-				Type: "ipc",
+				Type: specs.IPCNamespace,
 			},
 			{
-				Type: "pid",
+				Type: specs.PIDNamespace,
 			},
 			{
-				Type: "mount",
-			},
-			{
-				Type: "user",
+				Type: specs.MountNamespace,
 			},
 		},
 	}

--- a/internal/pkg/util/starter/starter.go
+++ b/internal/pkg/util/starter/starter.go
@@ -114,7 +114,7 @@ func Run(name string, config *config.Common, ops ...CommandOp) error {
 	cmd.Stderr = c.stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("while running %s: %s", c.path, err)
+		return fmt.Errorf("while running %s: %w", c.path, err)
 	}
 	return nil
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1135
 which fixed
- sylabs/singularity# 1035

The original PR description was:
> Implements initial --fakeroot support for --oci mode. Mirrors behavior with --compat / --contain.
> 
> The process of accomplishing this is fairly complex. In theory, we should be able to call `crun` directly from host namespaces. We can let `crun` create a default userns and user mapping, or be able to request arbitrary explicit uid mappings (permitted by /etc/subuid /etc/subgid) to be applied.
> 
> Unfortunately this can hit bugs as this path is not well tested in `crun`. See e.g.
> 
> - containers/crun# 1077
> - containers/crun# 1072 
> 
> To avoid requiring the very latest `crun` with fixes, instead move to creating a userns ourselves, with a 'fakeroot' ID mapping in place, and call `crun` from that. This is the kind of flow implemented in other runtimes that call `crun`, such as `podman`.... so `crun` is well tested with it.
> 
> We can use the singularity `starter` with the `fakeroot` engine ,and a minimal config, to create the userns and id mapping. We already use it this way to perform a simple `rm` cleanup in `--fakeroot` execution of a native singularity container. This approach avoids having to implement further C/Go executables, or making large imports, such as the `reexec` + `unshare` packages from `github.com/containers/storage`
> 
> We are now, by default, calling `crun` or `runc` with a `fakeroot` setup... with host uid/gid mapped to 0 inside the userns. This is default for most OCI runtimes, however singularity default is to preserve the host id.
> 
> We need to have (fake) root inside the userns for `crun` / `runc` to work properly... so to return to the host uid in the container we insert an inner user namespace / ID mapping request into the bundle `config.json`. This reverses the mapping, i.e.
> 
> * User ID on host (1001)
> * Root in outer user namespace (0)
> * User ID in container (1001)
> 
> I've added a README.md in this PR, as things are rather complex:
> 
> https://github.com/sylabs/singularity/blob/9680663bb1eccbfade2de9f639e1e4be49ffb3bf/internal/pkg/runtime/launcher/oci/README.md
> 
> Note that there are likely still some rough edges, and the oci launcher package is getting toward the point where it should be split, but I don't want to add too much more to this single review.