### PR TITLE
oci: pass in SystemContext for image handling, from sylabs 1233

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -29,7 +29,10 @@ import (
 	ocilauncher "github.com/apptainer/apptainer/internal/pkg/runtime/launcher/oci"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/uri"
+	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
+	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
+	"github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
 )
 
@@ -409,6 +412,20 @@ func launchContainer(cmd *cobra.Command, image string, containerCmd string, cont
 
 	if ociRuntime {
 		sylog.Debugf("Using OCI runtime launcher.")
+
+		sysCtx := &types.SystemContext{
+			OCIInsecureSkipTLSVerify: noHTTPS,
+			DockerAuthConfig:         &dockerAuthConfig,
+			DockerDaemonHost:         dockerHost,
+			OSChoice:                 "linux",
+			AuthFilePath:             syfs.DockerConf(),
+			DockerRegistryUserAgent:  useragent.Value(),
+		}
+		if noHTTPS {
+			sysCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(true)
+		}
+		opts = append(opts, launcher.OptSysContext(sysCtx))
+
 		l, err = ocilauncher.NewLauncher(opts...)
 		if err != nil {
 			return fmt.Errorf("while configuring container: %s", err)

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -204,7 +204,6 @@ func (c ctx) testDockerHost(t *testing.T) {
 
 	for _, profile := range []e2e.Profile{e2e.RootProfile, e2e.OCIRootProfile} {
 		t.Run(profile.String(), func(t *testing.T) {
-
 			t.Run("exec", func(t *testing.T) {
 				for _, tt := range tests {
 					cmdOps := []e2e.ApptainerCmdOp{
@@ -248,7 +247,6 @@ func (c ctx) testDockerHost(t *testing.T) {
 					c.env.RunApptainer(t, cmdOps...)
 				}
 			})
-
 		})
 	}
 

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -202,49 +202,55 @@ func (c ctx) testDockerHost(t *testing.T) {
 		},
 	}
 
-	t.Run("exec", func(t *testing.T) {
-		for _, tt := range tests {
-			cmdOps := []e2e.ApptainerCmdOp{
-				e2e.WithProfile(e2e.RootProfile),
-				e2e.AsSubtest(tt.name),
-				e2e.WithCommand("exec"),
-				e2e.WithArgs("--disable-cache", dockerURI, "/bin/true"),
-				e2e.WithEnv(append(os.Environ(), tt.envarName+"="+tt.envarValue)),
-				e2e.ExpectExit(tt.exit),
-			}
-			c.env.RunApptainer(t, cmdOps...)
-		}
-	})
+	for _, profile := range []e2e.Profile{e2e.RootProfile, e2e.OCIRootProfile} {
+		t.Run(profile.String(), func(t *testing.T) {
 
-	t.Run("pull", func(t *testing.T) {
-		for _, tt := range tests {
-			cmdOps := []e2e.ApptainerCmdOp{
-				e2e.WithProfile(e2e.RootProfile),
-				e2e.AsSubtest(tt.name),
-				e2e.WithCommand("pull"),
-				e2e.WithArgs("--force", "--disable-cache", dockerURI),
-				e2e.WithEnv(append(os.Environ(), tt.envarName+"="+tt.envarValue)),
-				e2e.WithDir(tmpPath),
-				e2e.ExpectExit(tt.exit),
-			}
-			c.env.RunApptainer(t, cmdOps...)
-		}
-	})
+			t.Run("exec", func(t *testing.T) {
+				for _, tt := range tests {
+					cmdOps := []e2e.ApptainerCmdOp{
+						e2e.WithProfile(profile),
+						e2e.AsSubtest(profile.String() + "/" + tt.name),
+						e2e.WithCommand("exec"),
+						e2e.WithArgs("--disable-cache", dockerURI, "/bin/true"),
+						e2e.WithEnv(append(os.Environ(), tt.envarName+"="+tt.envarValue)),
+						e2e.ExpectExit(tt.exit),
+					}
+					c.env.RunApptainer(t, cmdOps...)
+				}
+			})
 
-	t.Run("build", func(t *testing.T) {
-		for _, tt := range tests {
-			cmdOps := []e2e.ApptainerCmdOp{
-				e2e.WithProfile(e2e.RootProfile),
-				e2e.AsSubtest(tt.name),
-				e2e.WithCommand("build"),
-				e2e.WithArgs("--force", "--disable-cache", "test.sif", dockerURI),
-				e2e.WithEnv(append(os.Environ(), tt.envarName+"="+tt.envarValue)),
-				e2e.WithDir(tmpPath),
-				e2e.ExpectExit(tt.exit),
-			}
-			c.env.RunApptainer(t, cmdOps...)
-		}
-	})
+			t.Run("pull", func(t *testing.T) {
+				for _, tt := range tests {
+					cmdOps := []e2e.ApptainerCmdOp{
+						e2e.WithProfile(profile),
+						e2e.AsSubtest(tt.name),
+						e2e.WithCommand("pull"),
+						e2e.WithArgs("--force", "--disable-cache", dockerURI),
+						e2e.WithEnv(append(os.Environ(), tt.envarName+"="+tt.envarValue)),
+						e2e.WithDir(tmpPath),
+						e2e.ExpectExit(tt.exit),
+					}
+					c.env.RunApptainer(t, cmdOps...)
+				}
+			})
+
+			t.Run("build", func(t *testing.T) {
+				for _, tt := range tests {
+					cmdOps := []e2e.ApptainerCmdOp{
+						e2e.WithProfile(profile),
+						e2e.AsSubtest(tt.name),
+						e2e.WithCommand("build"),
+						e2e.WithArgs("--force", "--disable-cache", "test.sif", dockerURI),
+						e2e.WithEnv(append(os.Environ(), tt.envarName+"="+tt.envarValue)),
+						e2e.WithDir(tmpPath),
+						e2e.ExpectExit(tt.exit),
+					}
+					c.env.RunApptainer(t, cmdOps...)
+				}
+			})
+
+		})
+	}
 
 	// Clean up docker image
 	e2e.Privileged(func(t *testing.T) {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -202,9 +202,6 @@ func checkOpts(lo launcher.Options) error {
 	if lo.SIFFUSE {
 		badOpt = append(badOpt, "SIFFUSE")
 	}
-	if lo.CacheDisabled {
-		badOpt = append(badOpt, "CacheDisabled")
-	}
 
 	if len(badOpt) > 0 {
 		return fmt.Errorf("%w: %s", ErrUnsupportedOption, strings.Join(badOpt, ","))

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -30,11 +30,8 @@ import (
 	"github.com/apptainer/apptainer/pkg/ocibundle"
 	"github.com/apptainer/apptainer/pkg/ocibundle/native"
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
-	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
-	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
-	"github.com/containers/image/v5/types"
 	"github.com/google/uuid"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -351,6 +348,10 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		return fmt.Errorf("%w: instanceName", ErrNotImplemented)
 	}
 
+	if l.cfg.SysContext == nil {
+		return fmt.Errorf("launcher SysContext must be set for OCI image handling")
+	}
+
 	bundleDir, err := os.MkdirTemp("", "oci-bundle")
 	if err != nil {
 		return nil
@@ -363,19 +364,6 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	}()
 
 	sylog.Debugf("Creating OCI bundle at: %s", bundleDir)
-
-	// TODO - propagate auth config
-	sysCtx := &types.SystemContext{
-		// OCIInsecureSkipTLSVerify: cp.b.Opts.NoHTTPS,
-		// DockerAuthConfig:         cp.b.Opts.DockerAuthConfig,
-		// DockerDaemonHost:         cp.b.Opts.DockerDaemonHost,
-		OSChoice:                "linux",
-		AuthFilePath:            syfs.DockerConf(),
-		DockerRegistryUserAgent: useragent.Value(),
-	}
-	// if cp.b.Opts.NoHTTPS {
-	//      cp.sysCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(true)
-	// }
 
 	var imgCache *cache.Handle
 	if !l.cfg.CacheDisabled {
@@ -397,7 +385,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	b, err := native.New(
 		native.OptBundlePath(bundleDir),
 		native.OptImageRef(image),
-		native.OptSysCtx(sysCtx),
+		native.OptSysCtx(l.cfg.SysContext),
 		native.OptImgCache(imgCache),
 	)
 	if err != nil {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -49,7 +49,7 @@ func TestNewLauncher(t *testing.T) {
 		{
 			name: "unsupportedOption",
 			opts: []launcher.Option{
-				launcher.OptCacheDisabled(true),
+				launcher.OptSecurity([]string{"seccomp:example.json"}),
 			},
 			want:    nil,
 			wantErr: true,

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -11,6 +11,7 @@ package launcher
 
 import (
 	"github.com/apptainer/apptainer/pkg/util/cryptkey"
+	"github.com/containers/image/v5/types"
 )
 
 // Namespaces holds flags for the optional (non-mount) namespaces that can be
@@ -147,6 +148,10 @@ type Options struct {
 	IgnoreUserns      bool
 	UseBuildConfig    bool
 	TmpDir            string
+
+	// SysContext holds Docker/OCI image handling configuration.
+	// This will be used by a launcher handling OCI images directly.
+	SysContext *types.SystemContext
 }
 
 type Option func(co *Options) error
@@ -465,7 +470,7 @@ func OptKeyInfo(ki *cryptkey.KeyInfo) Option {
 	}
 }
 
-// CacheDisabled indicates caching of images was disabled in the CLI.
+// OptCacheDisabled indicates caching of images was disabled in the CLI.
 func OptCacheDisabled(b bool) Option {
 	return func(lo *Options) error {
 		lo.CacheDisabled = b
@@ -533,6 +538,14 @@ func OptUseBuildConfig(b bool) Option {
 func OptTmpDir(a string) Option {
 	return func(lo *Options) error {
 		lo.TmpDir = a
+		return nil
+	}
+}
+
+// OptSysContext sets Docker/OCI image handling configuration.
+func OptSysContext(sc *types.SystemContext) Option {
+	return func(lo *Options) error {
+		lo.SysContext = sc
 		return nil
 	}
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1233
 which fixed
- sylabs/singularity# 1220

The original PR description was:
> Honour the DOCKER_HOST, `--no-https`, and auth configuration in `--oci` mode.