### PR TITLE
feat: oci: enable bind mounts via --bind, --mount, from sylabs 1158

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2563,5 +2563,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociExec":    c.actionOciExec,    // apptainer exec --oci
 		"ociShell":   c.actionOciShell,   // apptainer shell --oci
 		"ociNetwork": c.actionOciNetwork, // apptainer exec --oci --net
+		"ociBinds":   c.actionOciBinds,   // apptainer exec --oci --bind / --mount
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 )
 
 const (
@@ -281,5 +282,212 @@ func (c actionTests) actionOciNetwork(t *testing.T) {
 			e2e.WithArgs("--net", "--network", tt.netType, imageRef, "id"),
 			e2e.ExpectExit(tt.expectExit),
 		)
+	}
+}
+
+//nolint:maintidx
+func (c actionTests) actionOciBinds(t *testing.T) {
+	e2e.EnsureOCIImage(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIImagePath
+
+	workspace, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "bind-workspace-", "")
+	defer e2e.Privileged(cleanup)
+
+	contCanaryDir := "/canary"
+	hostCanaryDir := filepath.Join(workspace, "canary")
+
+	contCanaryFile := "/canary/file"
+	hostCanaryFile := filepath.Join(hostCanaryDir, "file")
+
+	canaryFileBind := hostCanaryFile + ":" + contCanaryFile
+	canaryFileMount := "type=bind,source=" + hostCanaryFile + ",destination=" + contCanaryFile
+	canaryDirBind := hostCanaryDir + ":" + contCanaryDir
+	canaryDirMount := "type=bind,source=" + hostCanaryDir + ",destination=" + contCanaryDir
+
+	createWorkspaceDirs := func(t *testing.T) {
+		e2e.Privileged(func(t *testing.T) {
+			if err := os.RemoveAll(hostCanaryDir); err != nil && !os.IsNotExist(err) {
+				t.Fatalf("failed to delete canary_dir: %s", err)
+			}
+		})(t)
+
+		if err := fs.Mkdir(hostCanaryDir, 0o777); err != nil {
+			t.Fatalf("failed to create canary_dir: %s", err)
+		}
+		if err := fs.Touch(hostCanaryFile); err != nil {
+			t.Fatalf("failed to create canary_file: %s", err)
+		}
+		if err := os.Chmod(hostCanaryFile, 0o777); err != nil {
+			t.Fatalf("failed to apply permissions on canary_file: %s", err)
+		}
+	}
+
+	checkHostFn := func(path string, fn func(string) bool) func(*testing.T) {
+		return func(t *testing.T) {
+			if t.Failed() {
+				return
+			}
+			if !fn(path) {
+				t.Errorf("%s not found on host", path)
+			}
+			if err := os.RemoveAll(path); err != nil {
+				t.Errorf("failed to delete %s: %s", path, err)
+			}
+		}
+	}
+	checkHostFile := func(path string) func(*testing.T) {
+		return checkHostFn(path, fs.IsFile)
+	}
+	checkHostDir := func(path string) func(*testing.T) {
+		return checkHostFn(path, fs.IsDir)
+	}
+
+	tests := []struct {
+		name    string
+		args    []string
+		postRun func(*testing.T)
+		exit    int
+	}{
+		{
+			name: "NonExistentSource",
+			args: []string{
+				"--bind", "/non/existent/source/path",
+				imageRef,
+				"true",
+			},
+			exit: 255,
+		},
+		{
+			name: "RelativeBindDestination",
+			args: []string{
+				"--bind", hostCanaryFile + ":relative",
+				imageRef,
+				"true",
+			},
+			exit: 255,
+		},
+		{
+			name: "SimpleFile",
+			args: []string{
+				"--bind", canaryFileBind,
+				imageRef,
+				"test", "-f", contCanaryFile,
+			},
+			exit: 0,
+		},
+		{
+			name: "SimpleDir",
+			args: []string{
+				"--bind", canaryDirBind,
+				imageRef,
+				"test", "-f", contCanaryFile,
+			},
+			exit: 0,
+		},
+		{
+			name: "HomeOverride",
+			args: []string{
+				"--bind", hostCanaryDir + ":/home",
+				imageRef,
+				"test", "-f", "/home/file",
+			},
+			exit: 0,
+		},
+		{
+			name: "TmpOverride",
+			args: []string{
+				"--bind", hostCanaryDir + ":/tmp",
+				imageRef,
+				"test", "-f", "/tmp/file",
+			},
+			exit: 0,
+		},
+		{
+			name: "VarTmpOverride",
+			args: []string{
+				"--bind", hostCanaryDir + ":/var/tmp",
+				imageRef,
+				"test", "-f", "/var/tmp/file",
+			},
+			exit: 0,
+		},
+		{
+			name: "NestedBindFile",
+			args: []string{
+				"--bind", canaryDirBind,
+				"--bind", hostCanaryFile + ":" + filepath.Join(contCanaryDir, "file2"),
+				imageRef,
+				"test", "-f", "/canary/file2",
+			},
+			postRun: checkHostFile(filepath.Join(hostCanaryDir, "file2")),
+			exit:    0,
+		},
+		{
+			name: "NestedBindDir",
+			args: []string{
+				"--bind", canaryDirBind,
+				"--bind", hostCanaryDir + ":" + filepath.Join(contCanaryDir, "dir2"),
+				imageRef,
+				"test", "-d", "/canary/dir2",
+			},
+			postRun: checkHostDir(filepath.Join(hostCanaryDir, "dir2")),
+			exit:    0,
+		},
+		{
+			name: "MultipleNestedBindDir",
+			args: []string{
+				"--bind", canaryDirBind,
+				"--bind", hostCanaryDir + ":" + filepath.Join(contCanaryDir, "dir2"),
+				"--bind", hostCanaryFile + ":" + filepath.Join(filepath.Join(contCanaryDir, "dir2"), "nested"),
+				imageRef,
+				"test", "-f", "/canary/dir2/nested",
+			},
+			postRun: checkHostFile(filepath.Join(hostCanaryDir, "nested")),
+			exit:    0,
+		},
+		// For the --mount variants we are really just verifying the CLI
+		// acceptance of one or more --mount flags. Translation from --mount
+		// strings to BindPath structs is checked in unit tests. The
+		// functionality of bind mounts of various kinds is already checked
+		// above, with --bind flags. No need to duplicate all of these.
+		{
+			name: "MountSingle",
+			args: []string{
+				"--mount", canaryFileMount,
+				imageRef,
+				"test", "-f", contCanaryFile,
+			},
+			exit: 0,
+		},
+		{
+			name: "MountNested",
+			args: []string{
+				"--mount", canaryDirMount,
+				"--mount", "source=" + hostCanaryFile + ",destination=" + filepath.Join(contCanaryDir, "file3"),
+				imageRef,
+				"test", "-f", "/canary/file3",
+			},
+			postRun: checkHostFile(filepath.Join(hostCanaryDir, "file3")),
+			exit:    0,
+		},
+	}
+
+	for _, profile := range e2e.OCIProfiles {
+		profile := profile
+		createWorkspaceDirs(t)
+
+		t.Run(profile.String(), func(t *testing.T) {
+			for _, tt := range tests {
+				c.env.RunApptainer(
+					t,
+					e2e.AsSubtest(tt.name),
+					e2e.WithProfile(profile),
+					e2e.WithCommand("exec"),
+					e2e.WithArgs(tt.args...),
+					e2e.PostRun(tt.postRun),
+					e2e.ExpectExit(tt.exit),
+				)
+			}
+		})
 	}
 }

