### PR TITLE
fix: address cgroups v1 device related e2e test failures, from sylabs 1430

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   required for later ROCm versions.
 - Ensure consistent binding of libraries under `--nv/--rocm` when duplicate
   `<library>.so[.version]` files are listed by `ldconfig -p`.
+- Fix joining cgroup of instance started as root, with cgroups v1,
+  non-default cgroupfs manager, and no device rules.
 
 ### Bug fixes
 

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -383,8 +383,11 @@ var resourceFlagTests = []resourceFlagTest{
 		args:            []string{"--blkio-weight", "50"},
 		expectErrorCode: 0,
 		controllerV1:    "blkio",
-		// This is the new path. Older kernels may have only `blkio.weight`
-		resourceV1:   "blkio.bfq.weight",
+		// Could be `blkio.bfq.weight` if bfq is available. However, under
+		// cgroups v1 older crun will not set blkio.bfq.weight, so only test
+		// with blkio.weight.
+		// Ref: https://github.com/containers/crun/issues/1157
+		resourceV1:   "blkio.weight",
 		expectV1:     "50",
 		delegationV2: "io",
 		resourceV2:   "io.bfq.weight",


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1430
 which fixed
- sylabs/singularity# 1418
- sylabs/singularity# 1419

The original PR description was:
> _fix: Never skip device cgroup creation_
> 
> If a container is being run with a cgroups LinuxResources config that doesn't include any device rules, then the device cgroup creation was skipped. Singularity has historically had default-allow, while runc/libcontainer/cgroups is default deny.
> 
> Under cgroups v1 with cgroupfs manager we need the device cgroup for PID -> cgroup lookup at instance join, so don't skip it... use an explicit allow rule instead.
> 
> At update, we still skip if there are no resources provided, so we don't update to a default allow, or deny.
> 
> Also set rootless flag on update properly, so that we avoid warnings / errors with rootless cgroups where device limits don't apply.
> 
> _e2e: Only test blkio.weight on cgroups v1, not blkio.bfq.weight_
> 
> crun has an issue where on cgroups v1 it won't handle blkio.weight -> blkio.bfq.weight on systems that use bfq.
> 
> Only test with blkio.weight present, so we avoid failure due to this issue.