### PR TITLE
oci: drop warning about runc functionality, from sylabs 1426

### DIFF
--- a/internal/pkg/runtime/launcher/oci/oci_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_linux.go
@@ -51,7 +51,7 @@ func runtime() (path string, err error) {
 		return
 	}
 	sylog.Debugf("While finding crun: %s", err)
-	sylog.Warningf("crun not found. Will attempt to use runc, but not all functionality is supported.")
+	sylog.Debugf("Falling back to runc as OCI runtime.")
 	return bin.FindBin("runc")
 }
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1426
 which fixed
- sylabs/singularity# 1425

The original PR description was:
> Drop the warning that not all OCI functionality is supported with runc.
> 
> Some things turned out to be SingularityCE bugs. Some things are very version specific. A new enough runc will work.