### PR TITLE
fix: support and test yum bootstrap on newer distros, from sylabs 1420

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `apptainer instance stats` to be supported by default when possible.
 - `sessiondir maxsize` in `apptainer.conf` now defaults to 64 MiB for new
   installations. This is an increase from 16 MiB in prior versions.
+- Show standard output of yum bootstrap if log level is verbose or higher.
 
 ### New features / functionalities
 
@@ -37,6 +38,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Add new Linux capabilities: `CAP_PERFMON`, `CAP_BPF`, `CAP_CHECKPOINT_RESTORE`.
 - Instance name is available inside an instance via the new
   `APPTAINER_INSTANCE` environment variable.
+- Add `setopt` definition file header for the `yum` bootstrap agent. The
+  `setopt` value is passed to `yum / dnf` using the `--setopt` flag. This
+  permits setting e.g. `install_weak_deps=False` to bootstrap recent versions of
+  Fedora, where `systemd` (a weak dependency) cannot install correctly in the
+  container. See `examples/Fedora` for an example defintion file.
+- Warn user that a `yum` bootstrap of an older distro may fail if the host rpm
+  `_db_backend` is not `bdb`.
 
 ### Other changes
 

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -60,22 +60,26 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 	// `apptainer build -s /tmp/sand/ <URI>` works,
 	// see https://github.com/apptainer/singularity/issues/4407
 	tt := []struct {
-		name        string
-		dependency  string
-		buildSpec   string
-		requireArch string
+		name         string
+		dependency   string
+		buildSpec    string
+		requirements func(t *testing.T)
 	}{
 		// Disabled due to frequent download failures of the busybox tgz
 		// {
 		// 	name:      "BusyBox",
 		// 	buildSpec: "../examples/busybox/Apptainer",
 		// 	// TODO: example has arch hard coded in download URL
-		// 	requireArch: "amd64",
+		//  requirements: func(t *testing.T) {
+		//   require.Arch(t, "amd64")
+		//  },
 		// },
 		{
-			name:       "Debootstrap",
-			dependency: "debootstrap",
-			buildSpec:  "../examples/debian/Apptainer",
+			name:      "Debootstrap",
+			buildSpec: "../examples/debian/Apptainer",
+			requirements: func(t *testing.T) {
+				require.Command(t, "debootstrap")
+			},
 		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
@@ -100,28 +104,83 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 			buildSpec: c.env.OrasTestImage,
 		},
 		{
-			name:        "Yum",
-			dependency:  "yum",
-			buildSpec:   "../examples/centos/Apptainer",
-			requireArch: "amd64",
+			name:      "Yum CentOS7",
+			buildSpec: "../examples/centos/Apptainer",
+			requirements: func(t *testing.T) {
+				require.Command(t, "yum")
+				require.RPMMacro(t, "_db_backend", "bdb")
+				require.RPMMacro(t, "_dbpath", "/var/lib/rpm")
+				require.Arch(t, "arm64")
+			},
 		},
 		{
-			name:        "YumArm64",
-			dependency:  "yum",
-			buildSpec:   "../examples/centos-arm64/Apptainer",
-			requireArch: "arm64",
+			name:       "YumArm64 CentOS 7",
+			dependency: "yum",
+			buildSpec:  "../examples/centos-arm64/Apptainer",
+			requirements: func(t *testing.T) {
+				require.Command(t, "yum")
+				require.RPMMacro(t, "_db_backend", "bdb")
+				require.RPMMacro(t, "_dbpath", "/var/lib/rpm")
+				require.Arch(t, "arm64")
+			},
 		},
 		{
-			name:        "Zypper",
-			dependency:  "zypper",
-			buildSpec:   "../examples/opensuse/Apptainer",
-			requireArch: "amd64",
+			name:      "Dnf AlmaLinux 9",
+			buildSpec: "../examples/almalinux/Apptainer",
+			requirements: func(t *testing.T) {
+				require.Command(t, "dnf")
+				require.RPMMacro(t, "_db_backend", "sqlite")
+				require.RPMMacro(t, "_dbpath", "/var/lib/rpm")
+				require.Arch(t, "amd64")
+			},
 		},
 		{
-			name:        "ZypperArm64",
-			dependency:  "zypper",
-			buildSpec:   "../examples/opensuse-arm64/Apptainer",
-			requireArch: "arm64",
+			name:       "DnfArm64 AlmaLinux 9",
+			dependency: "yum",
+			buildSpec:  "../examples/almalinux-arm64/Apptainer",
+			requirements: func(t *testing.T) {
+				require.Command(t, "dnf")
+				require.RPMMacro(t, "_db_backend", "sqlite")
+				require.RPMMacro(t, "_dbpath", "/var/lib/rpm")
+				require.Arch(t, "arm64")
+			},
+		},
+		{
+			name:      "Dnf Fedora 37",
+			buildSpec: "../examples/fedora/Apptainer",
+			requirements: func(t *testing.T) {
+				require.Command(t, "dnf")
+				require.RPMMacro(t, "_db_backend", "sqlite")
+				require.RPMMacro(t, "_dbpath", "/usr/lib/sysimage/rpm")
+				require.Arch(t, "amd64")
+			},
+		},
+		{
+			name:       "DnfArm64 Fedora 37",
+			dependency: "yum",
+			buildSpec:  "../examples/fedora-arm64/Apptainer",
+			requirements: func(t *testing.T) {
+				require.Command(t, "dnf")
+				require.RPMMacro(t, "_db_backend", "sqlite")
+				require.RPMMacro(t, "_dbpath", "/usr/lib/sysimage/rpm")
+				require.Arch(t, "arm64")
+			},
+		},
+		{
+			name:      "Zypper",
+			buildSpec: "../examples/opensuse/Apptainer",
+			requirements: func(t *testing.T) {
+				require.Command(t, "zypper")
+				require.Arch(t, "amd64")
+			},
+		},
+		{
+			name:      "ZypperArm64",
+			buildSpec: "../examples/opensuse-arm64/Apptainer",
+			requirements: func(t *testing.T) {
+				require.Command(t, "zypper")
+				require.Arch(t, "arm64")
+			},
 		},
 	}
 
