### PR TITLE
feat: oci: add APPTAINERENV_ handling for --oci mode, from sylabs 1169

### DIFF
--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -647,6 +647,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		//
 		// --oci mode
 		//
-		"oci environment option": c.ociEnvOption,
+		"oci environment apptainerenv": c.ociApptainerEnv,
+		"oci environment option":       c.ociEnvOption,
 	}
 }

--- a/e2e/env/oci.go
+++ b/e2e/env/oci.go
@@ -16,6 +16,73 @@ import (
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
 )
 
+func (c ctx) ociApptainerEnv(t *testing.T) {
+	e2e.EnsureOCIImage(t, c.env)
+	defaultImage := "oci-archive:" + c.env.OCIImagePath
+
+	// Append or prepend this path.
+	partialPath := "/foo"
+
+	// Overwrite the path with this one.
+	overwrittenPath := "/usr/bin:/bin"
+
+	// A path with a trailing comma
+	trailingCommaPath := "/usr/bin:/bin,"
+
+	tests := []struct {
+		name  string
+		image string
+		path  string
+		env   []string
+	}{
+		{
+			name:  "DefaultPath",
+			image: defaultImage,
+			path:  defaultPath,
+			env:   []string{},
+		},
+		{
+			name:  "AppendToDefaultPath",
+			image: defaultImage,
+			path:  defaultPath + ":" + partialPath,
+			env:   []string{"APPTAINERENV_APPEND_PATH=/foo"},
+		},
+		{
+			name:  "PrependToDefaultPath",
+			image: defaultImage,
+			path:  partialPath + ":" + defaultPath,
+			env:   []string{"APPTAINERENV_PREPEND_PATH=/foo"},
+		},
+		{
+			name:  "OverwriteDefaultPath",
+			image: defaultImage,
+			path:  overwrittenPath,
+			env:   []string{"APPTAINERENV_PATH=" + overwrittenPath},
+		},
+		{
+			name:  "OverwriteTrailingCommaPath",
+			image: defaultImage,
+			path:  trailingCommaPath,
+			env:   []string{"APPTAINERENV_PATH=" + trailingCommaPath},
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.OCIUserProfile),
+			e2e.WithCommand("exec"),
+			e2e.WithEnv(tt.env),
+			e2e.WithArgs(tt.image, "/bin/sh", "-c", "echo $PATH"),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.ExactMatch, tt.path),
+			),
+		)
+	}
+}
+
 func (c ctx) ociEnvOption(t *testing.T) {
 	e2e.EnsureOCIImage(t, c.env)
 	defaultImage := "oci-archive:" + c.env.OCIImagePath

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -320,9 +320,11 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	// Assemble the runtime & user-requested environment, which will be merged
 	// with the image ENV and set in the container at runtime.
 	rtEnv := defaultEnv(image, bundleDir)
+	// APPTAINERENV_
+	rtEnv = mergeMap(rtEnv, apptainerEnvMap())
 	// --env flag
 	rtEnv = mergeMap(rtEnv, l.cfg.Env)
-	// TODO - --env-file, APPTAINERENV_
+	// TODO - --env-file
 
 	b, err := native.New(
 		native.OptBundlePath(bundleDir),

--- a/internal/pkg/runtime/launcher/oci/process_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestApptainerEnvMap(t *testing.T) {
+	tests := []struct {
+		name   string
+		setEnv map[string]string
+		want   map[string]string
+	}{
+		{
+			name:   "None",
+			setEnv: map[string]string{},
+			want:   map[string]string{},
+		},
+		{
+			name:   "NonPrefixed",
+			setEnv: map[string]string{"FOO": "bar"},
+			want:   map[string]string{},
+		},
+		{
+			name:   "PrefixedSingle",
+			setEnv: map[string]string{"APPTAINERENV_FOO": "bar"},
+			want:   map[string]string{"FOO": "bar"},
+		},
+		{
+			name: "PrefixedMultiple",
+			setEnv: map[string]string{
+				"APPTAINERENV_FOO": "bar",
+				"APPTAINERENV_ABC": "123",
+			},
+			want: map[string]string{
+				"FOO": "bar",
+				"ABC": "123",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.setEnv {
+				os.Setenv(k, v)
+				t.Cleanup(func() {
+					os.Unsetenv(k)
+				})
+			}
+			if got := apptainerEnvMap(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("apptainerEnvMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1169
 which fixed
- sylabs/singularity# 1031

The original PR description was:
> Pass SINGULARITYENV_ prefixed environment variables into container in --oci mode.