### PR TITLE
deb: ensure rc packages precede release, from sylabs 1189

### DIFF
--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -26,7 +26,13 @@ GOROOT = $${TMPDIR:-/tmp}/appdebgo/go
 GOCACHE = $${TMPDIR:-/tmp}/appdebgo/cache
 
 # get version via script
-SC_VERSION = $(shell scripts/get-version )
+# Transform version numbers so that they match debian precedence / rules.
+# https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+#
+# 3.4.2-rc.1            ->  3.4.2~rc.1
+# 3.4.2                 ->  3.4.2
+# 3.4.2+522-gee98ef356  ->  3.4.2+522.gee98ef356
+SC_VERSION = $(shell scripts/get-version | sed -e 's,\(^[^+]\+\)-,\1~,; s,-,.,g')
 NEW_VERSION = $(shell dpkg --compare-versions $(SC_VERSION) gt $(pkgver) && echo $(SC_VERSION) )
 
 # these can be overwritten by environment variables


### PR DESCRIPTION
This pulls in sylabs part of PR

- sylabs/singularity# 1189
 which fixed
- sylabs/singularity# 862

The original PR description was:
> Transform version numbers so that the match debian precedence / rules, as version number sorting doesn't work with semver (see sylabs/singularity# 862).
> 
> https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
> 
> ```
> 3.4.2-rc.1            ->  3.4.2~rc.1
> 3.4.2                 ->  3.4.2
> 3.4.2+522-gee98ef356  ->  3.4.2+522.gee98ef356
> ```