### PR TITLE
fix: block overlay for panfs, from sylabs 1219

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ### Bug fixes
 
+- Overlay is blocked on the `panfs` filesystem, allowing sandbox directories to be
+  run from `panfs` without error.
+
+### Bug fixes
+
 - Restored the ability for running instances to be tracked when apptainer
   is installed with tools/install-unprivileged.sh.  Instance tracking
   depends on argument 0 of the starter, which was not getting preserved.

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -45,6 +45,7 @@ const (
 	Ecrypt int64 = 0xF15F
 	Lustre int64 = 0x0BD00BD0 //nolint:misspell
 	Gpfs   int64 = 0x47504653
+	Panfs  int64 = 0xAAD7AAEA
 )
 
 var incompatibleFs = map[int64]fs{
@@ -72,6 +73,11 @@ var incompatibleFs = map[int64]fs{
 	// GPFS filesystem
 	Gpfs: {
 		name:       "GPFS",
+		overlayDir: lowerDir | upperDir,
+	},
+	// PANFS filesystem
+	Panfs: {
+		name:       "PANFS",
 		overlayDir: lowerDir | upperDir,
 	},
 }

--- a/internal/pkg/util/fs/overlay/overlay_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux_test.go
@@ -149,6 +149,24 @@ func TestCheckLowerUpper(t *testing.T) {
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
+		{
+			name:                  "PANFS mock lower",
+			path:                  "/",
+			fsName:                "PANFS",
+			dir:                   lowerDir,
+			fsType:                Panfs,
+			expectedSuccess:       false,
+			expectIncompatibleErr: true,
+		},
+		{
+			name:                  "PANFS mock upper",
+			path:                  "/",
+			fsName:                "PANFS",
+			dir:                   upperDir,
+			fsType:                Panfs,
+			expectedSuccess:       false,
+			expectIncompatibleErr: true,
+		},
 	}
 
 	if IsIncompatible(nil) {


### PR DESCRIPTION
This pulls in sylabs part of PR

- sylabs/singularity# 1219
 which fixed
- sylabs/singularity# 1215

The original PR description was:
> A sandbox container on a panfs (Panasas) filesystem causes an overlay error at runtime. Add panfs to to the list of incompatible filesystems.
> 
> Block panfs as both lower and upper overlay dirs, until support is confirmed with Panasas (same situation as GPFS).