### PR TITLE
instance: start with cgroup if possible, to enable stats, from sylabs 1186

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - When the kernel supports unprivileged overlay mounts in a user
   namespace, the container will be constructed using an overlay
   instead of underlay layout.
+- Instances are started in a cgroup, by default, when run as root or when
+  unified cgroups v2 with systemd as manager is configured. This allows
+  `apptainer instance stats` to be supported by default when possible.
 
 ### New features / functionalities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   and destinations.
 - Added `Provides: bundled(golang())` statements to the rpm packaging
   for each bundled golang module.
-- Fix non-root instance join with unprivileged systemd managed cgroups, when join is
-  from outside a user-owned cgroup.
+- Fix non-root instance join with unprivileged systemd managed cgroups, when
+  join is from outside a user-owned cgroup.
 
 ## v1.1.5 - \[2023-01-10\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   and destinations.
 - Added `Provides: bundled(golang())` statements to the rpm packaging
   for each bundled golang module.
+- Fix non-root instance join with unprivileged systemd managed cgroups, when join is
+  from outside a user-owned cgroup.
 
 ## v1.1.5 - \[2023-01-10\]
 

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -58,7 +58,7 @@ func (c *ctx) instanceStats(t *testing.T, profile e2e.Profile) {
 	}{
 		{
 			name:           "basic stats create",
-			createArgs:     []string{"--apply-cgroups", "testdata/cgroups/cpu_success.toml", c.env.ImagePath},
+			createArgs:     []string{c.env.ImagePath},
 			statsErrorCode: 0,
 			startErrorCode: 0,
 		},

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -53,6 +53,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/util/namespaces"
 	"github.com/apptainer/apptainer/pkg/util/rlimit"
 	lccgroups "github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 )
 
@@ -481,22 +482,39 @@ func (l *Launcher) setImageOrInstance(image string, name string) error {
 		l.engineConfig.SetImage(image)
 		l.engineConfig.SetInstanceJoin(true)
 
-		// If we are running non-root, without a user ns, join the instance cgroup now, as we
-		// can't manipulate the ppid cgroup in the engine
-		// prepareInstanceJoinConfig().
-		//
-		// TODO - consider where /proc/sys/fs/cgroup is mounted in the engine
-		// flow, to move this further down.
-		if file.Cgroup && l.uid != 0 && !l.cfg.Namespaces.User {
+		// If we are running non-root, join the instance cgroup now, as we
+		// can't manipulate the ppid cgroup in the engine prepareInstanceJoinConfig().
+		// This flow is only applicable with the systemd cgroups manager.
+		if file.Cgroup && l.uid != 0 {
+			if !l.engineConfig.File.SystemdCgroups {
+				return fmt.Errorf("joining non-root instance with cgroups requires systemd as cgroups manager")
+			}
+
 			pid := os.Getpid()
-			sylog.Debugf("Adding process %d to instance cgroup", pid)
-			manager, err := cgroups.GetManagerForPid(file.Pid)
+
+			// First, we create a new systemd managed cgroup for ourselves. This is so that we will be
+			// under a common user-owned ancestor, allowing us to move into the instance cgroup next.
+			// See: https://www.kernel.org/doc/html/v4.18/admin-guide/cgroup-v2.html#delegation-containment
+			sylog.Debugf("Adding process %d to sibling cgroup", pid)
+			manager, err := cgroups.NewManagerWithSpec(&specs.LinuxResources{}, pid, "", true)
+			if err != nil {
+				return fmt.Errorf("couldn't create cgroup manager: %w", err)
+			}
+			cgPath, _ := manager.GetCgroupRelPath()
+			sylog.Debugf("In sibling cgroup: %s", cgPath)
+
+			// Now we should be under the user-owned service directory in the cgroupfs,
+			// so we can move into the actual instance cgroup that we want.
+			sylog.Debugf("Moving process %d to instance cgroup", pid)
+			manager, err = cgroups.GetManagerForPid(file.Pid)
 			if err != nil {
 				return fmt.Errorf("couldn't create cgroup manager: %w", err)
 			}
 			if err := manager.AddProc(pid); err != nil {
 				return fmt.Errorf("couldn't add process to instance cgroup: %w", err)
 			}
+			cgPath, _ = manager.GetCgroupRelPath()
+			sylog.Debugf("In instance cgroup: %s", cgPath)
 		}
 	} else {
 		abspath, err := filepath.Abs(image)

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -52,6 +52,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/util/fs/proc"
 	"github.com/apptainer/apptainer/pkg/util/namespaces"
 	"github.com/apptainer/apptainer/pkg/util/rlimit"
+	lccgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	"golang.org/x/sys/unix"
 )
 
@@ -303,16 +304,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 		l.cfg.Namespaces.User = !l.cfg.IgnoreUserns
 	}
 
-	// If we are not root, we need to pass in XDG / DBUS environment so we can communicate
-	// with systemd for any cgroups (v2) operations.
-	if l.uid != 0 {
-		sylog.Debugf("Recording rootless XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS")
-		l.engineConfig.SetXdgRuntimeDir(os.Getenv("XDG_RUNTIME_DIR"))
-		l.engineConfig.SetDbusSessionBusAddress(os.Getenv("DBUS_SESSION_BUS_ADDRESS"))
-	}
-
-	// Handle cgroups configuration (parsed from file or flags in CLI).
-	l.engineConfig.SetCgroupsJSON(l.cfg.CGroupsJSON)
+	l.setCgroups(instanceName)
 
 	// --boot flag requires privilege, so check for this.
 	err = withPrivilege(l.uid, l.cfg.Boot, "--boot", func() error { return nil })
@@ -992,6 +984,48 @@ func (l *Launcher) setProcessCwd() {
 	} else {
 		sylog.Warningf("can't determine current working directory: %s", err)
 	}
+}
+
+// setCgroups sets cgroup related configuration
+func (l *Launcher) setCgroups(instanceName string) error {
+	// If we are not root, we need to pass in XDG / DBUS environment so we can communicate
+	// with systemd for any cgroups (v2) operations.
+	if l.uid != 0 {
+		sylog.Debugf("Recording rootless XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS")
+		l.engineConfig.SetXdgRuntimeDir(os.Getenv("XDG_RUNTIME_DIR"))
+		l.engineConfig.SetDbusSessionBusAddress(os.Getenv("DBUS_SESSION_BUS_ADDRESS"))
+	}
+
+	if l.cfg.CGroupsJSON != "" {
+		// Handle cgroups configuration (parsed from file or flags in CLI).
+		l.engineConfig.SetCgroupsJSON(l.cfg.CGroupsJSON)
+		return nil
+	}
+
+	if instanceName == "" {
+		return nil
+	}
+
+	// If we are an instance, always use a cgroup if possible, to enable stats.
+	// root can always create a cgroup.
+	useCG := l.uid == 0
+	// non-root needs cgroups v2 unified mode + systemd as cgroups manager.
+	if l.uid != 0 && lccgroups.IsCgroup2UnifiedMode() && l.engineConfig.File.SystemdCgroups {
+		useCG = true
+	}
+
+	if useCG {
+		cg := cgroups.Config{}
+		cgJSON, err := cg.MarshalJSON()
+		if err != nil {
+			return err
+		}
+		l.engineConfig.SetCgroupsJSON(cgJSON)
+		return nil
+	}
+
+	sylog.Infof("Instance stats will not be available - requires cgroups v2 with systemd as manager.")
+	return nil
 }
 
 // PrepareImage performs any image preparation required before execution.


### PR DESCRIPTION
This pulls in sylabs part of PR

- sylabs/singularity# 1186
 which fixed
- sylabs/singularity# 891

The original PR description was:
> Start an instance with a cgroup by default, where the calling user is root, or cgroups v2 unified mode with systemd as manager is available.
> 
> This allows `singularity instance stats` to work by default in these circumstances.
> 
> The PR also includes a fix for a limitation of non-group instances with cgroups that is more broadly exposed by the above change:
> 
> When joining a non-root instance using cgroups, we need to move our instance joining process into the instance cgroup.
> 
> Previously we did this directly. However, it is common for a CLI instance join to be started under a session scope cgroup that is root owned, and not delegated. We cannot move the CLI process into the instance cgroup directly from here, due to the requirements detailed in:
> 
> https://www.kernel.org/doc/html/v4.18/admin-guide/cgroup-v2.html#delegation-containment
> 
> Instead, create a new systemd managed cgroup, and move into this first. The new cgroup will be a sibling of the instance cgroup, in the systemd managed delegated tree. We can then move again, this time into the instance cgroup we need to be in.