### PR TITLE
fix: use conf file value for oci tmpfs size, from sylabs 1151

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `runc` to manage containers.
 - The `apptainer oci` flags `--sync-socket`, `--empty-process`, and
   `--timeout` have been removed.
+- `sessiondir maxsize` in `apptainer.conf` now defaults to 64 MiB for new
+  installations. This is an increase from 16 MiB in prior versions.
 
 ### New features / functionalities
 

--- a/etc/conf/testdata/test_1.out.correct
+++ b/etc/conf/testdata/test_1.out.correct
@@ -145,11 +145,12 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain and ephemeral changes when running with --writable-tmpfs.
+# In --oci mode, each tmpfs mount in the container can be up to this size.
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/etc/conf/testdata/test_2.in
+++ b/etc/conf/testdata/test_2.in
@@ -145,11 +145,12 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain and ephemeral changes when running with --writable-tmpfs,
+# and the equivalent data in --oci mode.
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/etc/conf/testdata/test_2.out.correct
+++ b/etc/conf/testdata/test_2.out.correct
@@ -145,11 +145,12 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain and ephemeral changes when running with --writable-tmpfs.
+# In --oci mode, each tmpfs mount in the container can be up to this size.
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/etc/conf/testdata/test_3.in
+++ b/etc/conf/testdata/test_3.in
@@ -136,11 +136,12 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain and ephemeral changes when running with --writable-tmpfs,
+# and the equivalent data in --oci mode.
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/etc/conf/testdata/test_3.out.correct
+++ b/etc/conf/testdata/test_3.out.correct
@@ -145,11 +145,12 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain and ephemeral changes when running with --writable-tmpfs.
+# In --oci mode, each tmpfs mount in the container can be up to this size.
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/etc/conf/testdata/test_default.tmpl
+++ b/etc/conf/testdata/test_default.tmpl
@@ -147,10 +147,11 @@ mount slave = {{ if eq .MountSlave true }}yes{{ else }}no{{ end }}
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain and ephemeral changes when running with --writable-tmpfs.
+# In --oci mode, each tmpfs mount in the container can be up to this size.
 sessiondir max size = {{ .SessiondirMaxSize }}
 
 

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/ocibundle/native"
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
 	"github.com/containers/image/v5/types"
 	"github.com/google/uuid"
@@ -39,7 +40,8 @@ var (
 // Launcher will holds configuration for, and will launch a container using an
 // OCI runtime.
 type Launcher struct {
-	cfg launcher.Options
+	cfg           launcher.Options
+	apptainerConf *apptainerconf.File
 }
 
 // NewLauncher returns a oci.Launcher with an initial configuration set by opts.
@@ -54,7 +56,13 @@ func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
 	if err := checkOpts(lo); err != nil {
 		return nil, err
 	}
-	return &Launcher{lo}, nil
+
+	c := apptainerconf.GetCurrentConfig()
+	if c == nil {
+		return nil, fmt.Errorf("apptainer configuration is not initialized")
+	}
+
+	return &Launcher{cfg: lo, apptainerConf: c}, nil
 }
 
 // checkOpts ensures that options set are supported by the oci.Launcher.

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -14,9 +14,16 @@ import (
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
+	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
 )
 
 func TestNewLauncher(t *testing.T) {
+	sc, err := apptainerconf.GetConfig(nil)
+	if err != nil {
+		t.Fatalf("while initializing apptainerconf: %s", err)
+	}
+	apptainerconf.SetCurrentConfig(sc)
+
 	tests := []struct {
 		name    string
 		opts    []launcher.Option
@@ -25,7 +32,7 @@ func TestNewLauncher(t *testing.T) {
 	}{
 		{
 			name:    "default",
-			want:    &Launcher{},
+			want:    &Launcher{apptainerConf: sc},
 			wantErr: false,
 		},
 		{
@@ -33,7 +40,7 @@ func TestNewLauncher(t *testing.T) {
 			opts: []launcher.Option{
 				launcher.OptHome("/home/test", false, false),
 			},
-			want: &Launcher{cfg: launcher.Options{HomeDir: "/home/test"}},
+			want: &Launcher{cfg: launcher.Options{HomeDir: "/home/test"}, apptainerConf: sc},
 		},
 		{
 			name: "unsupportedOption",

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -101,7 +101,7 @@ type File struct {
 	AlwaysUseRocm           bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
 	SharedLoopDevices       bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
 	MaxLoopDevices          uint     `default:"256" directive:"max loop devices"`
-	SessiondirMaxSize       uint     `default:"16" directive:"sessiondir max size"`
+	SessiondirMaxSize       uint     `default:"64" directive:"sessiondir max size"`
 	MountDev                string   `default:"yes" authorized:"yes,no,minimal" directive:"mount dev"`
 	EnableOverlay           string   `default:"try" authorized:"yes,no,try,driver" directive:"enable overlay"`
 	BindPath                []string `default:"/etc/localtime,/etc/hosts" directive:"bind path"`
@@ -277,11 +277,11 @@ enable underlay = {{ if eq .EnableUnderlay true }}yes{{ else }}no{{ end }}
 mount slave = {{ if eq .MountSlave true }}yes{{ else }}no{{ end }}
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB). It will
-# affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home") and
-# it will also affect users of "--writable-tmpfs".
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain and ephemeral changes when running with --writable-tmpfs.
+# In --oci mode, each tmpfs mount in the container can be up to this size.
 sessiondir max size = {{ .SessiondirMaxSize }}
 
 # LIMIT CONTAINER OWNERS: [STRING]


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1151
 which fixed
- sylabs/singularity# 1140

The original PR description was:
> Use the configuration file sessiondir max size value for --oci mode tmpfs mounts.
>
> Increase the default from 16M -> 64M. The 16M default is very low, and has periodically caused issues running programs that create even small amounts of temporary data on --contained filesystems.