### PR TITLE
fix: correctly honor DOCKER_HOST in actions and pull, from sylabs 1233

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 ### Bug fixes
 
 - Fix `GOCACHE` settings for golang build on PPA build environment.
+- Ensure `DOCKER_HOST` is honored in non-build flows.
 
 ## v1.1.6 - \[2023-02-14\]
 

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -77,7 +77,15 @@ func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, 
 	if err != nil {
 		sylog.Fatalf("While creating Docker credentials: %v", err)
 	}
-	return oci.Pull(ctx, imgCache, pullFrom, tmpDir, ociAuth, noHTTPS, false)
+
+	pullOpts := oci.PullOptions{
+		TmpDir:     tmpDir,
+		OciAuth:    ociAuth,
+		DockerHost: dockerHost,
+		NoHTTPS:    noHTTPS,
+	}
+
+	return oci.Pull(ctx, imgCache, pullFrom, pullOpts)
 }
 
 func handleOras(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, pullFrom string) (string, error) {

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -268,7 +268,15 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While creating Docker credentials: %v", err)
 		}
 
-		_, err = oci.PullToFile(ctx, imgCache, pullTo, pullFrom, tmpDir, ociAuth, noHTTPS, buildArgs.noCleanUp)
+		pullOpts := oci.PullOptions{
+			TmpDir:     tmpDir,
+			OciAuth:    ociAuth,
+			DockerHost: dockerHost,
+			NoHTTPS:    noHTTPS,
+			NoCleanUp:  buildArgs.noCleanUp,
+		}
+
+		_, err = oci.PullToFile(ctx, imgCache, pullTo, pullFrom, pullOpts)
 		if err != nil {
 			sylog.Fatalf("While making image from oci registry: %v", err)
 		}

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -248,7 +248,7 @@ func (c ctx) testDockerHost(t *testing.T) {
 
 	// Clean up docker image
 	e2e.Privileged(func(t *testing.T) {
-		cmd := exec.Command("docker", "rmi", dockerURI)
+		cmd := exec.Command("docker", "rmi", dockerRef)
 		_, err = cmd.Output()
 		if err != nil {
 			t.Fatalf("Unexpected error while cleaning up docker image.\n%s", err)

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -122,7 +122,7 @@ func (c ctx) testDockerPulls(t *testing.T) {
 func (c ctx) testDockerHost(t *testing.T) {
 	require.Command(t, "docker")
 
-	// Write a temporary "empty" Dockerfile (from scratch)
+	// Create a Dockerfile for a small image we can build locally
 	tmpPath, err := fs.MakeTmpDir(c.env.TestDir, "docker-", 0o755)
 	err = errors.Wrapf(err, "creating temporary directory in %q for docker host test", c.env.TestDir)
 	if err != nil {
@@ -130,37 +130,27 @@ func (c ctx) testDockerHost(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpPath)
 
-	// Here is the Dockerfile, and a temporary image path
 	dockerfile := filepath.Join(tmpPath, "Dockerfile")
-	emptyfile := filepath.Join(tmpPath, "file")
-	tmpImage := filepath.Join(tmpPath, "scratch-tmp.sif")
-
-	// Write Dockerfile and empty file to file
-	dockerfileContent := []byte("FROM scratch\nCOPY file /mrbigglesworth")
+	dockerfileContent := []byte("FROM alpine:latest\n")
 	err = os.WriteFile(dockerfile, dockerfileContent, 0o644)
 	if err != nil {
 		t.Fatalf("failed to create temporary Dockerfile: %+v", err)
 	}
 
-	fileContent := []byte("")
-	err = os.WriteFile(emptyfile, fileContent, 0o644)
-	if err != nil {
-		t.Fatalf("failed to create empty file: %+v", err)
-	}
+	dockerRef := "dinosaur/test-image:latest"
+	dockerURI := "docker-daemon:" + dockerRef
 
-	dockerURI := "dinosaur/test-image:latest"
-	pullURI := "docker-daemon:" + dockerURI
-
-	// Invoke docker build to build an empty scratch image in the docker daemon.
+	// Invoke docker build to build image in the docker daemon.
 	// Use os/exec because easier to generate a command with a working directory
 	e2e.Privileged(func(t *testing.T) {
-		cmd := exec.Command("docker", "build", "-t", dockerURI, ".")
+		cmd := exec.Command("docker", "build", "-t", dockerRef, tmpPath)
 		cmd.Dir = tmpPath
 		out, err := cmd.CombinedOutput()
+		t.Log(cmd.Args)
 		if err != nil {
 			t.Fatalf("Unexpected error while running command.\n%s: %s", err, string(out))
 		}
-	})
+	})(t)
 
 	tests := []struct {
 		name       string
@@ -212,33 +202,49 @@ func (c ctx) testDockerHost(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		// Export variable to environment if it's defined
-		if tt.envarValue != "" {
-			e2e.Privileged(func(t *testing.T) {
-				c.env.RunApptainer(
-					t,
-					e2e.WithEnv(append(os.Environ(), tt.envarValue)),
-					e2e.AsSubtest(tt.name),
-					e2e.WithProfile(e2e.UserProfile),
-					e2e.WithCommand("pull"),
-					e2e.WithArgs("--disable-cache", tmpImage, pullURI),
-					e2e.ExpectExit(tt.exit),
-				)
-			})
-		} else {
-			e2e.Privileged(func(t *testing.T) {
-				c.env.RunApptainer(
-					t,
-					e2e.AsSubtest(tt.name),
-					e2e.WithProfile(e2e.UserProfile),
-					e2e.WithCommand("pull"),
-					e2e.WithArgs("--disable-cache", tmpImage, pullURI),
-					e2e.ExpectExit(tt.exit),
-				)
-			})
+	t.Run("exec", func(t *testing.T) {
+		for _, tt := range tests {
+			cmdOps := []e2e.ApptainerCmdOp{
+				e2e.WithProfile(e2e.RootProfile),
+				e2e.AsSubtest(tt.name),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs("--disable-cache", dockerURI, "/bin/true"),
+				e2e.WithEnv(append(os.Environ(), tt.envarName+"="+tt.envarValue)),
+				e2e.ExpectExit(tt.exit),
+			}
+			c.env.RunApptainer(t, cmdOps...)
 		}
-	}
+	})
+
+	t.Run("pull", func(t *testing.T) {
+		for _, tt := range tests {
+			cmdOps := []e2e.ApptainerCmdOp{
+				e2e.WithProfile(e2e.RootProfile),
+				e2e.AsSubtest(tt.name),
+				e2e.WithCommand("pull"),
+				e2e.WithArgs("--force", "--disable-cache", dockerURI),
+				e2e.WithEnv(append(os.Environ(), tt.envarName+"="+tt.envarValue)),
+				e2e.WithDir(tmpPath),
+				e2e.ExpectExit(tt.exit),
+			}
+			c.env.RunApptainer(t, cmdOps...)
+		}
+	})
+
+	t.Run("build", func(t *testing.T) {
+		for _, tt := range tests {
+			cmdOps := []e2e.ApptainerCmdOp{
+				e2e.WithProfile(e2e.RootProfile),
+				e2e.AsSubtest(tt.name),
+				e2e.WithCommand("build"),
+				e2e.WithArgs("--force", "--disable-cache", "test.sif", dockerURI),
+				e2e.WithEnv(append(os.Environ(), tt.envarName+"="+tt.envarValue)),
+				e2e.WithDir(tmpPath),
+				e2e.ExpectExit(tt.exit),
+			}
+			c.env.RunApptainer(t, cmdOps...)
+		}
+	})
 
 	// Clean up docker image
 	e2e.Privileged(func(t *testing.T) {
@@ -247,7 +253,7 @@ func (c ctx) testDockerHost(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error while cleaning up docker image.\n%s", err)
 		}
-	})
+	})(t)
 }
 
 // AUFS sanity tests

--- a/internal/pkg/build/util.go
+++ b/internal/pkg/build/util.go
@@ -10,50 +10,17 @@
 package build
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/apptainer/apptainer/internal/pkg/cache"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/pkg/build/types"
-	buildtypes "github.com/apptainer/apptainer/pkg/build/types"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/slice"
-	ocitypes "github.com/containers/image/v5/types"
 	"golang.org/x/sys/unix"
 )
-
-// ConvertOciToSIF will convert an OCI source into a SIF using the build routines
-func ConvertOciToSIF(ctx context.Context, imgCache *cache.Handle, image, cachedImgPath, tmpDir string, noHTTPS, noCleanUp bool, authConf *ocitypes.DockerAuthConfig) error {
-	if imgCache == nil {
-		return fmt.Errorf("image cache is undefined")
-	}
-
-	b, err := NewBuild(
-		image,
-		Config{
-			Dest:      cachedImgPath,
-			Format:    "sif",
-			NoCleanUp: noCleanUp,
-			Opts: buildtypes.Options{
-				TmpDir:           tmpDir,
-				NoCache:          imgCache.IsDisabled(),
-				NoTest:           true,
-				NoHTTPS:          noHTTPS,
-				DockerAuthConfig: authConf,
-				ImgCache:         imgCache,
-			},
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("unable to create new build: %v", err)
-	}
-
-	return b.Full(ctx)
-}
 
 func createStageFile(source string, b *types.Bundle, warnMsg string) (string, error) {
 	dest := filepath.Join(b.RootfsPath, source)

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -20,27 +20,36 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/build/oci"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
+	buildtypes "github.com/apptainer/apptainer/pkg/build/types"
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
 	ocitypes "github.com/containers/image/v5/types"
 )
 
+type PullOptions struct {
+	TmpDir     string
+	OciAuth    *ocitypes.DockerAuthConfig
+	DockerHost string
+	NoHTTPS    bool
+	NoCleanUp  bool
+}
+
 // pull will build a SIF image into the cache if directTo="", or a specific file if directTo is set.
-func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS, noCleanUp bool) (imagePath string, err error) {
+func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, opts PullOptions) (imagePath string, err error) {
 	// DockerInsecureSkipTLSVerify is set only if --no-https is specified to honor
 	// configuration from /etc/containers/registries.conf because DockerInsecureSkipTLSVerify
 	// can have three possible values true/false and undefined, so we left it as undefined instead
 	// of forcing it to false in order to delegate decision to /etc/containers/registries.conf:
 	// https://github.com/apptainer/singularity/issues/5172
 	sysCtx := &ocitypes.SystemContext{
-		OCIInsecureSkipTLSVerify: noHTTPS,
-		DockerAuthConfig:         ociAuth,
+		OCIInsecureSkipTLSVerify: opts.NoHTTPS,
+		DockerAuthConfig:         opts.OciAuth,
 		AuthFilePath:             syfs.DockerConf(),
 		DockerRegistryUserAgent:  useragent.Value(),
-		BigFilesTemporaryDir:     tmpDir,
+		BigFilesTemporaryDir:     opts.TmpDir,
 	}
-	if noHTTPS {
+	if opts.NoHTTPS {
 		sysCtx.DockerInsecureSkipTLSVerify = ocitypes.NewOptionalBool(true)
 	}
 
@@ -51,7 +60,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDi
 
 	if directTo != "" {
 		sylog.Infof("Converting OCI blobs to SIF format")
-		if err := build.ConvertOciToSIF(ctx, imgCache, pullFrom, directTo, tmpDir, noHTTPS, noCleanUp, ociAuth); err != nil {
+		if err := convertOciToSIF(ctx, imgCache, pullFrom, directTo, opts); err != nil {
 			return "", fmt.Errorf("while building SIF from layers: %v", err)
 		}
 		imagePath = directTo
@@ -65,7 +74,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDi
 		if !cacheEntry.Exists {
 			sylog.Infof("Converting OCI blobs to SIF format")
 
-			if err := build.ConvertOciToSIF(ctx, imgCache, pullFrom, cacheEntry.TmpPath, tmpDir, noHTTPS, noCleanUp, ociAuth); err != nil {
+			if err := convertOciToSIF(ctx, imgCache, pullFrom, cacheEntry.TmpPath, opts); err != nil {
 				return "", fmt.Errorf("while building SIF from layers: %v", err)
 			}
 
@@ -83,12 +92,42 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDi
 	return imagePath, nil
 }
 
+// convertOciToSIF will convert an OCI source into a SIF using the build routines
+func convertOciToSIF(ctx context.Context, imgCache *cache.Handle, image, cachedImgPath string, opts PullOptions) error {
+	if imgCache == nil {
+		return fmt.Errorf("image cache is undefined")
+	}
+
+	b, err := build.NewBuild(
+		image,
+		build.Config{
+			Dest:      cachedImgPath,
+			Format:    "sif",
+			NoCleanUp: opts.NoCleanUp,
+			Opts: buildtypes.Options{
+				TmpDir:           opts.TmpDir,
+				NoCache:          imgCache.IsDisabled(),
+				NoTest:           true,
+				NoHTTPS:          opts.NoHTTPS,
+				DockerAuthConfig: opts.OciAuth,
+				DockerDaemonHost: opts.DockerHost,
+				ImgCache:         imgCache,
+			},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create new build: %v", err)
+	}
+
+	return b.Full(ctx)
+}
+
 // Pull will build a SIF image to the cache or direct to a temporary file if cache is disabled
-func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS, noCleanUp bool) (imagePath string, err error) {
+func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, opts PullOptions) (imagePath string, err error) {
 	directTo := ""
 
 	if imgCache.IsDisabled() {
-		file, err := os.CreateTemp(tmpDir, "sbuild-tmp-cache-")
+		file, err := os.CreateTemp(opts.TmpDir, "sbuild-tmp-cache-")
 		if err != nil {
 			return "", fmt.Errorf("unable to create tmp file: %v", err)
 		}
@@ -96,18 +135,18 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 		sylog.Infof("Downloading library image to tmp cache: %s", directTo)
 	}
 
-	return pull(ctx, imgCache, directTo, pullFrom, tmpDir, ociAuth, noHTTPS, noCleanUp)
+	return pull(ctx, imgCache, directTo, pullFrom, opts)
 }
 
 // PullToFile will build a SIF image from the specified oci URI and place it at the specified dest
-func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS, noCleanUp bool) (imagePath string, err error) {
+func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom string, opts PullOptions) (imagePath string, err error) {
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo
 		sylog.Debugf("Cache disabled, pulling directly to: %s", directTo)
 	}
 
-	src, err := pull(ctx, imgCache, directTo, pullFrom, tmpDir, ociAuth, noHTTPS, noCleanUp)
+	src, err := pull(ctx, imgCache, directTo, pullFrom, opts)
 	if err != nil {
 		if strings.Contains(err.Error(), "unsupported image-specific operation on artifact with type \"application/vnd.unknown.config.v1+json\"") {
 			return "", fmt.Errorf("%v; try changing the protocol to oras://", err)


### PR DESCRIPTION
This pulls in sylabs part of PR

- sylabs/singularity# 1233
 which fixed
- sylabs/singularity# 1220

The original PR description was:
> Honour the DOCKER_HOST, `--no-https`, and auth configuration in `--oci` mode.