### PR TITLE
Environment Variables for Signing Key Material, from sylabs 1155

### DIFF
--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -11,7 +11,6 @@ package cli
 
 import (
 	"crypto"
-	"fmt"
 
 	"github.com/apptainer/apptainer/docs"
 	"github.com/apptainer/apptainer/internal/app/apptainer"
@@ -136,7 +135,7 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 	// Set key material.
 	switch {
 	case cmd.Flag(signPrivateKeyFlag.Name).Changed:
-		fmt.Printf("Signing image with key material from '%s'\n", priKeyPath)
+		sylog.Infof("Signing image with key material from '%v'", priKeyPath)
 
 		s, err := signature.LoadSignerFromPEMFile(priKeyPath, crypto.SHA256, cryptoutils.GetPasswordFromStdIn)
 		if err != nil {
@@ -145,7 +144,7 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 		opts = append(opts, apptainer.OptSignWithSigner(s))
 
 	default:
-		fmt.Println("Signing image with PGP key material")
+		sylog.Infof("Signing image with PGP key material")
 
 		// Set entity selector option, and ensure the entity is decrypted.
 		var f sypgp.EntitySelector
@@ -170,7 +169,7 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 
 	// Sign the image.
 	if err := apptainer.Sign(cpath, opts...); err != nil {
-		sylog.Fatalf("Failed to sign container: %s", err)
+		sylog.Fatalf("Failed to sign container: %v", err)
 	}
-	fmt.Printf("Signature created and applied to %s\n", cpath)
+	sylog.Infof("Signature created and applied to %v\n", cpath)
 }

--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -76,6 +76,7 @@ var signPrivateKeyFlag = cmdline.Flag{
 	DefaultValue: "",
 	Name:         "key",
 	Usage:        "path to the private key file",
+	EnvKeys:      []string{"SIGN_KEY"},
 }
 
 // -k|--keyidx
@@ -135,6 +136,8 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 	// Set key material.
 	switch {
 	case cmd.Flag(signPrivateKeyFlag.Name).Changed:
+		fmt.Printf("Signing image with key material from '%s'\n", priKeyPath)
+
 		s, err := signature.LoadSignerFromPEMFile(priKeyPath, crypto.SHA256, cryptoutils.GetPasswordFromStdIn)
 		if err != nil {
 			sylog.Fatalf("Failed to load key material: %v", err)
@@ -142,6 +145,8 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 		opts = append(opts, apptainer.OptSignWithSigner(s))
 
 	default:
+		fmt.Println("Signing image with PGP key material")
+
 		// Set entity selector option, and ensure the entity is decrypted.
 		var f sypgp.EntitySelector
 		if cmd.Flag(signKeyIdxFlag.Name).Changed {
@@ -164,7 +169,6 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 	}
 
 	// Sign the image.
-	fmt.Printf("Signing image: %s\n", cpath)
 	if err := apptainer.Sign(cpath, opts...); err != nil {
 		sylog.Fatalf("Failed to sign container: %s", err)
 	}

--- a/docs/content.go
+++ b/docs/content.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2017-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2017-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -740,14 +740,19 @@ Enterprise Performance Computing (EPC)`
 	// sign
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	SignUse   string = `sign [sign options...] <image path>`
-	SignShort string = `Attach digital signature(s) to an image`
+	SignShort string = `Add digital signature(s) to an image`
 	SignLong  string = `
   The sign command allows a user to add one or more digital signatures to a SIF
   image. By default, one digital signature is added for each object group in
   the file.
-  
-  To generate a key pair, see 'apptainer help key newpair'`
+
+  Key material can be provided via PEM-encoded file, or an entity in the PGP
+  keyring. To manage the PGP keyring, see 'apptainer help key'.`
 	SignExample string = `
+  Sign with a private key:
+  $ apptainer sign --key private.pem container.sif
+
+  Sign with PGP:
   $ apptainer sign container.sif`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -36,7 +36,7 @@ func (c ctx) apptainerSignHelpOption(t *testing.T) {
 		e2e.WithArgs("--help"),
 		e2e.ExpectExit(
 			0,
-			e2e.ExpectOutput(e2e.ContainMatch, "Attach digital signature(s) to an image"),
+			e2e.ExpectOutput(e2e.ContainMatch, "Add digital signature(s) to an image"),
 		),
 	)
 }

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -220,6 +220,23 @@ func (c ctx) apptainerSignKeyOption(t *testing.T) {
 	)
 }
 
+func (c ctx) apptainerSignKeyEnv(t *testing.T) {
+	imgPath, cleanup := c.prepareImage(t)
+	defer cleanup(t)
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithEnv([]string{"APPTAINER_SIGN_KEY=" + filepath.Join("..", "test", "keys", "private.pem")}),
+		e2e.WithCommand("sign"),
+		e2e.WithArgs(imgPath),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied to "+imgPath),
+		),
+	)
+}
+
 func (c *ctx) generateKeypair(t *testing.T) {
 	keyGenInput := []e2e.ApptainerConsoleOp{
 		e2e.ConsoleSendLine("e2e sign test key"),
@@ -272,6 +289,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("apptainerSignGroupIDOption", c.apptainerSignGroupIDOption)
 			t.Run("apptainerSignKeyidxOption", c.apptainerSignKeyidxOption)
 			t.Run("apptainerSignKeyOption", c.apptainerSignKeyOption)
+			t.Run("apptainerSignKeyEnv", c.apptainerSignKeyEnv)
 		},
 	}
 }

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -63,16 +63,16 @@ func (c *ctx) sign(t *testing.T) {
 		{
 			name: "OK",
 			expectOps: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 		{
 			name:  "ObjectIDFlag",
 			flags: []string{"--sif-id", "1"},
 			expectOps: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 		{
@@ -80,7 +80,7 @@ func (c *ctx) sign(t *testing.T) {
 			flags:      []string{"--sif-id", "9"},
 			expectCode: 255,
 			expectOps: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
 				e2e.ExpectError(e2e.ContainMatch, "integrity: object not found"),
 			},
 		},
@@ -88,8 +88,8 @@ func (c *ctx) sign(t *testing.T) {
 			name:  "GroupIDFlag",
 			flags: []string{"--group-id", "1"},
 			expectOps: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 		{
@@ -97,7 +97,7 @@ func (c *ctx) sign(t *testing.T) {
 			flags:      []string{"--group-id", "5"},
 			expectCode: 255,
 			expectOps: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
 				e2e.ExpectError(e2e.ContainMatch, "integrity: group not found"),
 			},
 		},
@@ -105,16 +105,16 @@ func (c *ctx) sign(t *testing.T) {
 			name:  "AllFlag",
 			flags: []string{"--all"},
 			expectOps: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 		{
 			name:  "KeyIndexFlag",
 			flags: []string{"--keyidx", "0"},
 			expectOps: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 		{
@@ -122,7 +122,7 @@ func (c *ctx) sign(t *testing.T) {
 			flags:      []string{"--keyidx", "1"},
 			expectCode: 255,
 			expectOps: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
 				e2e.ExpectError(e2e.ContainMatch, "Failed to sign container: index out of range"),
 			},
 		},
@@ -130,16 +130,16 @@ func (c *ctx) sign(t *testing.T) {
 			name:  "KeyFlag",
 			flags: []string{"--key", keyPath},
 			expectOps: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with key material from '"+keyPath+"'"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with key material from '"+keyPath+"'"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 		{
 			name: "KeyEnvVar",
 			envs: []string{"APPTAINER_SIGN_KEY=" + keyPath},
 			expectOps: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with key material from '"+keyPath+"'"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with key material from '"+keyPath+"'"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 	}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1155
 which fixed
- sylabs/singularity# 1148

The original PR description was:
> Add visual indication of key material being used by `singularity sign`. Improve `singularity sign` documentation. Define `SINGULARITY_SIGN_KEY` environment variable for '--key' flag of `singularity sign`. Simplify `singularity sign` end-to-end tests, and add coverage for `SINGULARITY_SIGN_KEY` environment variable.