--- a/internal/pkg/checkpoint/dmtcp/checkpoint.go
+++ b/internal/pkg/checkpoint/dmtcp/checkpoint.go
@@ -38,11 +38,11 @@ func (e *Entry) CoordinatorPort() (string, error) {
 	return s.Text(), nil
 }
 
-func (e *Entry) BindPath() bind.BindPath {
-	return bind.BindPath{
+func (e *Entry) BindPath() bind.Path {
+	return bind.Path{
 		Source:      e.path,
 		Destination: containerStatepath,
-		Options: map[string]*bind.BindOption{
+		Options: map[string]*bind.Option{
 			"rw": {},
 		},
 	}

--- a/internal/pkg/checkpoint/dmtcp/checkpoint.go
+++ b/internal/pkg/checkpoint/dmtcp/checkpoint.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"path/filepath"
 
-	apptainerConfig "github.com/apptainer/apptainer/pkg/runtime/engine/apptainer/config"
+	"github.com/apptainer/apptainer/pkg/util/bind"
 )
 
 type Entry struct {
@@ -38,11 +38,11 @@ func (e *Entry) CoordinatorPort() (string, error) {
 	return s.Text(), nil
 }
 
-func (e *Entry) BindPath() apptainerConfig.BindPath {
-	return apptainerConfig.BindPath{
+func (e *Entry) BindPath() bind.BindPath {
+	return bind.BindPath{
 		Source:      e.path,
 		Destination: containerStatepath,
-		Options: map[string]*apptainerConfig.BindOption{
+		Options: map[string]*bind.BindOption{
 			"rw": {},
 		},
 	}

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -51,6 +51,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/runtime/engine/config"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
+	"github.com/apptainer/apptainer/pkg/util/bind"
 	"github.com/apptainer/apptainer/pkg/util/capabilities"
 	"github.com/apptainer/apptainer/pkg/util/cryptkey"
 	"github.com/apptainer/apptainer/pkg/util/namespaces"
@@ -611,14 +612,14 @@ func (l *Launcher) useSuid(insideUserNs bool) (useSuid bool) {
 func (l *Launcher) setBinds(fakerootPath string) error {
 	// First get binds from -B/--bind and env var
 	bindPaths := l.cfg.BindPaths
-	binds, err := apptainerConfig.ParseBindPath(bindPaths)
+	binds, err := bind.ParseBindPath(bindPaths)
 	if err != nil {
 		return fmt.Errorf("while parsing bind path: %w", err)
 	}
 	// Now add binds from one or more --mount and env var.
 	// Note that these do not get exported for nested containers
 	for _, m := range l.cfg.Mounts {
-		bps, err := apptainerConfig.ParseMountString(m)
+		bps, err := bind.ParseMountString(m)
 		if err != nil {
 			return fmt.Errorf("while parsing mount %q: %w", m, err)
 		}
@@ -633,7 +634,7 @@ func (l *Launcher) setBinds(fakerootPath string) error {
 			return fmt.Errorf("while getting fakeroot bindpoints: %w", err)
 		}
 		bindPaths = append(bindPaths, fakebindPaths...)
-		fakebinds, err := apptainerConfig.ParseBindPath(fakebindPaths)
+		fakebinds, err := bind.ParseBindPath(fakebindPaths)
 		if err != nil {
 			return fmt.Errorf("while parsing fakeroot bind paths: %w", err)
 		}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -100,15 +100,10 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "NoHome")
 	}
 
-	if len(lo.BindPaths) > 0 {
-		badOpt = append(badOpt, "BindPaths")
-	}
 	if len(lo.FuseMount) > 0 {
 		badOpt = append(badOpt, "FuseMount")
 	}
-	if len(lo.Mounts) > 0 {
-		badOpt = append(badOpt, "Mounts")
-	}
+
 	if len(lo.NoMount) > 0 {
 		badOpt = append(badOpt, "NoMount")
 	}

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -15,8 +15,11 @@ package oci
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/apptainer/apptainer/internal/pkg/util/user"
+	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/apptainer/apptainer/pkg/util/bind"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -25,14 +28,15 @@ func (l *Launcher) getMounts() ([]specs.Mount, error) {
 	mounts := &[]specs.Mount{}
 	l.addProcMount(mounts)
 	l.addSysMount(mounts)
-	err := l.addDevMounts(mounts)
-	if err != nil {
+	if err := l.addDevMounts(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring devpts mount: %w", err)
 	}
 	l.addTmpMounts(mounts)
-	err = l.addHomeMount(mounts)
-	if err != nil {
+	if err := l.addHomeMount(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring home mount: %w", err)
+	}
+	if err := l.addBindMounts(mounts); err != nil {
+		return nil, fmt.Errorf("while configuring bind mount(s): %w", err)
 	}
 	return *mounts, nil
 }
@@ -186,6 +190,63 @@ func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
 				fmt.Sprintf("uid=%d", pw.UID),
 				fmt.Sprintf("gid=%d", pw.GID),
 			},
+		})
+	return nil
+}
+
+func (l *Launcher) addBindMounts(mounts *[]specs.Mount) error {
+	// First get binds from -B/--bind and env var
+	binds, err := bind.ParseBindPath(l.cfg.BindPaths)
+	if err != nil {
+		return fmt.Errorf("while parsing bind path: %w", err)
+	}
+	// Now add binds from one or more --mount and env var.
+	for _, m := range l.cfg.Mounts {
+		bps, err := bind.ParseMountString(m)
+		if err != nil {
+			return fmt.Errorf("while parsing mount %q: %w", m, err)
+		}
+		binds = append(binds, bps...)
+	}
+
+	for _, b := range binds {
+		if !l.apptainerConf.UserBindControl {
+			sylog.Warningf("Ignoring bind mount request: user bind control disabled by system administrator")
+			return nil
+		}
+		if err := addBindMount(mounts, b); err != nil {
+			return fmt.Errorf("while adding mount %q: %w", b.Source, err)
+		}
+	}
+	return nil
+}
+
+func addBindMount(mounts *[]specs.Mount, b bind.BindPath) error {
+	if b.ID() != "" || b.ImageSrc() != "" {
+		return fmt.Errorf("image binds are not yet supported by the OCI runtime")
+	}
+
+	opts := []string{"rbind", "nosuid", "nodev"}
+	if b.Readonly() {
+		opts = append(opts, "ro")
+	}
+
+	absSource, err := filepath.Abs(b.Source)
+	if err != nil {
+		return fmt.Errorf("cannot determine absolute path of %s: %w", b.Source, err)
+	}
+	if _, err := os.Stat(absSource); err != nil {
+		return fmt.Errorf("cannot stat bind source %s: %w", b.Source, err)
+	}
+
+	sylog.Debugf("Adding bind of %s to %s, with options %v", absSource, b.Destination, opts)
+
+	*mounts = append(*mounts,
+		specs.Mount{
+			Source:      absSource,
+			Destination: b.Destination,
+			Type:        "none",
+			Options:     opts,
 		})
 	return nil
 }

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -221,7 +221,7 @@ func (l *Launcher) addBindMounts(mounts *[]specs.Mount) error {
 	return nil
 }
 
-func addBindMount(mounts *[]specs.Mount, b bind.BindPath) error {
+func addBindMount(mounts *[]specs.Mount, b bind.Path) error {
 	if b.ID() != "" || b.ImageSrc() != "" {
 		return fmt.Errorf("image binds are not yet supported by the OCI runtime")
 	}

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -239,6 +239,10 @@ func addBindMount(mounts *[]specs.Mount, b bind.BindPath) error {
 		return fmt.Errorf("cannot stat bind source %s: %w", b.Source, err)
 	}
 
+	if !filepath.IsAbs(b.Destination) {
+		return fmt.Errorf("bind destination %s must be an absolute path", b.Destination)
+	}
+
 	sylog.Debugf("Adding bind of %s to %s, with options %v", absSource, b.Destination, opts)
 
 	*mounts = append(*mounts,

--- a/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
@@ -1,0 +1,268 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// Package oci implements a Launcher that will configure and launch a container
+// with an OCI runtime. It also provides implementations of OCI state
+// transitions that can be called directly, Create/Start/Kill etc.
+package oci
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
+	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
+	"github.com/apptainer/apptainer/pkg/util/bind"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func Test_addBindMount(t *testing.T) {
+	tests := []struct {
+		name       string
+		b          bind.BindPath
+		wantMounts *[]specs.Mount
+		wantErr    bool
+	}{
+		{
+			name: "Valid",
+			b: bind.BindPath{
+				Source:      "/tmp",
+				Destination: "/tmp",
+			},
+			wantMounts: &[]specs.Mount{
+				{
+					Source:      "/tmp",
+					Destination: "/tmp",
+					Type:        "none",
+					Options:     []string{"rbind", "nosuid", "nodev"},
+				},
+			},
+		},
+		{
+			name: "ValidRO",
+			b: bind.BindPath{
+				Source:      "/tmp",
+				Destination: "/tmp",
+				Options:     map[string]*bind.BindOption{"ro": {}},
+			},
+			wantMounts: &[]specs.Mount{
+				{
+					Source:      "/tmp",
+					Destination: "/tmp",
+					Type:        "none",
+					Options:     []string{"rbind", "nosuid", "nodev", "ro"},
+				},
+			},
+		},
+		{
+			name: "BadSource",
+			b: bind.BindPath{
+				Source:      "doesnotexist!",
+				Destination: "/mnt",
+			},
+			wantMounts: &[]specs.Mount{},
+			wantErr:    true,
+		},
+		{
+			name: "ImageID",
+			b: bind.BindPath{
+				Source:      "/myimage.sif",
+				Destination: "/mnt",
+				Options:     map[string]*bind.BindOption{"id": {Value: "4"}},
+			},
+			wantMounts: &[]specs.Mount{},
+			wantErr:    true,
+		},
+		{
+			name: "ImageSrc",
+			b: bind.BindPath{
+				Source:      "/myimage.sif",
+				Destination: "/mnt",
+				Options:     map[string]*bind.BindOption{"img-src": {Value: "/test"}},
+			},
+			wantMounts: &[]specs.Mount{},
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mounts := &[]specs.Mount{}
+			err := addBindMount(mounts, tt.b)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("addBindMount() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(mounts, tt.wantMounts) {
+				t.Errorf("addBindMount() want %v, got %v", tt.wantMounts, mounts)
+			}
+		})
+	}
+}
+
+func TestLauncher_addBindMounts(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        launcher.Options
+		userbind   bool
+		wantMounts *[]specs.Mount
+		wantErr    bool
+	}{
+		{
+			name: "Disabled",
+			cfg: launcher.Options{
+				BindPaths: []string{"/tmp"},
+			},
+			wantMounts: &[]specs.Mount{},
+			wantErr:    false,
+		},
+		{
+			name: "ValidBindSrc",
+			cfg: launcher.Options{
+				BindPaths: []string{"/tmp"},
+			},
+			userbind: true,
+			wantMounts: &[]specs.Mount{
+				{
+					Source:      "/tmp",
+					Destination: "/tmp",
+					Type:        "none",
+					Options:     []string{"rbind", "nosuid", "nodev"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ValidBindSrcDst",
+			cfg: launcher.Options{
+				BindPaths: []string{"/tmp:/mnt"},
+			},
+			userbind: true,
+			wantMounts: &[]specs.Mount{
+				{
+					Source:      "/tmp",
+					Destination: "/mnt",
+					Type:        "none",
+					Options:     []string{"rbind", "nosuid", "nodev"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ValidBindRO",
+			cfg: launcher.Options{
+				BindPaths: []string{"/tmp:/mnt:ro"},
+			},
+			userbind: true,
+			wantMounts: &[]specs.Mount{
+				{
+					Source:      "/tmp",
+					Destination: "/mnt",
+					Type:        "none",
+					Options:     []string{"rbind", "nosuid", "nodev", "ro"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "InvalidBindSrc",
+			cfg: launcher.Options{
+				BindPaths: []string{"!doesnotexist"},
+			},
+			userbind:   true,
+			wantMounts: &[]specs.Mount{},
+			wantErr:    true,
+		},
+		{
+			name: "UnsupportedBindID",
+			cfg: launcher.Options{
+				BindPaths: []string{"my.sif:/mnt:id=2"},
+			},
+			userbind:   true,
+			wantMounts: &[]specs.Mount{},
+			wantErr:    true,
+		},
+		{
+			name: "UnsupportedBindImgSrc",
+			cfg: launcher.Options{
+				BindPaths: []string{"my.sif:/mnt:img-src=/test"},
+			},
+			userbind:   true,
+			wantMounts: &[]specs.Mount{},
+			wantErr:    true,
+		},
+		{
+			name: "ValidMount",
+			cfg: launcher.Options{
+				Mounts: []string{"type=bind,source=/tmp,destination=/mnt"},
+			},
+			userbind: true,
+			wantMounts: &[]specs.Mount{
+				{
+					Source:      "/tmp",
+					Destination: "/mnt",
+					Type:        "none",
+					Options:     []string{"rbind", "nosuid", "nodev"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ValidMountRO",
+			cfg: launcher.Options{
+				Mounts: []string{"type=bind,source=/tmp,destination=/mnt,ro"},
+			},
+			userbind: true,
+			wantMounts: &[]specs.Mount{
+				{
+					Source:      "/tmp",
+					Destination: "/mnt",
+					Type:        "none",
+					Options:     []string{"rbind", "nosuid", "nodev", "ro"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "UnsupportedMountID",
+			cfg: launcher.Options{
+				Mounts: []string{"type=bind,source=my.sif,destination=/mnt,id=2"},
+			},
+			userbind:   true,
+			wantMounts: &[]specs.Mount{},
+			wantErr:    true,
+		},
+		{
+			name: "UnsupportedMountImgSrc",
+			cfg: launcher.Options{
+				Mounts: []string{"type=bind,source=my.sif,destination=/mnt,image-src=/test"},
+			},
+			userbind:   true,
+			wantMounts: &[]specs.Mount{},
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &Launcher{
+				cfg:           tt.cfg,
+				apptainerConf: &apptainerconf.File{},
+			}
+			if tt.userbind {
+				l.apptainerConf.UserBindControl = true
+			}
+			mounts := &[]specs.Mount{}
+			err := l.addBindMounts(mounts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("addBindMount() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(mounts, tt.wantMounts) {
+				t.Errorf("addBindMount() want %v, got %v", tt.wantMounts, mounts)
+			}
+		})
+	}
+}

--- a/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
@@ -25,13 +25,13 @@ import (
 func Test_addBindMount(t *testing.T) {
 	tests := []struct {
 		name       string
-		b          bind.BindPath
+		b          bind.Path
 		wantMounts *[]specs.Mount
 		wantErr    bool
 	}{
 		{
 			name: "Valid",
-			b: bind.BindPath{
+			b: bind.Path{
 				Source:      "/tmp",
 				Destination: "/tmp",
 			},
@@ -46,10 +46,10 @@ func Test_addBindMount(t *testing.T) {
 		},
 		{
 			name: "ValidRO",
-			b: bind.BindPath{
+			b: bind.Path{
 				Source:      "/tmp",
 				Destination: "/tmp",
-				Options:     map[string]*bind.BindOption{"ro": {}},
+				Options:     map[string]*bind.Option{"ro": {}},
 			},
 			wantMounts: &[]specs.Mount{
 				{
@@ -62,7 +62,7 @@ func Test_addBindMount(t *testing.T) {
 		},
 		{
 			name: "BadSource",
-			b: bind.BindPath{
+			b: bind.Path{
 				Source:      "doesnotexist!",
 				Destination: "/mnt",
 			},
@@ -71,7 +71,7 @@ func Test_addBindMount(t *testing.T) {
 		},
 		{
 			name: "RelDest",
-			b: bind.BindPath{
+			b: bind.Path{
 				Source:      "/tmp",
 				Destination: "relative",
 			},
@@ -80,20 +80,20 @@ func Test_addBindMount(t *testing.T) {
 		},
 		{
 			name: "ImageID",
-			b: bind.BindPath{
+			b: bind.Path{
 				Source:      "/myimage.sif",
 				Destination: "/mnt",
-				Options:     map[string]*bind.BindOption{"id": {Value: "4"}},
+				Options:     map[string]*bind.Option{"id": {Value: "4"}},
 			},
 			wantMounts: &[]specs.Mount{},
 			wantErr:    true,
 		},
 		{
 			name: "ImageSrc",
-			b: bind.BindPath{
+			b: bind.Path{
 				Source:      "/myimage.sif",
 				Destination: "/mnt",
-				Options:     map[string]*bind.BindOption{"img-src": {Value: "/test"}},
+				Options:     map[string]*bind.Option{"img-src": {Value: "/test"}},
 			},
 			wantMounts: &[]specs.Mount{},
 			wantErr:    true,

--- a/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
@@ -70,6 +70,15 @@ func Test_addBindMount(t *testing.T) {
 			wantErr:    true,
 		},
 		{
+			name: "RelDest",
+			b: bind.BindPath{
+				Source:      "/tmp",
+				Destination: "relative",
+			},
+			wantMounts: &[]specs.Mount{},
+			wantErr:    true,
+		},
+		{
 			name: "ImageID",
 			b: bind.BindPath{
 				Source:      "/myimage.sif",
@@ -172,6 +181,15 @@ func TestLauncher_addBindMounts(t *testing.T) {
 			name: "InvalidBindSrc",
 			cfg: launcher.Options{
 				BindPaths: []string{"!doesnotexist"},
+			},
+			userbind:   true,
+			wantMounts: &[]specs.Mount{},
+			wantErr:    true,
+		},
+		{
+			name: "RelBindDst",
+			cfg: launcher.Options{
+				BindPaths: []string{"/tmp:relative"},
 			},
 			userbind:   true,
 			wantMounts: &[]specs.Mount{},

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -80,7 +80,7 @@ type JSONConfig struct {
 	LibrariesPath         []string          `json:"librariesPath,omitempty"`
 	FuseMount             []FuseMount       `json:"fuseMount,omitempty"`
 	ImageList             []image.Image     `json:"imageList,omitempty"`
-	BindPath              []bind.BindPath   `json:"bindpath,omitempty"`
+	BindPath              []bind.Path       `json:"bindpath,omitempty"`
 	ApptainerEnv          map[string]string `json:"apptainerEnv,omitempty"`
 	UnixSocketPair        [2]int            `json:"unixSocketPair,omitempty"`
 	OpenFd                []int             `json:"openFd,omitempty"`
@@ -293,12 +293,12 @@ func (e *EngineConfig) GetCustomHome() bool {
 }
 
 // SetBindPath sets the paths to bind into container.
-func (e *EngineConfig) SetBindPath(bindpath []bind.BindPath) {
+func (e *EngineConfig) SetBindPath(bindpath []bind.Path) {
 	e.JSON.BindPath = bindpath
 }
 
 // GetBindPath retrieves the bind paths.
-func (e *EngineConfig) GetBindPath() []bind.BindPath {
+func (e *EngineConfig) GetBindPath() []bind.Path {
 	return e.JSON.BindPath
 }
 

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci"
 	"github.com/apptainer/apptainer/pkg/image"
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
+	"github.com/apptainer/apptainer/pkg/util/bind"
 )
 
 // Name is the name of the runtime.
@@ -79,7 +80,7 @@ type JSONConfig struct {
 	LibrariesPath         []string          `json:"librariesPath,omitempty"`
 	FuseMount             []FuseMount       `json:"fuseMount,omitempty"`
 	ImageList             []image.Image     `json:"imageList,omitempty"`
-	BindPath              []BindPath        `json:"bindpath,omitempty"`
+	BindPath              []bind.BindPath   `json:"bindpath,omitempty"`
 	ApptainerEnv          map[string]string `json:"apptainerEnv,omitempty"`
 	UnixSocketPair        [2]int            `json:"unixSocketPair,omitempty"`
 	OpenFd                []int             `json:"openFd,omitempty"`
@@ -292,12 +293,12 @@ func (e *EngineConfig) GetCustomHome() bool {
 }
 
 // SetBindPath sets the paths to bind into container.
-func (e *EngineConfig) SetBindPath(bindpath []BindPath) {
+func (e *EngineConfig) SetBindPath(bindpath []bind.BindPath) {
 	e.JSON.BindPath = bindpath
 }
 
 // GetBindPath retrieves the bind paths.
-func (e *EngineConfig) GetBindPath() []BindPath {
+func (e *EngineConfig) GetBindPath() []bind.BindPath {
 	return e.JSON.BindPath
 }
 

--- a/pkg/util/bind/bind.go
+++ b/pkg/util/bind/bind.go
@@ -1,9 +1,9 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package apptainer
+package bind
 
 import (
 	"fmt"

--- a/pkg/util/bind/bind.go
+++ b/pkg/util/bind/bind.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 )
 
-// BindOption represents a bind option with its associated
+// Option represents a bind option with its associated
 // value if any.
-type BindOption struct {
+type Option struct {
 	Value string `json:"value,omitempty"`
 }
 
@@ -31,17 +31,17 @@ var bindOptions = map[string]bool{
 	"id":        valueOption,
 }
 
-// BindPath stores a parsed bind path specification. Source and Destination
+// Path stores a parsed bind path specification. Source and Destination
 // paths are required.
-type BindPath struct {
-	Source      string                 `json:"source"`
-	Destination string                 `json:"destination"`
-	Options     map[string]*BindOption `json:"options"`
+type Path struct {
+	Source      string             `json:"source"`
+	Destination string             `json:"destination"`
+	Options     map[string]*Option `json:"options"`
 }
 
 // ImageSrc returns the value of the option image-src for a BindPath, or an
 // empty string if the option wasn't set.
-func (b *BindPath) ImageSrc() string {
+func (b *Path) ImageSrc() string {
 	if b.Options != nil && b.Options["image-src"] != nil {
 		src := b.Options["image-src"].Value
 		if src == "" {
@@ -54,7 +54,7 @@ func (b *BindPath) ImageSrc() string {
 
 // ID returns the value of the option id for a BindPath, or an empty string if
 // the option wasn't set.
-func (b *BindPath) ID() string {
+func (b *Path) ID() string {
 	if b.Options != nil && b.Options["id"] != nil {
 		return b.Options["id"].Value
 	}
@@ -62,7 +62,7 @@ func (b *BindPath) ID() string {
 }
 
 // Readonly returns true if the ro option was set for a BindPath.
-func (b *BindPath) Readonly() bool {
+func (b *Path) Readonly() bool {
 	return b.Options != nil && b.Options["ro"] != nil
 }
 
@@ -70,8 +70,8 @@ func (b *BindPath) Readonly() bool {
 // more (comma separated) bind paths in src[:dst[:options]] format, and
 // returns all encountered bind paths as a slice. Options may be simple
 // flags, e.g. 'rw', or take a value, e.g. 'id=2'.
-func ParseBindPath(paths []string) ([]BindPath, error) {
-	var binds []BindPath
+func ParseBindPath(paths []string) ([]Path, error) {
+	var binds []Path
 
 	// there is a better regular expression to handle
 	// that directly without all the logic below ...
@@ -216,8 +216,8 @@ func splitBy(str string, sep byte) []string {
 
 // newBindPath returns BindPath record based on the provided bind
 // string argument and ensures that the options are valid.
-func newBindPath(bind string) (BindPath, error) {
-	var bp BindPath
+func newBindPath(bind string) (Path, error) {
+	var bp Path
 
 	splitted := splitBy(bind, ':')
 
@@ -233,17 +233,17 @@ func newBindPath(bind string) (BindPath, error) {
 	}
 
 	if len(splitted) > 2 {
-		bp.Options = make(map[string]*BindOption)
+		bp.Options = make(map[string]*Option)
 
 		for _, value := range strings.Split(splitted[2], ",") {
 			valid := false
 			for optName, isFlag := range bindOptions {
 				if isFlag && optName == value {
-					bp.Options[optName] = &BindOption{}
+					bp.Options[optName] = &Option{}
 					valid = true
 					break
 				} else if strings.HasPrefix(value, optName+"=") {
-					bp.Options[optName] = &BindOption{Value: value[len(optName+"="):]}
+					bp.Options[optName] = &Option{Value: value[len(optName+"="):]}
 					valid = true
 					break
 				}

--- a/pkg/util/bind/bind_test.go
+++ b/pkg/util/bind/bind_test.go
@@ -14,13 +14,13 @@ func TestParseBindPath(t *testing.T) {
 	tests := []struct {
 		name      string
 		bindpaths []string
-		want      []BindPath
+		want      []Path
 		wantErr   bool
 	}{
 		{
 			name:      "srcOnly",
 			bindpaths: []string{"/opt"},
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/opt",
@@ -30,7 +30,7 @@ func TestParseBindPath(t *testing.T) {
 		{
 			name:      "srcOnlyMultiple",
 			bindpaths: []string{"/opt,/tmp"},
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/opt",
@@ -44,7 +44,7 @@ func TestParseBindPath(t *testing.T) {
 		{
 			name:      "srcDst",
 			bindpaths: []string{"/opt:/other"},
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/other",
@@ -54,7 +54,7 @@ func TestParseBindPath(t *testing.T) {
 		{
 			name:      "srcDstMultiple",
 			bindpaths: []string{"/opt:/other,/tmp:/other2,"},
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/other",
@@ -68,11 +68,11 @@ func TestParseBindPath(t *testing.T) {
 		{
 			name:      "srcDstRO",
 			bindpaths: []string{"/opt:/other:ro"},
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/other",
-					Options: map[string]*BindOption{
+					Options: map[string]*Option{
 						"ro": {},
 					},
 				},
@@ -81,18 +81,18 @@ func TestParseBindPath(t *testing.T) {
 		{
 			name:      "srcDstROMultiple",
 			bindpaths: []string{"/opt:/other:ro,/tmp:/other2:ro"},
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/other",
-					Options: map[string]*BindOption{
+					Options: map[string]*Option{
 						"ro": {},
 					},
 				},
 				{
 					Source:      "/tmp",
 					Destination: "/other2",
-					Options: map[string]*BindOption{
+					Options: map[string]*Option{
 						"ro": {},
 					},
 				},
@@ -103,11 +103,11 @@ func TestParseBindPath(t *testing.T) {
 			// parsing multiple simple options.
 			name:      "srcDstRORW",
 			bindpaths: []string{"/opt:/other:ro,rw"},
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/other",
-					Options: map[string]*BindOption{
+					Options: map[string]*Option{
 						"ro": {},
 						"rw": {},
 					},
@@ -121,11 +121,11 @@ func TestParseBindPath(t *testing.T) {
 			// delimiting an additional option, vs an additional bind.
 			name:      "srcDstRORWMultiple",
 			bindpaths: []string{"/opt:/other:ro,rw,/tmp:/other2:ro,rw"},
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/other",
-					Options: map[string]*BindOption{
+					Options: map[string]*Option{
 						"ro": {},
 						"rw": {},
 					},
@@ -133,7 +133,7 @@ func TestParseBindPath(t *testing.T) {
 				{
 					Source:      "/tmp",
 					Destination: "/other2",
-					Options: map[string]*BindOption{
+					Options: map[string]*Option{
 						"ro": {},
 						"rw": {},
 					},
@@ -143,11 +143,11 @@ func TestParseBindPath(t *testing.T) {
 		{
 			name:      "srcDstImageSrc",
 			bindpaths: []string{"test.sif:/other:image-src=/opt"},
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "test.sif",
 					Destination: "/other",
-					Options: map[string]*BindOption{
+					Options: map[string]*Option{
 						"image-src": {"/opt"},
 					},
 				},
@@ -157,17 +157,17 @@ func TestParseBindPath(t *testing.T) {
 			// Can't use image-src without a value
 			name:      "srcDstImageSrcNoVal",
 			bindpaths: []string{"test.sif:/other:image-src"},
-			want:      []BindPath{},
+			want:      []Path{},
 			wantErr:   true,
 		},
 		{
 			name:      "srcDstId",
 			bindpaths: []string{"test.sif:/other:image-src=/opt,id=2"},
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "test.sif",
 					Destination: "/other",
-					Options: map[string]*BindOption{
+					Options: map[string]*Option{
 						"image-src": {"/opt"},
 						"id":        {"2"},
 					},
@@ -177,13 +177,13 @@ func TestParseBindPath(t *testing.T) {
 		{
 			name:      "invalidOption",
 			bindpaths: []string{"/opt:/other:invalid"},
-			want:      []BindPath{},
+			want:      []Path{},
 			wantErr:   true,
 		},
 		{
 			name:      "invalidSpec",
 			bindpaths: []string{"/opt:/other:rw:invalid"},
-			want:      []BindPath{},
+			want:      []Path{},
 			wantErr:   true,
 		},
 	}

--- a/pkg/util/bind/bind_test.go
+++ b/pkg/util/bind/bind_test.go
@@ -1,9 +1,9 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package apptainer
+package bind
 
 import (
 	"reflect"

--- a/pkg/util/bind/mount.go
+++ b/pkg/util/bind/mount.go
@@ -29,17 +29,17 @@ import (
 //
 // We only support type=bind at present, so assume this if type is missing and
 // error for other types.
-func ParseMountString(mount string) (bindPaths []BindPath, err error) {
+func ParseMountString(mount string) (bindPaths []Path, err error) {
 	r := strings.NewReader(mount)
 	c := csv.NewReader(r)
 	records, err := c.ReadAll()
 	if err != nil {
-		return []BindPath{}, fmt.Errorf("error parsing mount: %v", err)
+		return []Path{}, fmt.Errorf("error parsing mount: %v", err)
 	}
 
 	for _, r := range records {
-		bp := BindPath{
-			Options: map[string]*BindOption{},
+		bp := Path{
+			Options: map[string]*Option{},
 		}
 
 		for _, f := range r {
@@ -54,41 +54,41 @@ func ParseMountString(mount string) (bindPaths []BindPath, err error) {
 			// TODO - Eventually support volume and tmpfs? Requires structural changes to engine mount functionality.
 			case "type":
 				if val != "bind" {
-					return []BindPath{}, fmt.Errorf("unsupported mount type %q, only 'bind' is supported", val)
+					return []Path{}, fmt.Errorf("unsupported mount type %q, only 'bind' is supported", val)
 				}
 			case "source", "src":
 				if val == "" {
-					return []BindPath{}, fmt.Errorf("mount source cannot be empty")
+					return []Path{}, fmt.Errorf("mount source cannot be empty")
 				}
 				bp.Source = val
 			case "destination", "dst", "target":
 				if val == "" {
-					return []BindPath{}, fmt.Errorf("mount destination cannot be empty")
+					return []Path{}, fmt.Errorf("mount destination cannot be empty")
 				}
 				bp.Destination = val
 			case "ro", "readonly":
-				bp.Options["ro"] = &BindOption{}
+				bp.Options["ro"] = &Option{}
 			// Apptainer only - directory inside an image file source to mount from
 			case "image-src":
 				if val == "" {
-					return []BindPath{}, fmt.Errorf("img-src cannot be empty")
+					return []Path{}, fmt.Errorf("img-src cannot be empty")
 				}
-				bp.Options["image-src"] = &BindOption{Value: val}
+				bp.Options["image-src"] = &Option{Value: val}
 			// Apptainer only - id of the descriptor in a SIF image source to mount from
 			case "id":
 				if val == "" {
-					return []BindPath{}, fmt.Errorf("id cannot be empty")
+					return []Path{}, fmt.Errorf("id cannot be empty")
 				}
-				bp.Options["id"] = &BindOption{Value: val}
+				bp.Options["id"] = &Option{Value: val}
 			case "bind-propagation":
-				return []BindPath{}, fmt.Errorf("bind-propagation not supported for individual mounts, check apptainer.conf for global setting")
+				return []Path{}, fmt.Errorf("bind-propagation not supported for individual mounts, check apptainer.conf for global setting")
 			default:
-				return []BindPath{}, fmt.Errorf("invalid key %q in mount specification", key)
+				return []Path{}, fmt.Errorf("invalid key %q in mount specification", key)
 			}
 		}
 
 		if bp.Source == "" || bp.Destination == "" {
-			return []BindPath{}, fmt.Errorf("mounts must specify a source and a destination")
+			return []Path{}, fmt.Errorf("mounts must specify a source and a destination")
 		}
 		bindPaths = append(bindPaths, bp)
 	}

--- a/pkg/util/bind/mount.go
+++ b/pkg/util/bind/mount.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package apptainer
+package bind
 
 import (
 	"encoding/csv"

--- a/pkg/util/bind/mount_test.go
+++ b/pkg/util/bind/mount_test.go
@@ -14,53 +14,53 @@ func TestParseMountString(t *testing.T) {
 	tests := []struct {
 		name        string
 		mountString string
-		want        []BindPath
+		want        []Path
 		wantErr     bool
 	}{
 		{
 			name:        "sourceOnly",
 			mountString: "type=bind,source=/opt",
-			want:        []BindPath{},
+			want:        []Path{},
 			wantErr:     true,
 		},
 		{
 			name:        "destinationOnly",
 			mountString: "type=bind,destination=/opt",
-			want:        []BindPath{},
+			want:        []Path{},
 			wantErr:     true,
 		},
 		{
 			name:        "emptySource",
 			mountString: "type=bind,source=,destination=/opt",
-			want:        []BindPath{},
+			want:        []Path{},
 			wantErr:     true,
 		},
 		{
 			name:        "emptyDestination",
 			mountString: "type=bind,source=/opt,destination=",
-			want:        []BindPath{},
+			want:        []Path{},
 			wantErr:     true,
 		},
 		{
 			name:        "invalidType",
 			mountString: "type=potato,source=/opt,destination=/opt",
-			want:        []BindPath{},
+			want:        []Path{},
 			wantErr:     true,
 		},
 		{
 			name:        "invalidField",
 			mountString: "type=bind,source=/opt,destination=/opt,color=turquoise",
-			want:        []BindPath{},
+			want:        []Path{},
 			wantErr:     true,
 		},
 		{
 			name:        "simple",
 			mountString: "type=bind,source=/opt,destination=/opt",
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/opt",
-					Options:     map[string]*BindOption{},
+					Options:     map[string]*Option{},
 				},
 			},
 			wantErr: false,
@@ -68,11 +68,11 @@ func TestParseMountString(t *testing.T) {
 		{
 			name:        "simpleSrc",
 			mountString: "type=bind,src=/opt,destination=/opt",
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/opt",
-					Options:     map[string]*BindOption{},
+					Options:     map[string]*Option{},
 				},
 			},
 			wantErr: false,
@@ -80,11 +80,11 @@ func TestParseMountString(t *testing.T) {
 		{
 			name:        "simpleDst",
 			mountString: "type=bind,source=/opt,dst=/opt",
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/opt",
-					Options:     map[string]*BindOption{},
+					Options:     map[string]*Option{},
 				},
 			},
 			wantErr: false,
@@ -92,11 +92,11 @@ func TestParseMountString(t *testing.T) {
 		{
 			name:        "simpleTarget",
 			mountString: "type=bind,source=/opt,target=/opt",
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/opt",
-					Options:     map[string]*BindOption{},
+					Options:     map[string]*Option{},
 				},
 			},
 			wantErr: false,
@@ -104,11 +104,11 @@ func TestParseMountString(t *testing.T) {
 		{
 			name:        "noType",
 			mountString: "source=/opt,destination=/opt",
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/opt",
-					Options:     map[string]*BindOption{},
+					Options:     map[string]*Option{},
 				},
 			},
 			wantErr: false,
@@ -116,11 +116,11 @@ func TestParseMountString(t *testing.T) {
 		{
 			name:        "ro",
 			mountString: "type=bind,source=/opt,destination=/opt,ro",
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/opt",
-					Options: map[string]*BindOption{
+					Options: map[string]*Option{
 						"ro": {},
 					},
 				},
@@ -130,11 +130,11 @@ func TestParseMountString(t *testing.T) {
 		{
 			name:        "readonly",
 			mountString: "type=bind,source=/opt,destination=/opt,readonly",
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/opt",
-					Options: map[string]*BindOption{
+					Options: map[string]*Option{
 						"ro": {},
 					},
 				},
@@ -144,11 +144,11 @@ func TestParseMountString(t *testing.T) {
 		{
 			name:        "imagesrc",
 			mountString: "type=bind,source=test.sif,destination=/opt,image-src=/opt",
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "test.sif",
 					Destination: "/opt",
-					Options: map[string]*BindOption{
+					Options: map[string]*Option{
 						"image-src": {Value: "/opt"},
 					},
 				},
@@ -158,23 +158,23 @@ func TestParseMountString(t *testing.T) {
 		{
 			name:        "imagesrcNoValue",
 			mountString: "type=bind,source=test.sif,destination=/opt,image-src",
-			want:        []BindPath{},
+			want:        []Path{},
 			wantErr:     true,
 		},
 		{
 			name:        "imagesrcEmpty",
 			mountString: "type=bind,source=test.sif,destination=/opt,image-src=",
-			want:        []BindPath{},
+			want:        []Path{},
 			wantErr:     true,
 		},
 		{
 			name:        "id",
 			mountString: "type=bind,source=test.sif,destination=/opt,image-src=/opt,id=2",
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "test.sif",
 					Destination: "/opt",
-					Options: map[string]*BindOption{
+					Options: map[string]*Option{
 						"image-src": {Value: "/opt"},
 						"id":        {Value: "2"},
 					},
@@ -185,29 +185,29 @@ func TestParseMountString(t *testing.T) {
 		{
 			name:        "idNoValue",
 			mountString: "type=bind,source=test.sif,destination=/opt,image-src=/opt,id",
-			want:        []BindPath{},
+			want:        []Path{},
 			wantErr:     true,
 		},
 		{
 			name:        "idEmpty",
 			mountString: "type=bind,source=test.sif,destination=/opt,image-src=/opt,id=",
-			want:        []BindPath{},
+			want:        []Path{},
 			wantErr:     true,
 		},
 		{
 			name:        "bindpropagation",
 			mountString: "type=bind,source=/opt,destination=/opt,bind-propagation=shared",
-			want:        []BindPath{},
+			want:        []Path{},
 			wantErr:     true,
 		},
 		{
 			name:        "csvEscaped",
 			mountString: `type=bind,"source=/comma,dir","destination=/quote""dir"`,
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/comma,dir",
 					Destination: "/quote\"dir",
-					Options:     map[string]*BindOption{},
+					Options:     map[string]*Option{},
 				},
 			},
 			wantErr: false,
@@ -215,16 +215,16 @@ func TestParseMountString(t *testing.T) {
 		{
 			name:        "multiple",
 			mountString: "type=bind,source=/opt,destination=/opt\ntype=bind,source=/srv,destination=/srv",
-			want: []BindPath{
+			want: []Path{
 				{
 					Source:      "/opt",
 					Destination: "/opt",
-					Options:     map[string]*BindOption{},
+					Options:     map[string]*Option{},
 				},
 				{
 					Source:      "/srv",
 					Destination: "/srv",
-					Options:     map[string]*BindOption{},
+					Options:     map[string]*Option{},
 				},
 			},
 			wantErr: false,

--- a/pkg/util/bind/mount_test.go
+++ b/pkg/util/bind/mount_test.go
@@ -1,9 +1,9 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package apptainer
+package bind
 
 import (
 	"reflect"


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1158
 which fixed
- sylabs/singularity# 1027
- sylabs/singularity# 1028

The original PR description was:
> Implement support for bind mounts (rw & ro) specified using -B/--bind and --mount on the singularity command line.