### PR TITLE
fix: lack of passwd / group should be warning in --oci mode, from sylabs 1287

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -899,6 +899,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("user", c.testDockerUSER)
 			// Regressions
 			t.Run("issue 4524", c.issue4524)
+			t.Run("issue 1286", c.issue1286)
 		},
 		// Tests that are especially slow, or run against a local docker
 		// registry, can be run in parallel, with `--disable-cache` used within

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -167,3 +167,20 @@ From: continuumio/miniconda3:latest
 		),
 	)
 }
+
+// https://github.com/sylabs/singularity/issues/1286
+// Ensure the bare docker://hello-world image runs in all modes
+func (c ctx) issue1286(t *testing.T) {
+	for _, profile := range e2e.AllProfiles() {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(profile.String()),
+			e2e.WithProfile(profile),
+			e2e.WithCommand("run"),
+			e2e.WithArgs("docker://hello-world"),
+			e2e.ExpectExit(0,
+				e2e.ExpectOutput(e2e.ContainMatch, "Hello from Docker!"),
+			),
+		)
+	}
+}

--- a/e2e/internal/e2e/profile.go
+++ b/e2e/internal/e2e/profile.go
@@ -158,6 +158,18 @@ var OCIProfiles = map[string]Profile{
 	},
 }
 
+// AllProfiles is initialized to the union of NativeProfiles and OCIProfiles
+func AllProfiles() map[string]Profile {
+	ap := map[string]Profile{}
+	for k, p := range NativeProfiles {
+		ap[k] = p
+	}
+	for k, p := range OCIProfiles {
+		ap[k] = p
+	}
+	return ap
+}
+
 // Privileged returns whether the test should be executed with
 // elevated privileges or not.
 func (p Profile) Privileged() bool {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -328,18 +328,16 @@ func (l *Launcher) updatePasswdGroup(rootfs string, uid, gid uint32) error {
 	sylog.Debugf("Updating passwd file: %s", containerPasswd)
 	content, err := files.Passwd(containerPasswd, pw.Dir, int(uid))
 	if err != nil {
-		return fmt.Errorf("while creating passwd file: %w", err)
-	}
-	if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {
+		sylog.Warningf("%s", err)
+	} else if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {
 		return fmt.Errorf("while writing passwd file: %w", err)
 	}
 
 	sylog.Debugf("Updating group file: %s", containerGroup)
 	content, err = files.Group(containerGroup, int(uid), []int{int(gid)})
 	if err != nil {
-		return fmt.Errorf("while creating group file: %w", err)
-	}
-	if err := os.WriteFile(containerGroup, content, 0o755); err != nil {
+		sylog.Warningf("%s", err)
+	} else if err := os.WriteFile(containerGroup, content, 0o755); err != nil {
 		return fmt.Errorf("while writing passwd file: %w", err)
 	}
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1287
 which fixed
- sylabs/singularity# 1286

The original PR description was:
> In the --oci launcher, When a minimal container doesn't have an `/etc/passwd` or `/etc/groups` file then don't fail with a fatal error. Instead warn like the native runtime does.