@@ -131,6 +190,7 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tc := range tt {
+
 				dn, cleanup := c.tempDir(t, "build-from")
 				defer cleanup()
 
@@ -146,17 +206,7 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 					e2e.WithProfile(profile),
 					e2e.WithCommand("build"),
 					e2e.WithArgs(args...),
-					e2e.PreRun(func(t *testing.T) {
-						require.Arch(t, tc.requireArch)
-
-						if tc.dependency == "" {
-							return
-						}
-
-						if _, err := exec.LookPath(tc.dependency); err != nil {
-							t.Skipf("%v not found in path", tc.dependency)
-						}
-					}),
+					e2e.PreRun(tc.requirements),
 					e2e.PostRun(func(t *testing.T) {
 						if t.Failed() {
 							return

--- a/examples/almalinux-arm64/Apptainer
+++ b/examples/almalinux-arm64/Apptainer
@@ -1,0 +1,11 @@
+BootStrap: yum
+OSVersion: 9
+MirrorURL: http://repo.almalinux.org/almalinux/%{OSVERSION}/BaseOS/aarch64/os
+Include: dnf
+
+%runscript
+    echo "This is what happens when you run the container..."
+
+%post
+    echo "Hello from inside the container"
+    dnf -y install vim-minimal

--- a/examples/almalinux/Apptainer
+++ b/examples/almalinux/Apptainer
@@ -1,0 +1,11 @@
+BootStrap: yum
+OSVersion: 9
+MirrorURL: http://repo.almalinux.org/almalinux/%{OSVERSION}/BaseOS/x86_64/os
+Include: dnf
+
+%runscript
+    echo "This is what happens when you run the container..."
+
+%post
+    echo "Hello from inside the container"
+    dnf -y install vim-minimal

--- a/examples/fedora-arm64/Apptainer
+++ b/examples/fedora-arm64/Apptainer
@@ -1,0 +1,12 @@
+BootStrap: yum
+OSVersion: 37
+MirrorURL: http://dfw.mirror.rackspace.com/fedora/releases/%{OSVERSION}/Everything/aarch64/os/
+Include: fedora-release-container dnf
+Setopt: install_weak_deps=False
+
+%runscript
+    echo "This is what happens when you run the container..."
+
+%post
+    echo "Hello from inside the container"
+    dnf -y install vim-minimal

--- a/examples/fedora/Apptainer
+++ b/examples/fedora/Apptainer
@@ -1,0 +1,12 @@
+BootStrap: yum
+OSVersion: 37
+MirrorURL: http://dfw.mirror.rackspace.com/fedora/releases/%{OSVERSION}/Everything/x86_64/os/
+Include: fedora-release-container dnf
+Setopt: install_weak_deps=False
+
+%runscript
+    echo "This is what happens when you run the container..."
+
+%post
+    echo "Hello from inside the container"
+    dnf -y install vim-minimal

--- a/internal/pkg/build/sources/conveyorPacker_yum_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum_test.go
@@ -29,6 +29,8 @@ func TestYumConveyor(t *testing.T) {
 	// TODO - Centos puts non-amd64 at a different mirror location
 	// need multiple def files to test on other archs
 	require.Arch(t, "amd64")
+	require.RPMMacro(t, "_db_backend", "bdb")
+	require.RPMMacro(t, "_dbpath", "/var/lib/rpm")
 
 	if testing.Short() {
 		t.SkipNow()
@@ -73,6 +75,8 @@ func TestYumPacker(t *testing.T) {
 	// TODO - Centos puts non-amd64 at a different mirror location
 	// need multiple def files to test on other archs
 	require.Arch(t, "amd64")
+	require.RPMMacro(t, "_db_backend", "bdb")
+	require.RPMMacro(t, "_dbpath", "/var/lib/rpm")
 
 	if testing.Short() {
 		t.SkipNow()

--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/security/seccomp"
+	"github.com/apptainer/apptainer/internal/pkg/util/rpm"
 	"github.com/apptainer/apptainer/pkg/network"
 	"github.com/apptainer/apptainer/pkg/util/fs/proc"
 	"github.com/apptainer/apptainer/pkg/util/slice"
@@ -319,5 +320,16 @@ func MkfsExt3(t *testing.T) {
 
 	if !strings.Contains(buf.String(), "[-d ") {
 		t.Skipf("mkfs.ext3 is too old and doesn't support -d")
+	}
+}
+
+func RPMMacro(t *testing.T, name, value string) {
+	eval, err := rpm.GetMacro(name)
+	if err != nil {
+		t.Skipf("Couldn't get value of %s: %s", name, err)
+	}
+
+	if eval != value {
+		t.Skipf("Need %s as value of %s, got %s", value, name, eval)
 	}
 }

--- a/internal/pkg/util/rpm/rpm.go
+++ b/internal/pkg/util/rpm/rpm.go
@@ -1,0 +1,40 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package rpm
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+var ErrMacroUndefined = errors.New("macro is not defined")
+
+// GetMacro returns the value of the provided macro name
+func GetMacro(name string) (value string, err error) {
+	rpm, err := exec.LookPath("rpm")
+	if err != nil {
+		return "", fmt.Errorf("rpm command not found: %w", err)
+	}
+
+	args := []string{"--eval", "%{" + name + "}"}
+	cmd := exec.Command(rpm, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("while looking up value of rpm macro %s: %s", name, err)
+	}
+
+	eval := strings.TrimSuffix(string(out), "\n")
+	if eval == "%{"+name+"}" {
+		return "", ErrMacroUndefined
+	}
+	return eval, nil
+}

--- a/internal/pkg/util/rpm/rpm_test.go
+++ b/internal/pkg/util/rpm/rpm_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package rpm
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestGetMacro(t *testing.T) {
+	_, err := exec.LookPath("rpm")
+	if err != nil {
+		t.Skipf("rpm command not found in $PATH")
+	}
+
+	tests := []struct {
+		name      string
+		macroName string
+		wantValue string
+		wantErr   error
+	}{
+		{
+			name:      "_host_os",
+			macroName: "_host_os",
+			wantValue: "linux",
+			wantErr:   nil,
+		},
+		{
+			name:      "not defined",
+			macroName: "_not_a_macro_abc_123",
+			wantValue: "",
+			wantErr:   ErrMacroUndefined,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotValue, err := GetMacro(tt.macroName)
+			if err != tt.wantErr {
+				t.Errorf("GetMacro() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("GetMacro() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -592,4 +592,5 @@ var validHeaders = map[string]bool{
 	"otherurl&n":   true,
 	"fingerprints": true,
 	"confurl":      true,
+	"setopt":       true,
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1420
 which fixed
- sylabs/singularity# 1105

The original PR description was:
> The yum bootstrap is fragile, as over time rpm has changed both the format of its database, and the location of the database. This means that newer RPM distros (EL9, recent Fedora) cannot bootstrap older ones successfully.
> 
> * Refactor code checking for rpm macro values. 
> * Check for host `_db_backend` value `sqlite` and warn that older distros using `bdb` cannot be bootstrapped in this case.
> * Add a `setopt` def file header, which will pass the value to yum/dnf via the `--setopt` flag. This allows specifying `install_weak_deps=False`, which is necessary to bootstrap a minimal Fedora with no systemd (which fails to install).
> * Add examples and gated e2e tests so that we test bootstrapping CentOS 7, AlmaLinux 9, or Fedora 37, depending on what the host rpm setup will support. 
> * Don't create an `.rpmmacros` file for the e2e-tests to try and force bootstrap on 'foreign' distributions. This is no longer effective with the database format mistmatch issue, and blocks testing a Fedora bootstrap. 
> * Show standard output of yum/dnf bootstrap if log level is verbose or higher (permits debugging bootstraps more easily).