### PR TITLE
fix: Pass LD_LIBRARY_PATH to wrapped unsquashfs correctly, from sylabs 1356

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Build via zypper on SLE systems will use repositories of host via
   suseconnect-container.
 - Avoid incorrect error when reqesting fakeroot network.
+- Pass computed `LD_LIBRARY_PATH` to wrapped unsquashfs. Fixes issues where
+  `unsquashfs` on host uses libraries in non-default paths.
 
 ## v1.1.6 - \[2023-02-14\]
 

--- a/internal/pkg/image/unpacker/squashfs_apptainer.go
+++ b/internal/pkg/image/unpacker/squashfs_apptainer.go
@@ -362,6 +362,7 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 	cmd.Dir = "/"
 	cmd.Env = []string{
 		fmt.Sprintf("LD_LIBRARY_PATH=%s", strings.Join(libraryPath, string(os.PathListSeparator))),
+		fmt.Sprintf("APPTAINERENV_LD_LIBRARY_PATH=%s", strings.Join(libraryPath, string(os.PathListSeparator))),
 		fmt.Sprintf("APPTAINER_DEBUG=%s", os.Getenv("APPTAINER_DEBUG")),
 	}
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1356
 which fixed
- sylabs/singularity# 1335

The original PR description was:
> In our handling of unsquashfs extraction, wrapped in a minimal container invocation, we are computing an LD_LIBRARY_PATH that holds the paths to all libraries needed by unsquashfs.
> 
> Unfortunately, we were setting `LD_LIBRARY_PATH` in the outer environment, and it does not pass into the container by default. We need to set `SINGULARITYENV_LD_LIBRARY_PATH` to pass it in.
> 
> This is very challenging to write a test for, as it requires modifying host binaries or ld.so.conf etc. Verified fix using the reproducer detailed in sylabs/singularity# 1335.