### PR TITLE
fix: gpu: always bind first variant of lib in ldconfig -p output, from sylabs 1390

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Ensure `DOCKER_HOST` is honored in non-build flows.
 - Make the error message more helpful in another place where a remote is found
   to have no library client.
+- Ensure consistent binding of libraries under `--nv/--rocm` when duplicate
+  `<library>.so[.version]` files are listed by `ldconfig -p`.
 
 ## v1.1.6 - \[2023-02-14\]
 

--- a/internal/pkg/util/paths/resolve_test.go
+++ b/internal/pkg/util/paths/resolve_test.go
@@ -41,7 +41,7 @@ func TestLdCache(t *testing.T) {
 	if len(gotCache) == 0 {
 		t.Error("ldCache() gave no results")
 	}
-	for path, name := range gotCache {
+	for name, path := range gotCache {
 		if strings.HasPrefix(name, "ld-linux") {
 			if strings.Contains(path, "ld-linux") {
 				return


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1390
 which fixed
- sylabs/singularity# 1345

The original PR description was:
> We use the output of `ldconfig -p` to construct a list of libraries to consider for binding into the container with `--nv` / `--rocm` enabled.
> 
> Previously, the entire `ldconfig -p` output was parsed into a map of path->library. This map was then iterated over when computing the binds to perform.
> 
> It's possible for a given `<library>.so[.version]` to be present at multiple paths, e.g. when a vendor and system `libEGL.so.0` are both present on the system. Because the map is keyed by path, multiple entries would be created in it. Range over map has a random order in Go, and we can only bind a single `<library>.so[.version]` under `.singularity.d/libs` - so the library bound would vary between runs.
> 
> This PR modifies the mapping to be library->path and ensures there is only a single `<library>.so[.version]` in the map, making behavior consistent between runs. Only the first occurence of a specific `<library>.so[.version]` in the `ldconfig -p` output will be bound into the container.
> 
> There is no impact on systems where `ldconfig -p` does not list multiple locations for the same `<library>.so[.version]`.