### PR TITLE
feat: oci: support namespace flags, from sylabs 1157

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2559,8 +2559,9 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		//
 		// OCI Runtime Mode
 		//
-		"ociRun":   c.actionOciRun,   // apptainer run --oci
-		"ociExec":  c.actionOciExec,  // apptainer exec --oci
-		"ociShell": c.actionOciShell, // apptainer shell --oci
+		"ociRun":     c.actionOciRun,     // apptainer run --oci
+		"ociExec":    c.actionOciExec,    // apptainer exec --oci
+		"ociShell":   c.actionOciShell,   // apptainer shell --oci
+		"ociNetwork": c.actionOciNetwork, // apptainer exec --oci --net
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -147,6 +147,11 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			argv: []string{imageRef, "/bin/sh", "-c", "touch $HOME"},
 			exit: 0,
 		},
+		{
+			name: "UTSNamespace",
+			argv: []string{"--uts", imageRef, "true"},
+			exit: 0,
+		},
 	}
 	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {
@@ -216,5 +221,65 @@ func (c actionTests) actionOciShell(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func (c actionTests) actionOciNetwork(t *testing.T) {
+	e2e.EnsureOCIImage(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIImagePath
+
+	tests := []struct {
+		name       string
+		profile    e2e.Profile
+		netType    string
+		expectExit int
+	}{
+		{
+			name:       "InvalidNetworkRoot",
+			profile:    e2e.OCIRootProfile,
+			netType:    "bridge",
+			expectExit: 255,
+		},
+		{
+			name:       "InvalidNetworkUser",
+			profile:    e2e.OCIUserProfile,
+			netType:    "bridge",
+			expectExit: 255,
+		},
+		{
+			name:       "InvalidNetworkFakeroot",
+			profile:    e2e.OCIFakerootProfile,
+			netType:    "bridge",
+			expectExit: 255,
+		},
+		{
+			name:       "NoneNetworkRoot",
+			profile:    e2e.OCIRootProfile,
+			netType:    "none",
+			expectExit: 0,
+		},
+		{
+			name:       "NoneNetworkUser",
+			profile:    e2e.OCIUserProfile,
+			netType:    "none",
+			expectExit: 0,
+		},
+		{
+			name:       "NoneNetworkFakeRoot",
+			profile:    e2e.OCIFakerootProfile,
+			netType:    "none",
+			expectExit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(tt.profile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs("--net", "--network", tt.netType, imageRef, "id"),
+			e2e.ExpectExit(tt.expectExit),
+		)
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -30,6 +30,7 @@ import (
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
 	"github.com/containers/image/v5/types"
 	"github.com/google/uuid"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 var (
@@ -143,25 +144,10 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "NoEval")
 	}
 
-	if lo.Namespaces.IPC {
-		badOpt = append(badOpt, "Namespaces.IPC")
-	}
-	if lo.Namespaces.Net {
-		badOpt = append(badOpt, "Namespaces.Net")
-	}
-	if lo.Namespaces.PID {
-		badOpt = append(badOpt, "Namespaces.PID")
-	}
-	if lo.Namespaces.UTS {
-		badOpt = append(badOpt, "Namespaces.UTS")
-	}
-	if lo.Namespaces.User {
-		badOpt = append(badOpt, "Namespaces.User")
-	}
-
 	// Network always set in CLI layer even if network namespace not requested.
-	if lo.Namespaces.Net && lo.Network != "" {
-		badOpt = append(badOpt, "Network")
+	// We only support isolation at present
+	if lo.Namespaces.Net && lo.Network != "none" {
+		badOpt = append(badOpt, "Network (except none)")
 	}
 
 	if len(lo.NetworkArgs) > 0 {
@@ -313,6 +299,41 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		return err
 	}
 	spec.Process.Cwd = cwd
+
+	if l.cfg.Namespaces.IPC {
+		sylog.Infof("--oci runtime always uses an IPC namespace, ipc flag is redundant.")
+	}
+
+	// Currently supports only `--network none`, i.e. isolated loopback only.
+	// Launcher.checkopts enforces this.
+	if l.cfg.Namespaces.Net {
+		spec.Linux.Namespaces = append(
+			spec.Linux.Namespaces,
+			specs.LinuxNamespace{Type: specs.NetworkNamespace},
+		)
+	}
+
+	if l.cfg.Namespaces.PID {
+		sylog.Infof("--oci runtime always uses a PID namespace, pid flag is redundant.")
+	}
+
+	if l.cfg.Namespaces.User {
+		if os.Getuid() == 0 {
+			spec.Linux.Namespaces = append(
+				spec.Linux.Namespaces,
+				specs.LinuxNamespace{Type: specs.UserNamespace},
+			)
+		} else {
+			sylog.Infof("--oci runtime always uses a user namespace when run as a non-root userns, user flag is redundant.")
+		}
+	}
+
+	if l.cfg.Namespaces.UTS {
+		spec.Linux.Namespaces = append(
+			spec.Linux.Namespaces,
+			specs.LinuxNamespace{Type: specs.UTSNamespace},
+		)
+	}
 
 	mounts, err := l.getMounts()
 	if err != nil {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
@@ -31,6 +32,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/google/uuid"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/term"
 )
 
 var (
@@ -238,6 +240,11 @@ func checkOpts(lo launcher.Options) error {
 // the image config is available, to account for the image's CMD / ENTRYPOINT.
 func (l *Launcher) createSpec() (*specs.Spec, error) {
 	spec := minimalSpec()
+
+	// Override the default Process.Terminal to false if our stdin is not a terminal.
+	if !term.IsTerminal(syscall.Stdin) {
+		spec.Process.Terminal = false
+	}
 
 	spec.Process.User = l.getProcessUser()
 

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -233,6 +233,42 @@ func checkOpts(lo launcher.Options) error {
 	return nil
 }
 
+// createSpec produces an OCI runtime specification, suitable to launch a
+// container. This spec excludes ProcessArgs, as these have to be computed where
+// the image config is available, to account for the image's CMD / ENTRYPOINT.
+func (l *Launcher) createSpec() (*specs.Spec, error) {
+	spec := minimalSpec()
+
+	spec.Process.User = l.getProcessUser()
+
+	// If we are *not* requesting fakeroot, then we need to map the container
+	// uid back to host uid, through the initial fakeroot userns.
+	if !l.cfg.Fakeroot && os.Getuid() != 0 {
+		uidMap, gidMap, err := l.getReverseUserMaps()
+		if err != nil {
+			return nil, err
+		}
+		spec.Linux.UIDMappings = uidMap
+		spec.Linux.GIDMappings = gidMap
+	}
+
+	spec = addNamespaces(spec, l.cfg.Namespaces)
+
+	cwd, err := l.getProcessCwd()
+	if err != nil {
+		return nil, err
+	}
+	spec.Process.Cwd = cwd
+
+	mounts, err := l.getMounts()
+	if err != nil {
+		return nil, err
+	}
+	spec.Mounts = mounts
+
+	return &spec, nil
+}
+
 // Exec will interactively execute a container via the runc low-level runtime.
 // image is a reference to an OCI image, e.g. docker://ubuntu or oci:/tmp/mycontainer
 func (l *Launcher) Exec(ctx context.Context, image string, process string, args []string, instanceName string) error {
@@ -276,70 +312,10 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		}
 	}
 
-	spec, err := MinimalSpec()
+	spec, err := l.createSpec()
 	if err != nil {
-		return err
+		return fmt.Errorf("while creating OCI spec: %w", err)
 	}
-
-	spec.Process.User = l.getProcessUser()
-
-	// If we are *not* requesting fakeroot, then we need to map the container
-	// uid back to host uid, through the initial fakeroot userns.
-	if !l.cfg.Fakeroot && os.Getuid() != 0 {
-		uidMap, gidMap, err := l.getReverseUserMaps()
-		if err != nil {
-			return err
-		}
-		spec.Linux.UIDMappings = uidMap
-		spec.Linux.GIDMappings = gidMap
-	}
-
-	cwd, err := l.getProcessCwd()
-	if err != nil {
-		return err
-	}
-	spec.Process.Cwd = cwd
-
-	if l.cfg.Namespaces.IPC {
-		sylog.Infof("--oci runtime always uses an IPC namespace, ipc flag is redundant.")
-	}
-
-	// Currently supports only `--network none`, i.e. isolated loopback only.
-	// Launcher.checkopts enforces this.
-	if l.cfg.Namespaces.Net {
-		spec.Linux.Namespaces = append(
-			spec.Linux.Namespaces,
-			specs.LinuxNamespace{Type: specs.NetworkNamespace},
-		)
-	}
-
-	if l.cfg.Namespaces.PID {
-		sylog.Infof("--oci runtime always uses a PID namespace, pid flag is redundant.")
-	}
-
-	if l.cfg.Namespaces.User {
-		if os.Getuid() == 0 {
-			spec.Linux.Namespaces = append(
-				spec.Linux.Namespaces,
-				specs.LinuxNamespace{Type: specs.UserNamespace},
-			)
-		} else {
-			sylog.Infof("--oci runtime always uses a user namespace when run as a non-root userns, user flag is redundant.")
-		}
-	}
-
-	if l.cfg.Namespaces.UTS {
-		spec.Linux.Namespaces = append(
-			spec.Linux.Namespaces,
-			specs.LinuxNamespace{Type: specs.UTSNamespace},
-		)
-	}
-
-	mounts, err := l.getMounts()
-	if err != nil {
-		return err
-	}
-	spec.Mounts = mounts
 
 	b, err := native.New(
 		native.OptBundlePath(bundleDir),

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -14,10 +14,14 @@ import (
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
+	"github.com/apptainer/apptainer/internal/pkg/test"
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
 )
 
 func TestNewLauncher(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
 	sc, err := apptainerconf.GetConfig(nil)
 	if err != nil {
 		t.Fatalf("while initializing apptainerconf: %s", err)

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -10,13 +10,30 @@
 package oci
 
 import (
+	"os"
+
+	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
+	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-// MinimalSpec returns an OCI runtime spec with a minimal OCI configuration that
+// defaultNamespaces matching native runtime with --compat / --containall.
+var defaultNamespaces = []specs.LinuxNamespace{
+	{
+		Type: specs.IPCNamespace,
+	},
+	{
+		Type: specs.PIDNamespace,
+	},
+	{
+		Type: specs.MountNamespace,
+	},
+}
+
+// minimalSpec returns an OCI runtime spec with a minimal OCI configuration that
 // is a starting point for compatibility with Apptainer's native launcher in
 // `--compat` mode.
-func MinimalSpec() (*specs.Spec, error) {
+func minimalSpec() specs.Spec {
 	config := specs.Spec{
 		Version: specs.Version,
 	}
@@ -58,20 +75,47 @@ func MinimalSpec() (*specs.Spec, error) {
 	// All mounts are added by the launcher, as it must handle flags.
 	config.Mounts = []specs.Mount{}
 
-	config.Linux = &specs.Linux{
-		// Minimum namespaces matching native runtime with --compat / --containall.
-		// TODO: Additional namespaces to be added by launcher.
-		Namespaces: []specs.LinuxNamespace{
-			{
-				Type: specs.IPCNamespace,
-			},
-			{
-				Type: specs.PIDNamespace,
-			},
-			{
-				Type: specs.MountNamespace,
-			},
-		},
+	config.Linux = &specs.Linux{Namespaces: defaultNamespaces}
+	return config
+}
+
+// addNamespaces adds requested namespace, if appropriate, to an existing spec.
+// It is assumed that spec contains at least the defaultNamespaces.
+func addNamespaces(spec specs.Spec, ns launcher.Namespaces) specs.Spec {
+	if ns.IPC {
+		sylog.Infof("--oci runtime always uses an IPC namespace, ipc flag is redundant.")
 	}
-	return &config, nil
+
+	// Currently supports only `--network none`, i.e. isolated loopback only.
+	// Launcher.checkopts enforces this.
+	if ns.Net {
+		spec.Linux.Namespaces = append(
+			spec.Linux.Namespaces,
+			specs.LinuxNamespace{Type: specs.NetworkNamespace},
+		)
+	}
+
+	if ns.PID {
+		sylog.Infof("--oci runtime always uses a PID namespace, pid flag is redundant.")
+	}
+
+	if ns.User {
+		if os.Getuid() == 0 {
+			spec.Linux.Namespaces = append(
+				spec.Linux.Namespaces,
+				specs.LinuxNamespace{Type: specs.UserNamespace},
+			)
+		} else {
+			sylog.Infof("--oci runtime always uses a user namespace when run as a non-root userns, user flag is redundant.")
+		}
+	}
+
+	if ns.UTS {
+		spec.Linux.Namespaces = append(
+			spec.Linux.Namespaces,
+			specs.LinuxNamespace{Type: specs.UTSNamespace},
+		)
+	}
+
+	return spec
 }

--- a/internal/pkg/runtime/launcher/oci/spec_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
+	"github.com/apptainer/apptainer/internal/pkg/test"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func Test_addNamespaces(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	tests := []struct {
+		name   string
+		ns     launcher.Namespaces
+		wantNS []specs.LinuxNamespace
+	}{
+		{
+			name:   "none",
+			ns:     launcher.Namespaces{},
+			wantNS: defaultNamespaces,
+		},
+		{
+			name:   "pid",
+			ns:     launcher.Namespaces{PID: true},
+			wantNS: defaultNamespaces,
+		},
+		{
+			name:   "ipc",
+			ns:     launcher.Namespaces{IPC: true},
+			wantNS: defaultNamespaces,
+		},
+		{
+			name:   "user",
+			ns:     launcher.Namespaces{User: true},
+			wantNS: defaultNamespaces,
+		},
+		{
+			name:   "net",
+			ns:     launcher.Namespaces{Net: true},
+			wantNS: append(defaultNamespaces, specs.LinuxNamespace{Type: specs.NetworkNamespace}),
+		},
+		{
+			name:   "uts",
+			ns:     launcher.Namespaces{UTS: true},
+			wantNS: append(defaultNamespaces, specs.LinuxNamespace{Type: specs.UTSNamespace}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := minimalSpec()
+			newSpec := addNamespaces(spec, tt.ns)
+			newNS := newSpec.Linux.Namespaces
+			if !reflect.DeepEqual(newNS, tt.wantNS) {
+				t.Errorf("addNamespaces() got %v, want %v", newNS, tt.wantNS)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1157
 which fixed
- sylabs/singularity# 1026

The original PR description was:
> Support namespace request CLI options.
> 
> * --ipc - no effect, always used in --oci mode.
> * --net - only supported with --network none.
> * --pid - no effect, always used in --oci mode.
> * -u / --userns - only effective for root, non-root always uses user ns.
> * --uts
> 
> Add info logging where the option is redundant.