### PR TITLE
rocm: fixups and --oci support, from sylabs 1181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
     - Additional namespaces requests with `--net`, `--uts`, `--user`.
     - Container environment variables via `--env`, `--env-file`, and
       `APPTAINERENV_` host env vars.
+    - `--rocm` to bind ROCm GPU libraries and devices into the container.
 
 ### Security fix
 

--- a/e2e/gpu/gpu.go
+++ b/e2e/gpu/gpu.go
@@ -291,9 +291,18 @@ func (c ctx) testRocm(t *testing.T) {
 
 func (c ctx) ociTestRocm(t *testing.T) {
 	require.Rocm(t)
-	// Use Ubuntu 20.04 as this is the most recent distro officially supported by ROCm.
+
+	require.Command(t, "lsmod")
+
+	// rocminfo now needs lsmod - do a brittle bind in for simplicity.
+	lsmod, err := exec.LookPath("lsmod")
+	if err != nil {
+		t.Fatalf("while finding lsmod: %v", err)
+	}
+
+	// Use Ubuntu 22.04 as this is the most recent distro officially supported by ROCm.
 	// We can't use our test image as it's alpine based and we need a compatible glibc.
-	imageURL := "docker://ubuntu:20.04"
+	imageURL := "docker://ubuntu:22.04"
 
 	// Basic test that we can run the bound in `rocminfo` which *should* be on the PATH
 	tests := []struct {
@@ -302,15 +311,15 @@ func (c ctx) ociTestRocm(t *testing.T) {
 	}{
 		{
 			profile: e2e.OCIUserProfile,
-			args:    []string{"--rocm", imageURL, "rocminfo"},
+			args:    []string{"-B", lsmod, "--rocm", imageURL, "rocminfo"},
 		},
 		{
 			profile: e2e.OCIFakerootProfile,
-			args:    []string{"--rocm", imageURL, "rocminfo"},
+			args:    []string{"-B", lsmod, "--rocm", imageURL, "rocminfo"},
 		},
 		{
 			profile: e2e.OCIRootProfile,
-			args:    []string{"--rocm", imageURL, "rocminfo"},
+			args:    []string{"-B", lsmod, "--rocm", imageURL, "rocminfo"},
 		},
 	}
 

--- a/e2e/gpu/gpu.go
+++ b/e2e/gpu/gpu.go
@@ -289,6 +289,43 @@ func (c ctx) testRocm(t *testing.T) {
 	}
 }
 
+func (c ctx) ociTestRocm(t *testing.T) {
+	require.Rocm(t)
+	// Use Ubuntu 20.04 as this is the most recent distro officially supported by ROCm.
+	// We can't use our test image as it's alpine based and we need a compatible glibc.
+	imageURL := "docker://ubuntu:20.04"
+
+	// Basic test that we can run the bound in `rocminfo` which *should* be on the PATH
+	tests := []struct {
+		profile e2e.Profile
+		args    []string
+	}{
+		{
+			profile: e2e.OCIUserProfile,
+			args:    []string{"--rocm", imageURL, "rocminfo"},
+		},
+		{
+			profile: e2e.OCIFakerootProfile,
+			args:    []string{"--rocm", imageURL, "rocminfo"},
+		},
+		{
+			profile: e2e.OCIRootProfile,
+			args:    []string{"--rocm", imageURL, "rocminfo"},
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.profile.String()),
+			e2e.WithProfile(tt.profile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(0),
+		)
+	}
+}
+
 //nolint:dupl
 func (c ctx) testBuildNvidiaLegacy(t *testing.T) {
 	require.Nvidia(t)
@@ -555,5 +592,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"build nvidia": c.testBuildNvidiaLegacy,
 		"build nvccli": c.testBuildNvCCLI,
 		"build rocm":   c.testBuildRocm,
+		// oci mode
+		"oci rocm": c.ociTestRocm,
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -18,13 +18,17 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs/files"
+	"github.com/apptainer/apptainer/internal/pkg/util/user"
 	"github.com/apptainer/apptainer/pkg/ocibundle/native"
+	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
@@ -116,12 +120,6 @@ func checkOpts(lo launcher.Options) error {
 	}
 	if lo.NoNvidia {
 		badOpt = append(badOpt, "NoNvidia")
-	}
-	if lo.Rocm {
-		badOpt = append(badOpt, "Rocm")
-	}
-	if lo.NoRocm {
-		badOpt = append(badOpt, "NoRocm")
 	}
 
 	if len(lo.ContainLibs) > 0 {
@@ -266,6 +264,43 @@ func (l *Launcher) createSpec() (*specs.Spec, error) {
 	return &spec, nil
 }
 
+func (l *Launcher) updatePasswdGroup(rootfs string) error {
+	uid := os.Getuid()
+	gid := os.Getgid()
+
+	if os.Getuid() == 0 || l.cfg.Fakeroot {
+		return nil
+	}
+
+	containerPasswd := filepath.Join(rootfs, "etc", "passwd")
+	containerGroup := filepath.Join(rootfs, "etc", "group")
+
+	pw, err := user.CurrentOriginal()
+	if err != nil {
+		return err
+	}
+
+	sylog.Debugf("Updating passwd file: %s", containerPasswd)
+	content, err := files.Passwd(containerPasswd, pw.Dir, uid)
+	if err != nil {
+		return fmt.Errorf("while creating passwd file: %w", err)
+	}
+	if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {
+		return fmt.Errorf("while writing passwd file: %w", err)
+	}
+
+	sylog.Debugf("Updating group file: %s", containerGroup)
+	content, err = files.Group(containerGroup, uid, []int{gid})
+	if err != nil {
+		return fmt.Errorf("while creating group file: %w", err)
+	}
+	if err := os.WriteFile(containerGroup, content, 0o755); err != nil {
+		return fmt.Errorf("while writing passwd file: %w", err)
+	}
+
+	return nil
+}
+
 // Exec will interactively execute a container via the runc low-level runtime.
 // image is a reference to an OCI image, e.g. docker://ubuntu or oci:/tmp/mycontainer
 func (l *Launcher) Exec(ctx context.Context, image string, process string, args []string, instanceName string) error {
@@ -343,6 +378,10 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	}
 
 	if err := b.Create(ctx, spec); err != nil {
+		return err
+	}
+
+	if err := l.updatePasswdGroup(tools.RootFs(b.Path()).Path()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1181
 which fixed
- sylabs/singularity# 1034

The original PR description was:
> A selection of ROCm fixes and addition of --oci support. Am including all in a single PR to minimize amount of work needed testing on a ROCm enabled system.
> 
> * In `--oci` mode ensure user and group entries written to container passwd / group files. Required to proceed with ROCm stuff. 
> * When binding ROCm devices with --contain in effect, we were only taking /dev/dri/cardxxx and /dev/kfd. At least some circumstances also require /dev/dri. Bind the whole of /dev/dri, just like the AMD ROCm container documentation for Docker does.
> * Under --oci mode, allow --rocm, which will bind ROCm devices, libraries, and binaries into the container.
> * e2e: minimal --rocm --oci test
> * fix: rocm: update rocmliblist and fix e2e tests -`rocminfo` now needs `lsmod` and libdrm libdrm_amdgpu. Bind the former in tests, the libraries from rocmliblist.conf. We can now use Ubuntu 22.04 for ROCm tests.
> 
> 
> You may need to trust me that this works :-) Here's the output on a Fedora 37 machine with a ROCm supported GPU:
> 
> ```
> $ make -C builddir e2e-test E2E_GROUPS=GPU
> ...
> --- PASS: TestE2E (28.26s)
>     --- PASS: TestE2E/PAR (0.00s)
>         --- PASS: TestE2E/PAR/GPU (0.00s)
>             --- SKIP: TestE2E/PAR/GPU/build_nvidia (0.00s)
>             --- SKIP: TestE2E/PAR/GPU/build_nvccli (0.00s)
>             --- SKIP: TestE2E/PAR/GPU/nvccli (0.00s)
>             --- SKIP: TestE2E/PAR/GPU/nvidia (0.00s)
>             --- PASS: TestE2E/PAR/GPU/rocm (17.42s)
>                 --- PASS: TestE2E/PAR/GPU/rocm/User (0.20s)
>                 --- PASS: TestE2E/PAR/GPU/rocm/UserContain (0.18s)
>                 --- PASS: TestE2E/PAR/GPU/rocm/UserNamespace (1.56s)
>                 --- PASS: TestE2E/PAR/GPU/rocm/Fakeroot (0.55s)
>                 --- PASS: TestE2E/PAR/GPU/rocm/Root (0.18s)
>             --- PASS: TestE2E/PAR/GPU/build_rocm (21.48s)
>                 --- PASS: TestE2E/PAR/GPU/build_rocm/WithRocmRoot (1.31s)
>                 --- PASS: TestE2E/PAR/GPU/build_rocm/WithRocmFakeroot (1.71s)
>                 --- PASS: TestE2E/PAR/GPU/build_rocm/WithoutRocmRoot (1.14s)
>                 --- PASS: TestE2E/PAR/GPU/build_rocm/WithoutRocmFakeroot (2.19s)
>             --- PASS: TestE2E/PAR/GPU/oci_rocm (25.08s)
>                 --- PASS: TestE2E/PAR/GPU/oci_rocm/OCIUser (13.37s)
>                 --- PASS: TestE2E/PAR/GPU/oci_rocm/OCIFakeroot (3.84s)
>                 --- PASS: TestE2E/PAR/GPU/oci_rocm/OCIRoot (7.84s)
> ```