### PR TITLE
rpm: fix: correct BuildRequires/Requires for SLES, from sylabs 1456

### DIFF
--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -91,19 +91,14 @@ BuildRequires: gcc
 BuildRequires: make
 # Paths to runtime dependencies detected by mconfig, so must be present at build time.
 BuildRequires: cryptsetup
-%if "%{_target_vendor}" == "suse"
-Requires: squashfs
-%else
-Requires: squashfs-tools
-%endif
 # Required for building bundled conmon
 BuildRequires: libseccomp-devel
 Requires: conmon
 # crun requirement not satisfied on EL7 or SLES default repos - use runc there.
-%if "%{_target_vendor}" == "suse" || 0%{?rhel} > 7
-Requires: crun
-%else
+%if "%{_target_vendor}" == "suse" || 0%{?rhel} < 8
 Requires: runc
+%else
+Requires: crun
 %endif
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1456
 which fixed
- sylabs/singularity# 1453

The original PR description was:
> * On SLES we intend to require runc, not crun.
> * squashfs had a duplicate Requires, instead of a BuildRequires.