### PR TITLE
e2e: refactor test image handling, from sylabs 1368

### DIFF
--- a/e2e/cache/regressions.go
+++ b/e2e/cache/regressions.go
@@ -84,6 +84,7 @@ func (c cacheTests) issue5097(t *testing.T) {
 // issue5350 - need to handle the cache being inside a non-accessible directory
 // e.g. home directory without perms to access
 func (c cacheTests) issue5350(t *testing.T) {
+	e2e.EnsureORASImage(t, c.env)
 	outerDir, cleanupOuter := e2e.MakeTempDir(t, c.env.TestDir, "issue5350-cache-", "")
 	defer e2e.Privileged(cleanupOuter)(t)
 
@@ -102,7 +103,7 @@ func (c cacheTests) issue5350(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs([]string{"--force", "-s", sandboxDir, "oras://ghcr.io/apptainer/alpine:3.15.0"}...),
+		e2e.WithArgs([]string{"--force", "-s", sandboxDir, c.env.OrasTestImage}...),
 		e2e.ExpectExit(0),
 	)
 

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -208,8 +208,9 @@ func (c *ctx) testContain(t *testing.T) {
 
 // Test by running directly from URI
 func (c *ctx) testInstanceFromURI(t *testing.T) {
-	name := "test_from_library"
-	args := []string{"oras://ghcr.io/apptainer/busybox:latest", name}
+	e2e.EnsureORASImage(t, c.env)
+	name := "test_from_uri"
+	args := []string{c.env.OrasTestImage, name}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(c.profile),

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -17,9 +17,10 @@ type TestEnv struct {
 	ImagePath            string // Path to the image that has to be used for the execution of an Apptainer command
 	SingularityImagePath string // Path to a Singularity image for legacy tests
 	DebianImagePath      string // Path to an image containing a Debian distribution with libc compatible to the host libc
-	OrasTestImage        string
+	OrasTestImage        string // URI to SIF image pushed into local registry with ORAS
 	TestDir              string // Path to the directory from which an Apptainer command needs to be executed
-	TestRegistry         string
+	TestRegistry         string // Host:Port of local registry
+	TestRegistryImage    string // URI to OCI image pushed into local registry
 	HomeDir              string // HomeDir sets the home directory that will be used for the execution of a command
 	KeyringDir           string // KeyringDir sets the directory where the keyring will be created for the execution of a command (instead of using APPTAINER_KEYSDIR which should be avoided when running e2e tests)
 	PrivCacheDir         string // PrivCacheDir sets the location of the image cache to be used by the Apptainer command to be executed as root (instead of using APPTAINER_CACHE_DIR which should be avoided when running e2e tests)

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -30,6 +30,7 @@ type ctx struct {
 // using that directory as cache. This reflects a problem that is important
 // for the grid use case.
 func (c ctx) testRun555Cache(t *testing.T) {
+	e2e.EnsureORASImage(t, c.env)
 	tempDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "", "")
 	defer cleanup(t)
 	cacheDir := filepath.Join(tempDir, "image-cache")
@@ -39,7 +40,7 @@ func (c ctx) testRun555Cache(t *testing.T) {
 	}
 	// Directory is deleted when tempDir is deleted
 
-	cmdArgs := []string{"oras://ghcr.io/apptainer/alpine:3.15.0", "/bin/true"}
+	cmdArgs := []string{c.env.OrasTestImage, "true"}
 	// We explicitly pass the environment to the command, not through c.env.ImgCacheDir
 	// because c.env is shared between all the tests, something we do not want here.
 	cacheDirEnv := fmt.Sprintf("%s=%s", cache.DirEnv, cacheDir)

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -140,6 +140,7 @@ func Run(t *testing.T) {
 	// create an empty ECL configuration and empty global keyring
 	e2e.SetupSystemECLAndGlobalKeyRing(t, testenv.TestDir)
 
+	// Creates '$HOME/.apptainer/docker-config.json' with credentials
 	e2e.SetupDockerHubCredentials(t)
 
 	// Ensure config files are installed
@@ -160,25 +161,18 @@ func Run(t *testing.T) {
 		}
 	}
 
-	// Build a base image for tests
-	imagePath := path.Join(name, "test.sif")
-	t.Log("Path to test image:", imagePath)
-	testenv.ImagePath = imagePath
-	defer os.Remove(imagePath)
-
 	testenv.SingularityImagePath = path.Join(name, "test-singularity.sif")
 	defer os.Remove(testenv.SingularityImagePath)
-
-	// WARNING(Sylabs-team): Please DO NOT add a call to e2e.EnsureImage here.
-	// If you need the test image, add the call at the top of your
-	// own test.
 
 	testenv.DebianImagePath = path.Join(name, "test-debian.sif")
 	defer os.Remove(testenv.DebianImagePath)
 
 	testenv.OrasTestImage = fmt.Sprintf("oras://%s/oras_test_sif:latest", testenv.TestRegistry)
 
-	// provision local registry
+	// Provision local registry
+	testenv.TestRegistryImage = fmt.Sprintf("docker://%s/my-busybox:latest", testenv.TestRegistry)
+
+	// Copy small test image (busybox:latest) into local registry from DockerHub
 	insecureSource := false
 	insecureValue := os.Getenv("E2E_DOCKER_MIRROR_INSECURE")
 	if insecureValue != "" {
@@ -187,7 +181,19 @@ func Run(t *testing.T) {
 			t.Fatalf("could not convert E2E_DOCKER_MIRROR_INSECURE=%s: %s", insecureValue, err)
 		}
 	}
-	e2e.CopyImage(t, "busybox:latest", fmt.Sprintf("%s/my-busybox:latest", testenv.TestRegistry), insecureSource, true)
+	e2e.CopyImage(t, "docker://busybox:latest", testenv.TestRegistryImage, insecureSource, true)
+
+	// SIF base test path, built on demand by e2e.EnsureImage
+	imagePath := path.Join(name, "test.sif")
+	t.Log("Path to test image:", imagePath)
+	testenv.ImagePath = imagePath
+
+	// Local registry ORAS SIF image, built on demand by e2e.EnsureORASImage
+	testenv.OrasTestImage = fmt.Sprintf("oras://%s/oras_test_sif:latest", testenv.TestRegistry)
+
+	t.Cleanup(func() {
+		os.Remove(imagePath)
+	})
 
 	suite := testhelper.NewSuite(t, testenv)
 


### PR DESCRIPTION
This pulls in sylabs part of PR

- sylabs/singularity# 1368
 which fixed
- sylabs/singularity# 1364

The original PR description was:
> Fetch the OCI archive image used in tests from Docker Hub, so that it will match the host architecture.