### PR TITLE
e2e: improve ImageVerify efficiency and replace defer-based cleanups, from sylabs 1399

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -45,7 +45,11 @@ func (c ctx) testDockerPulls(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %+v", err)
 	}
-	defer os.RemoveAll(tmpPath)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.RemoveAll(tmpPath)
+		}
+	})
 
 	tmpImage := filepath.Join(tmpPath, tmpContainerFile)
 
@@ -262,7 +266,11 @@ func (c ctx) testDockerHost(t *testing.T) {
 // AUFS sanity tests
 func (c ctx) testDockerAUFS(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "aufs-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	c.env.RunApptainer(
@@ -309,7 +317,11 @@ func (c ctx) testDockerAUFS(t *testing.T) {
 // Check force permissions for user builds #977
 func (c ctx) testDockerPermissions(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "perm-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	c.env.RunApptainer(
@@ -355,7 +367,11 @@ func (c ctx) testDockerPermissions(t *testing.T) {
 // Check whiteout of symbolic links #1592 #1576
 func (c ctx) testDockerWhiteoutSymlink(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "whiteout-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	c.env.RunApptainer(
@@ -375,7 +391,11 @@ func (c ctx) testDockerWhiteoutSymlink(t *testing.T) {
 
 func (c ctx) testDockerDefFile(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "def-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	getKernelMajor := func(t *testing.T) (major int) {
@@ -419,7 +439,7 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		deffile := e2e.PrepareDefFile(e2e.DefFileDetails{
+		defFile := e2e.PrepareDefFile(e2e.DefFileDetails{
 			Bootstrap: "docker",
 			From:      tt.from,
 		})
@@ -429,7 +449,7 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("build"),
-			e2e.WithArgs([]string{imagePath, deffile}...),
+			e2e.WithArgs([]string{imagePath, defFile}...),
 			e2e.PreRun(func(t *testing.T) {
 				require.Arch(t, tt.archRequired)
 				if getKernelMajor(t) < tt.kernelMajorRequired {
@@ -437,14 +457,16 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 				}
 			}),
 			e2e.PostRun(func(t *testing.T) {
-				defer os.Remove(imagePath)
-				defer os.Remove(deffile)
-
 				if t.Failed() {
 					return
 				}
 
 				c.env.ImageVerify(t, imagePath, e2e.RootProfile)
+
+				if !t.Failed() {
+					os.Remove(imagePath)
+					os.Remove(defFile)
+				}
 			}),
 			e2e.ExpectExit(0),
 		)
@@ -453,7 +475,11 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 
 func (c ctx) testDockerRegistry(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "registry-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	tests := []struct {
@@ -499,14 +525,16 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 			e2e.WithCommand("build"),
 			e2e.WithArgs("--disable-cache", "--no-https", imagePath, defFile),
 			e2e.PostRun(func(t *testing.T) {
-				defer os.Remove(imagePath)
-				defer os.Remove(defFile)
-
 				if t.Failed() || tt.exit != 0 {
 					return
 				}
 
 				c.env.ImageVerify(t, imagePath, e2e.RootProfile)
+
+				if !t.Failed() {
+					os.Remove(imagePath)
+					os.Remove(defFile)
+				}
 			}),
 			e2e.ExpectExit(tt.exit),
 		)
@@ -528,7 +556,11 @@ func (c ctx) testDockerCMDQuotes(t *testing.T) {
 
 func (c ctx) testDockerLabels(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "labels-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	// Test container & set labels
@@ -568,7 +600,11 @@ func (c ctx) testDockerLabels(t *testing.T) {
 //nolint:dupl
 func (c ctx) testDockerCMD(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	home, err := os.UserHomeDir()
@@ -667,7 +703,11 @@ func (c ctx) testDockerCMD(t *testing.T) {
 //nolint:dupl
 func (c ctx) testDockerENTRYPOINT(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	home, err := os.UserHomeDir()
@@ -753,7 +793,11 @@ func (c ctx) testDockerENTRYPOINT(t *testing.T) {
 //nolint:dupl
 func (c ctx) testDockerCMDENTRYPOINT(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	home, err := os.UserHomeDir()

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -132,7 +132,11 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tc := range tt {
 				dn, cleanup := c.tempDir(t, "build-from")
-				defer cleanup()
+				t.Cleanup(func() {
+					if !t.Failed() {
+						cleanup()
+					}
+				})
 
 				imagePath := path.Join(dn, "sandbox")
 
@@ -162,7 +166,11 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 							return
 						}
 
-						defer os.RemoveAll(imagePath)
+						t.Cleanup(func() {
+							if !t.Failed() {
+								os.RemoveAll(imagePath)
+							}
+						})
 						c.env.ImageVerify(t, imagePath, profile)
 					}),
 					e2e.ExpectExit(0),
@@ -207,7 +215,11 @@ func (c imgBuildTests) nonRootBuild(t *testing.T) {
 
 	for _, tc := range tt {
 		dn, cleanup := c.tempDir(t, "non-root-build")
-		defer cleanup()
+		t.Cleanup(func() {
+			if !t.Failed() {
+				cleanup()
+			}
+		})
 
 		imagePath := path.Join(dn, "container")
 
@@ -238,13 +250,21 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 
 	tmpdir, cleanup := c.tempDir(t, "build-local-image")
 
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	liDefFile := e2e.PrepareDefFile(e2e.DefFileDetails{
 		Bootstrap: "localimage",
 		From:      c.env.ImagePath,
 	})
-	defer os.Remove(liDefFile)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(liDefFile)
+		}
+	})
 
 	labels := make(map[string]string)
 	labels["FOO"] = "bar"
@@ -253,7 +273,11 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 		From:      c.env.ImagePath,
 		Labels:    labels,
 	})
-	defer os.Remove(liLabelDefFile)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(liLabelDefFile)
+		}
+	})
 
 	sandboxImage := path.Join(tmpdir, "test-sandbox")
 
@@ -273,7 +297,11 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 		From:      sandboxImage,
 		Labels:    labels,
 	})
-	defer os.Remove(localSandboxDefFile)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(localSandboxDefFile)
+		}
+	})
 
 	tt := []struct {
 		name      string
@@ -303,7 +331,11 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 						if t.Failed() {
 							return
 						}
-						defer os.RemoveAll(imagePath)
+						t.Cleanup(func() {
+							if !t.Failed() {
+								os.RemoveAll(imagePath)
+							}
+						})
 						c.env.ImageVerify(t, imagePath, profile)
 					}),
 					e2e.ExpectExit(0),
@@ -315,7 +347,11 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 
 func (c imgBuildTests) badPath(t *testing.T) {
 	dn, cleanup := c.tempDir(t, "bad-path")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	imagePath := path.Join(dn, "container")
 
@@ -334,7 +370,11 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer os.Remove(tmpfile) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(tmpfile)
+		}
+	})
 
 	tests := []struct {
 		name    string
@@ -513,7 +553,11 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 
 	for _, tt := range tests {
 		dn, cleanup := c.tempDir(t, "multi-stage-definition")
-		defer cleanup()
+		t.Cleanup(func() {
+			if !t.Failed() {
+				cleanup()
+			}
+		})
 
 		imagePath := path.Join(dn, "container")
 
@@ -528,7 +572,11 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 			e2e.WithCommand("build"),
 			e2e.WithArgs(args...),
 			e2e.PostRun(func(t *testing.T) {
-				defer os.Remove(defFile)
+				t.Cleanup(func() {
+					if !t.Failed() {
+						os.Remove(defFile)
+					}
+				})
 
 				e2e.DefinitionImageVerify(t, c.env.CmdPath, imagePath, tt.correct)
 			}),
@@ -544,7 +592,11 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer os.Remove(tmpfile) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(tmpfile)
+		}
+	})
 
 	tt := map[string]e2e.DefFileDetails{
 		"Empty": {
@@ -809,7 +861,11 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 		t.Run(profile.String(), func(t *testing.T) {
 			for name, dfd := range tt {
 				dn, cleanup := c.tempDir(t, "build-definition")
-				defer cleanup()
+				t.Cleanup(func() {
+					if !t.Failed() {
+						cleanup()
+					}
+				})
 
 				imagePath := path.Join(dn, "container")
 
@@ -825,7 +881,11 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 						if t.Failed() {
 							return
 						}
-						defer os.Remove(defFile)
+						t.Cleanup(func() {
+							if !t.Failed() {
+								os.Remove(defFile)
+							}
+						})
 						e2e.DefinitionImageVerify(t, c.env.CmdPath, imagePath, dfd)
 					}),
 					e2e.ExpectExit(0),
@@ -860,7 +920,11 @@ func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
 	// We create a temporary directory to store the image, making sure tests
 	// will not pollute each other
 	dn, cleanup := c.tempDir(t, "pem-encryption")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	// Generate the PEM file
 	pemFile, _ := e2e.GeneratePemFiles(t, c.env.TestDir)
@@ -928,7 +992,11 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	// We create a temporary directory to store the image, making sure tests
 	// will not pollute each other
 	dn, cleanup := c.tempDir(t, "passphrase-encryption")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	// If the version of cryptsetup is not compatible with Apptainer encryption,
 	// the build commands are expected to fail
@@ -1026,7 +1094,11 @@ func (c imgBuildTests) buildUpdateSandbox(t *testing.T) {
 	const badSandbox = "/bad/sandbox/path"
 
 	testDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "build-sandbox-", "")
-	defer e2e.Privileged(cleanup)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			e2e.Privileged(cleanup)
+		}
+	})
 
 	tests := []struct {
 		name     string
@@ -1075,10 +1147,10 @@ func (c imgBuildTests) buildUpdateSandbox(t *testing.T) {
 // buildWithFingerprint checks that we correctly verify a source image fingerprint when specified
 func (c imgBuildTests) buildWithFingerprint(t *testing.T) {
 	tmpDir, remove := e2e.MakeTempDir(t, "", "imgbuild-fingerprint-", "")
-	defer func() {
+	t.Cleanup(func() {
 		c.env.KeyringDir = ""
 		remove(t)
-	}()
+	})
 
 	pgpDir, _ := e2e.MakeKeysDir(t, tmpDir)
 	c.env.KeyringDir = pgpDir
@@ -1242,7 +1314,11 @@ func (c imgBuildTests) buildWithFingerprint(t *testing.T) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		defer os.Remove(defFile)
+		t.Cleanup(func() {
+			if !t.Failed() {
+				os.Remove(defFile)
+			}
+		})
 		c.env.RunApptainer(t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(e2e.RootProfile),
@@ -1260,7 +1336,11 @@ func (c imgBuildTests) buildBindMount(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	tmpdir, cleanup := c.tempDir(t, "build-local-image")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	dir, _ := e2e.MakeTempDir(t, tmpdir, "mount", "")
 
@@ -1411,7 +1491,11 @@ func (c imgBuildTests) buildLibraryHost(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	tmpdir, cleanup := c.tempDir(t, "build-libraryhost-test")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	// Library hostname in the From URI
 	// The hostname is invalid, and we should get an error to that effect.
@@ -1438,7 +1522,11 @@ func (c imgBuildTests) testWritableTmpfs(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	tmpdir, cleanup := c.tempDir(t, "build-writabletmpfs-test")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	// Definition will attempt to touch a file in /var/test during %test.
 	// This would fail without a writable tmpfs.
@@ -1477,13 +1565,21 @@ echo 'export LEGACY_TEST_ENV=legacy-value' >> $SINGULARITY_ENVIRONMENT
 `
 
 	tmpdir, cleanup := c.tempDir(t, "build-environment-test")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	defFile, err := e2e.WriteTempFile(tmpdir, "testFile-", definition)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer os.Remove(defFile)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(defFile)
+		}
+	})
 
 	imagePath := filepath.Join(tmpdir, "image-build-environment")
 	c.env.RunApptainer(
@@ -1532,7 +1628,11 @@ func (c *imgBuildTests) testContainerBuildUnderFakerootModes(t *testing.T) {
 	e2e.EnsureDebianImage(t, c.env)
 
 	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "test-container-build-under-fakeroot-modes-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 
 	// Make the DebianImagePath available for Bootstrap: localimage
 	sif := c.env.DebianImagePath
@@ -1541,7 +1641,11 @@ func (c *imgBuildTests) testContainerBuildUnderFakerootModes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("while symlinking %s to %s: %v", sif, basesif, err)
 	}
-	defer os.Remove(basesif)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(basesif)
+		}
+	})
 
 	// running under the mode 1, 1a (--with-suid) (https://apptainer.org/docs/user/main/fakeroot.html)
 	c.env.RunApptainer(
@@ -1600,7 +1704,11 @@ func (c *imgBuildTests) testContainerBuildUnderFakerootModes(t *testing.T) {
 
 func (c *imgBuildTests) testSIFHeaderAndExecute(t *testing.T) {
 	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "test-SIF-header-fields-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 
 	path := fmt.Sprintf("%s/img.sif", tmpDir)
 
@@ -1636,7 +1744,11 @@ func (c *imgBuildTests) testSIFHeaderAndExecute(t *testing.T) {
 // Check that test and runscript that specify a custom #! use it as the interpreter.
 func (c imgBuildTests) buildCustomShebang(t *testing.T) {
 	tmpdir, cleanup := c.tempDir(t, "build-shebang-test")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	definition := `Bootstrap: localimage
 From: %s

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -40,7 +40,11 @@ func (c imgBuildTests) issue4203(t *testing.T) {
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_4203.def"),
 		e2e.PostRun(func(t *testing.T) {
-			defer os.Remove(image)
+			t.Cleanup(func() {
+				if !t.Failed() {
+					os.Remove(image)
+				}
+			})
 
 			if t.Failed() {
 				return
@@ -103,7 +107,11 @@ func (c *imgBuildTests) issue4407(t *testing.T) {
 					return
 				}
 
-				defer os.RemoveAll(imagePath)
+				t.Cleanup(func() {
+					if !t.Failed() {
+						os.RemoveAll(imagePath)
+					}
+				})
 
 				c.env.ImageVerify(t, imagePath, e2e.RootProfile)
 			}),
@@ -121,7 +129,11 @@ func (c *imgBuildTests) issue4583(t *testing.T) {
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_4583.def"),
 		e2e.PostRun(func(t *testing.T) {
-			defer os.Remove(image)
+			t.Cleanup(func() {
+				if !t.Failed() {
+					os.Remove(image)
+				}
+			})
 
 			if t.Failed() {
 				return
@@ -295,11 +307,11 @@ func (c *imgBuildTests) issue5315(t *testing.T) {
 func (c *imgBuildTests) issue5435(t *testing.T) {
 	// create a directory that we don't care about
 	cwd, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "throwaway-dir-", "")
-	defer func(t *testing.T) {
+	t.Cleanup(func() {
 		if !t.Failed() {
 			cleanup(t)
 		}
-	}(t)
+	})
 
 	c.env.RunApptainer(
 		t,
@@ -356,7 +368,11 @@ func (c *imgBuildTests) issue5668(t *testing.T) {
 		t.Fatalf("Could not get home dir: %v", err)
 	}
 	sbDir, sbCleanup := e2e.MakeTempDir(t, home, "issue-5668-", "")
-	defer e2e.Privileged(sbCleanup)(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			e2e.Privileged(sbCleanup)(t)
+		}
+	})
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
@@ -372,7 +388,11 @@ func (c *imgBuildTests) issue5690(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	sandbox, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue-5690-", "")
-	defer e2e.Privileged(cleanup)(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			e2e.Privileged(cleanup)(t)
+		}
+	})
 
 	c.env.RunApptainer(
 		t,
@@ -393,7 +413,11 @@ func (c *imgBuildTests) issue5690(t *testing.T) {
 
 func (c *imgBuildTests) issue3848(t *testing.T) {
 	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue-3848-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 
 	f, err := os.CreateTemp(tmpDir, "test-def-")
 	if err != nil {
@@ -405,7 +429,11 @@ func (c *imgBuildTests) issue3848(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmpfile) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(tmpfile)
+		}
+	})
 
 	d := struct {
 		From string

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -24,63 +24,21 @@ import (
 
 // ImageVerify checks for an image integrity.
 func (env TestEnv) ImageVerify(t *testing.T, imagePath string, profile Profile) {
-	tt := []struct {
-		name string
-		argv []string
-		exit int
-	}{
-		{
-			name: "False",
-			argv: []string{imagePath, "false"},
-			exit: 1,
-		},
-		{
-			name: "RunScript",
-			argv: []string{imagePath, "test", "-f", "/.singularity.d/runscript"},
-			exit: 0,
-		},
-		{
-			name: "OneBase",
-			argv: []string{imagePath, "test", "-f", "/.singularity.d/env/01-base.sh"},
-			exit: 0,
-		},
-		{
-			name: "ActionsShell",
-			argv: []string{imagePath, "test", "-f", "/.singularity.d/actions/shell"},
-			exit: 0,
-		},
-		{
-			name: "ActionsExec",
-			argv: []string{imagePath, "test", "-f", "/.singularity.d/actions/exec"},
-			exit: 0,
-		},
-		{
-			name: "ActionsRun",
-			argv: []string{imagePath, "test", "-f", "/.singularity.d/actions/run"},
-			exit: 0,
-		},
-		{
-			name: "Environment",
-			argv: []string{imagePath, "test", "-L", "/environment"},
-			exit: 0,
-		},
-		{
-			name: "Singularity",
-			argv: []string{imagePath, "test", "-L", "/singularity"},
-			exit: 0,
-		},
-	}
-
-	for _, tc := range tt {
-		env.RunApptainer(
-			t,
-			AsSubtest(tc.name),
-			WithProfile(profile),
-			WithCommand("exec"),
-			WithArgs(tc.argv...),
-			ExpectExit(tc.exit),
-		)
-	}
+	env.RunApptainer(
+		t,
+		AsSubtest("BasicIntegrityTests"),
+		WithProfile(profile),
+		WithCommand("exec"),
+		WithArgs(imagePath, "/bin/sh", "-c",
+			"test -f /.singularity.d/runscript -a "+
+				"-f /.singularity.d/env/01-base.sh -a "+
+				"-f /.singularity.d/actions/shell -a "+
+				"-f /.singularity.d/actions/exec -a "+
+				"-f /.singularity.d/actions/run -a "+
+				"-L /environment -a "+
+				"-L /singularity"),
+		ExpectExit(0),
+	)
 
 	tests := []struct {
 		name      string
@@ -93,33 +51,34 @@ func (env TestEnv) ImageVerify(t *testing.T, imagePath string, profile Profile) 
 			expectOut: "container",
 		},
 		{
-			name:      "LabelCheckSchemaVersion",
+			// name:      "LabelCheckSchemaVersion",
 			jsonPath:  []string{"data", "attributes", "labels", "org.label-schema.schema-version"},
 			expectOut: "1.0",
 		},
 	}
 
-	// Verify the label partition
-	for _, tt := range tests {
-		verifyOutput := func(t *testing.T, r *ApptainerCmdResult) {
-			jsonOut, err := jsonparser.GetString(r.Stdout, tt.jsonPath...)
-			if err != nil {
-				t.Fatalf("unable to get expected output from json: %v", err)
-			}
-			if jsonOut != tt.expectOut {
-				t.Fatalf("unexpected failure: got: '%s', expecting: '%s'", jsonOut, tt.expectOut)
-			}
+	verifyOutput := func(t *testing.T, r *ApptainerCmdResult) {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				jsonOut, err := jsonparser.GetString(r.Stdout, tt.jsonPath...)
+				if err != nil {
+					t.Fatalf("unable to get expected output from json: %v", err)
+				}
+				if jsonOut != tt.expectOut {
+					t.Fatalf("unexpected failure: got: '%s', expecting: '%s'", jsonOut, tt.expectOut)
+				}
+			})
 		}
-
-		env.RunApptainer(
-			t,
-			AsSubtest(tt.name),
-			WithProfile(UserProfile),
-			WithCommand("inspect"),
-			WithArgs([]string{"--json", "--labels", imagePath}...),
-			ExpectExit(0, verifyOutput),
-		)
 	}
+
+	env.RunApptainer(
+		t,
+		AsSubtest("LabelChecks"),
+		WithProfile(profile),
+		WithCommand("inspect"),
+		WithArgs([]string{"--json", "--labels", imagePath}...),
+		ExpectExit(0, verifyOutput),
+	)
 }
 
 // DefinitionImageVerify checks for image correctness based off off supplied DefFileDetail

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -61,7 +61,11 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 	// Use a one-time cache directory specific to this pull. This ensures we are always
 	// testing an entire pull operation, performing the download into an empty cache.
 	cacheDir, cleanup := e2e.MakeCacheDir(t, "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	c.env.UnprivCacheDir = cacheDir
 
 	// We use a string rather than a slice of strings to avoid having an empty
@@ -366,7 +370,11 @@ func (c ctx) testPullCmd(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create temporary directory for pull test: %+v", err)
 			}
-			defer os.RemoveAll(tmpdir)
+			t.Cleanup(func() {
+				if !t.Failed() {
+					os.RemoveAll(tmpdir)
+				}
+			})
 
 			if tt.setPullDir {
 				tt.pullDir, err = os.MkdirTemp(tmpdir, "pull_dir.")
@@ -496,12 +504,14 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s", err)
 	}
-	defer func() {
-		err := os.RemoveAll(cacheDir)
-		if err != nil {
-			t.Fatalf("failed to delete temporary directory %s: %s", cacheDir, err)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			err := os.RemoveAll(cacheDir)
+			if err != nil {
+				t.Fatalf("failed to delete temporary directory %s: %s", cacheDir, err)
+			}
 		}
-	}()
+	})
 
 	c.env.UnprivCacheDir = cacheDir
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1399
 which fixed
- sylabs/singularity# 1106

The original PR description was:
> There are two kinds of changes here. First, the number of times `singularity exec` and `singularity inspect` are invoked from the `ImageVerify()` function has been reduced from 8 and 2, respectively, to 1 and 1, respectively.
> 
> Second, and relatedly, code that invokes `ImageVerify()` and used `defer f()` statements for cleanup has been changed to use `t.Cleanup()` statements that, crucially, check for `!t.Failed()` before performing the actual cleanup operations. This is a good idea in general, since suppressing cleanups when a test fails allows for more straightforward manual inspection of the fail state. This is a change we should eventually make throughout our test suites. But in this case it's especially important, because the consolidation of `singularity exec` and `singularity inspect` invocations means that error messages, should they occur, will be less detailed than before, and manual inspection of the fail state will be especially important. (This is a trade-off between test efficiency and the quality of automated error messages, where, in this case, we have decided in favor of the former.)