### PR TITLE
Increases the sessiondir max size from 16 to 64, from sylabs 1151

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Instances are started in a cgroup, by default, when run as root or when
   unified cgroups v2 with systemd as manager is configured. This allows
   `apptainer instance stats` to be supported by default when possible.
+- `sessiondir maxsize` in `apptainer.conf` now defaults to 64 MiB for new
+  installations. This is an increase from 16 MiB in prior versions.
 
 ### New features / functionalities
 

--- a/internal/pkg/confgen/testdata/test_1.out.correct
+++ b/internal/pkg/confgen/testdata/test_1.out.correct
@@ -145,11 +145,11 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
+# DEFAULT: 64
 # This specifies how large the default sessiondir should be (in MB) and it will
 # only affect users who use the "--contain" options and don't also specify a
 # location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/internal/pkg/confgen/testdata/test_2.in
+++ b/internal/pkg/confgen/testdata/test_2.in
@@ -145,11 +145,11 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
+# DEFAULT: 64
 # This specifies how large the default sessiondir should be (in MB) and it will
 # only affect users who use the "--contain" options and don't also specify a
 # location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/internal/pkg/confgen/testdata/test_2.out.correct
+++ b/internal/pkg/confgen/testdata/test_2.out.correct
@@ -145,11 +145,11 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
+# DEFAULT: 64
 # This specifies how large the default sessiondir should be (in MB) and it will
 # only affect users who use the "--contain" options and don't also specify a
 # location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/internal/pkg/confgen/testdata/test_3.in
+++ b/internal/pkg/confgen/testdata/test_3.in
@@ -136,11 +136,11 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
+# DEFAULT: 64
 # This specifies how large the default sessiondir should be (in MB) and it will
 # only affect users who use the "--contain" options and don't also specify a
 # location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/internal/pkg/confgen/testdata/test_3.out.correct
+++ b/internal/pkg/confgen/testdata/test_3.out.correct
@@ -145,11 +145,11 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
+# DEFAULT: 64
 # This specifies how large the default sessiondir should be (in MB) and it will
 # only affect users who use the "--contain" options and don't also specify a
 # location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/internal/pkg/confgen/testdata/test_default.tmpl
+++ b/internal/pkg/confgen/testdata/test_default.tmpl
@@ -147,7 +147,7 @@ mount slave = {{ if eq .MountSlave true }}yes{{ else }}no{{ end }}
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
+# DEFAULT: 64
 # This specifies how large the default sessiondir should be (in MB) and it will
 # only affect users who use the "--contain" options and don't also specify a
 # location to do default read/writes to (e.g. "--workdir" or "--home").

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -101,7 +101,7 @@ type File struct {
 	AlwaysUseRocm           bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
 	SharedLoopDevices       bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
 	MaxLoopDevices          uint     `default:"256" directive:"max loop devices"`
-	SessiondirMaxSize       uint     `default:"16" directive:"sessiondir max size"`
+	SessiondirMaxSize       uint     `default:"64" directive:"sessiondir max size"`
 	MountDev                string   `default:"yes" authorized:"yes,no,minimal" directive:"mount dev"`
 	EnableOverlay           string   `default:"try" authorized:"yes,no,try,driver" directive:"enable overlay"`
 	BindPath                []string `default:"/etc/localtime,/etc/hosts" directive:"bind path"`
@@ -277,7 +277,7 @@ enable underlay = {{ if eq .EnableUnderlay true }}yes{{ else }}no{{ end }}
 mount slave = {{ if eq .MountSlave true }}yes{{ else }}no{{ end }}
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
+# DEFAULT: 64
 # This specifies how large the default sessiondir should be (in MB). It will
 # affect users who use the "--contain" options and don't also specify a
 # location to do default read/writes to (e.g. "--workdir" or "--home") and


### PR DESCRIPTION
This pulls in sylabs part of PR

- sylabs/singularity# 1151
 which fixed
- sylabs/singularity# 1140

The original PR description was:
> Use the configuration file sessiondir max size value for --oci mode tmpfs mounts.
>
> Increase the default from 16M -> 64M. The 16M default is very low, and has periodically caused issues running programs that create even small amounts of temporary data on --contained filesystems.