### PR TITLE
chore: bump go to 1.19.5 and docs: Bump LICENSE.md copyright year, from sylabs 1300

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   check_go_mod:
     name: check_go_mod
     runs-on: ubuntu-22.04
-    container: golang:1.19.3
+    container: golang:1.19.5
     steps:
       - uses: actions/checkout@v2
 
@@ -51,7 +51,7 @@ jobs:
   alpine:
     name: alpine
     runs-on: ubuntu-22.04
-    container: golang:1.19.3-alpine
+    container: golang:1.19.5-alpine
     steps:
       - name: Fetch deps
         run: apk add -q --no-cache git bash alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
@@ -84,7 +84,7 @@ jobs:
   check_license_dependencies:
     name: check_license_dependencies
     runs-on: ubuntu-22.04
-    container: golang:1.19.3
+    container: golang:1.19.5
     steps:
       - uses: actions/checkout@v2
 
@@ -215,7 +215,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.3
+          go-version: 1.19.5
 
       - name: Fetch deps
         run: sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup dbus-user-session
@@ -245,7 +245,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.3
+          go-version: 1.19.5
 
       - name: Fetch deps
         run: sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup dbus-user-session
@@ -289,7 +289,7 @@ jobs:
         if: env.run_tests
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.3
+          go-version: 1.19.5
 
       - name: Fetch deps
         if: env.run_tests
@@ -348,7 +348,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.3
+          go-version: 1.19.5
 
       - name: Check pkg/... doesn't depend on buildcfg
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check go.mod
-        run: ./scripts/check-go.mod
+        run: |
+          git config --global --add safe.directory $(pwd)
+          ./scripts/check-go.mod
 
   lint_markdown:
     name: lint_markdown
@@ -89,7 +91,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Update LICENSE_DEPENDENCIES.md
-        run: ./scripts/update-license-dependencies.sh
+        run: |
+          git config --global --add safe.directory $(pwd)
+          ./scripts/update-license-dependencies.sh
 
       - name: Check License Changes
         run: git diff --exit-code -- LICENSE_DEPENDENCIES.md
@@ -272,6 +276,7 @@ jobs:
           PROJECT_REPOSITORY: ${{ github.repository }}
           PROJECT_PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          git config --global --add safe.directory $(pwd)
           rc=0
           ./scripts/should-e2e-run "${PROJECT_REPOSITORY}" "${PROJECT_REF##*/}" "${PROJECT_PR_NUMBER}" || rc=$?
           case $rc in

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -23,7 +23,7 @@ reserved.
 
 Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 
-Copyright (c) 2018-2022, Sylabs, Inc. All rights reserved.
+Copyright (c) 2018-2023, Sylabs, Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1300

The original PR description was:
> Will move up to 1.20 after the 3.11 release, to avoid change in RC->release period.