### PR TITLE
feat: oci: enable --env-file in --oci mode, from sylabs 1170

### DIFF
--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -649,5 +649,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		//
 		"oci environment apptainerenv": c.ociApptainerEnv,
 		"oci environment option":       c.ociEnvOption,
+		"oci environment file":         c.ociEnvFile,
 	}
 }

--- a/e2e/env/oci.go
+++ b/e2e/env/oci.go
@@ -10,6 +10,8 @@
 package apptainerenv
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -177,6 +179,108 @@ func (c ctx) ociEnvOption(t *testing.T) {
 			args = append(args, "--env", strings.Join(tt.envOpt, ","))
 		}
 		args = append(args, tt.image, "/bin/sh", "-c", "echo \"${"+tt.matchEnv+"}\"")
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.OCIUserProfile),
+			e2e.WithCommand("exec"),
+			e2e.WithEnv(tt.hostEnv),
+			e2e.WithArgs(args...),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.ExactMatch, tt.matchVal),
+			),
+		)
+	}
+}
+
+func (c ctx) ociEnvFile(t *testing.T) {
+	e2e.EnsureOCIImage(t, c.env)
+	defaultImage := "oci-archive:" + c.env.OCIImagePath
+
+	dir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "envfile-", "")
+	defer cleanup(t)
+	p := filepath.Join(dir, "env.file")
+
+	tests := []struct {
+		name     string
+		image    string
+		envFile  string
+		envOpt   []string
+		hostEnv  []string
+		matchEnv string
+		matchVal string
+	}{
+		{
+			name:     "DefaultPathOverride",
+			image:    defaultImage,
+			envFile:  "PATH=/",
+			matchEnv: "PATH",
+			matchVal: "/",
+		},
+		{
+			name:     "DefaultPathOverrideEnvOptionPrecedence",
+			image:    defaultImage,
+			envOpt:   []string{"PATH=/etc"},
+			envFile:  "PATH=/",
+			matchEnv: "PATH",
+			matchVal: "/etc",
+		},
+		{
+			name:     "DefaultPathOverrideEnvOptionPrecedence",
+			image:    defaultImage,
+			envOpt:   []string{"PATH=/etc"},
+			envFile:  "PATH=/",
+			matchEnv: "PATH",
+			matchVal: "/etc",
+		},
+		{
+			name:     "AppendDefaultPath",
+			image:    defaultImage,
+			envFile:  "APPEND_PATH=/",
+			matchEnv: "PATH",
+			matchVal: defaultPath + ":/",
+		},
+		{
+			name:     "PrependDefaultPath",
+			image:    defaultImage,
+			envFile:  "PREPEND_PATH=/",
+			matchEnv: "PATH",
+			matchVal: "/:" + defaultPath,
+		},
+		{
+			name:     "DefaultLdLibraryPath",
+			image:    defaultImage,
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: apptainerLibs,
+		},
+		{
+			name:     "CustomLdLibraryPath",
+			image:    defaultImage,
+			envFile:  "LD_LIBRARY_PATH=/foo",
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo:" + apptainerLibs,
+		},
+		{
+			name:     "CustomTrailingCommaPath",
+			image:    defaultImage,
+			envFile:  "LD_LIBRARY_PATH=/foo,",
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo,:" + apptainerLibs,
+		},
+	}
+
+	for _, tt := range tests {
+		args := make([]string, 0)
+		if tt.envOpt != nil {
+			args = append(args, "--env", strings.Join(tt.envOpt, ","))
+		}
+		if tt.envFile != "" {
+			os.WriteFile(p, []byte(tt.envFile), 0o644)
+			args = append(args, "--env-file", p)
+		}
+		args = append(args, tt.image, "/bin/sh", "-c", "echo $"+tt.matchEnv)
+
 		c.env.RunApptainer(
 			t,
 			e2e.AsSubtest(tt.name),

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -953,7 +953,7 @@ func (l *Launcher) setEnvVars(ctx context.Context, args []string) error {
 
 		content, err := os.ReadFile(l.cfg.EnvFile)
 		if err != nil {
-			return fmt.Errorf("could not read %q environment file: %w", l.cfg.EnvFile, err)
+			return fmt.Errorf("could not read environment file %q: %w", l.cfg.EnvFile, err)
 		}
 
 		envvars, err := interpreter.EvaluateEnv(ctx, content, args, currentEnv)
@@ -968,12 +968,12 @@ func (l *Launcher) setEnvVars(ctx context.Context, args []string) error {
 		for _, envar := range envvars {
 			e := strings.SplitN(envar, "=", 2)
 			if len(e) != 2 {
-				sylog.Warningf("Ignore environment variable %q: '=' is missing", envar)
+				sylog.Warningf("Ignored environment variable %q: '=' is missing", envar)
 				continue
 			}
 			// Ensure we don't overwrite --env variables with environment file
 			if _, ok := l.cfg.Env[e[0]]; ok {
-				sylog.Warningf("Ignore environment variable %s from %s: override from --env", e[0], l.cfg.EnvFile)
+				sylog.Warningf("Ignored environment variable %s from %s: override from --env", e[0], l.cfg.EnvFile)
 			} else {
 				l.cfg.Env[e[0]] = e[1]
 			}

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -10,12 +10,14 @@
 package oci
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/apptainer/apptainer/internal/pkg/fakeroot"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
+	"github.com/apptainer/apptainer/internal/pkg/util/shell/interpreter"
 	"github.com/apptainer/apptainer/internal/pkg/util/user"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -169,4 +171,40 @@ func apptainerEnvMap() map[string]string {
 	}
 
 	return apptainerEnv
+}
+
+// envFileMap returns a map of KEY=VAL env vars from an environment file
+func envFileMap(ctx context.Context, f string) (map[string]string, error) {
+	envMap := map[string]string{}
+
+	content, err := os.ReadFile(f)
+	if err != nil {
+		return envMap, fmt.Errorf("could not read environment file %q: %w", f, err)
+	}
+
+	// Use the embedded shell interpreter to evaluate the env file, with an empty starting environment.
+	// Shell takes care of comments, quoting etc. for us and keeps compatibility with native runtime.
+	env, err := interpreter.EvaluateEnv(ctx, content, []string{}, []string{})
+	if err != nil {
+		return envMap, fmt.Errorf("while processing %s: %w", f, err)
+	}
+
+	for _, envVar := range env {
+		parts := strings.SplitN(envVar, "=", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		// Strip out the runtime env vars set by the shell interpreter
+		if parts[0] == "GID" ||
+			parts[0] == "HOME" ||
+			parts[0] == "IFS" ||
+			parts[0] == "OPTIND" ||
+			parts[0] == "PWD" ||
+			parts[0] == "UID" {
+			continue
+		}
+		envMap[parts[0]] = parts[1]
+	}
+
+	return envMap, nil
 }

--- a/internal/pkg/runtime/launcher/oci/process_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux_test.go
@@ -10,7 +10,9 @@
 package oci
 
 import (
+	"context"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -58,6 +60,82 @@ func TestApptainerEnvMap(t *testing.T) {
 			}
 			if got := apptainerEnvMap(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("apptainerEnvMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnvFileMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		envFile string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "EmptyFile",
+			envFile: "",
+			want:    map[string]string{},
+			wantErr: false,
+		},
+		{
+			name: "Simple",
+			envFile: `FOO=BAR
+			ABC=123`,
+			want: map[string]string{
+				"FOO": "BAR",
+				"ABC": "123",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "DoubleQuote",
+			envFile: `FOO="FOO BAR"`,
+			want: map[string]string{
+				"FOO": "FOO BAR",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "SingleQuote",
+			envFile: `FOO='FOO BAR'`,
+			want: map[string]string{
+				"FOO": "FOO BAR",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "MultiLine",
+			envFile: "FOO=\"FOO\nBAR\"",
+			want: map[string]string{
+				"FOO": "FOO\nBAR",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Invalid",
+			envFile: "!!!@@NOTAVAR",
+			want:    map[string]string{},
+			wantErr: true,
+		},
+	}
+
+	tmpDir := t.TempDir()
+	envFile := filepath.Join(tmpDir, "env-file")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.WriteFile(envFile, []byte(tt.envFile), 0o755); err != nil {
+				t.Fatalf("Could not write test env-file: %v", err)
+			}
+
+			got, err := envFileMap(context.Background(), envFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("envFileMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("envFileMap() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1170
 which fixed
- sylabs/singularity# 1030

The original PR description was:
> Allow --env-file to be used to provide environment variables in a file, when running a container in --oci mode.
> 
> We use the same approach as the native runtime for compatibility. The env file is evaluated in the embedded shell interpreter, but starting with an empty environment. This handles quoting, comments etc. for us, and keeps maximum compatibility with the existing handling.