### PR TITLE
e2e: refactor test image handling, from sylabs 1368

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -19,25 +19,14 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 )
 
-const (
-	dockerArchiveURI = "https://github.com/apptainer/apptainer/releases/download/v0.1.0/alpine-docker-save.tar"
-)
-
 func (c actionTests) actionOciRun(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
+	e2e.EnsureDockerArchive(t, c.env)
 
-	// Prepare docker-archive source
-	tmpDir := t.TempDir()
-	dockerArchive := filepath.Join(tmpDir, "docker-archive.tar")
-	err := e2e.DownloadFile(dockerArchiveURI, dockerArchive)
-	if err != nil {
-		t.Fatalf("Could not download docker archive test file: %v", err)
-	}
-	defer os.Remove(dockerArchive)
 	// Prepare oci source (oci directory layout)
 	ociLayout := t.TempDir()
-	cmd := exec.Command("tar", "-C", ociLayout, "-xf", c.env.OCIImagePath)
-	err = cmd.Run()
+	cmd := exec.Command("tar", "-C", ociLayout, "-xf", c.env.OCIArchivePath)
+	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("Error extracting oci archive to layout: %v", err)
 	}
@@ -50,12 +39,12 @@ func (c actionTests) actionOciRun(t *testing.T) {
 	}{
 		{
 			name:     "docker-archive",
-			imageRef: "docker-archive:" + dockerArchive,
+			imageRef: "docker-archive:" + c.env.DockerArchivePath,
 			exit:     0,
 		},
 		{
 			name:     "oci-archive",
-			imageRef: "oci-archive:" + c.env.OCIImagePath,
+			imageRef: "oci-archive:" + c.env.OCIArchivePath,
 			exit:     0,
 		},
 		{
@@ -99,9 +88,9 @@ func (c actionTests) actionOciRun(t *testing.T) {
 
 // exec tests min fuctionality for apptainer exec
 func (c actionTests) actionOciExec(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
 
-	imageRef := "oci-archive:" + c.env.OCIImagePath
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
 	tests := []struct {
 		name string
@@ -173,7 +162,7 @@ func (c actionTests) actionOciExec(t *testing.T) {
 
 // Shell interaction tests
 func (c actionTests) actionOciShell(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
 
 	tests := []struct {
 		name       string
@@ -183,7 +172,7 @@ func (c actionTests) actionOciShell(t *testing.T) {
 	}{
 		{
 			name: "ShellExit",
-			argv: []string{"oci-archive:" + c.env.OCIImagePath},
+			argv: []string{"oci-archive:" + c.env.OCIArchivePath},
 			consoleOps: []e2e.ApptainerConsoleOp{
 				// "cd /" to work around issue where a long
 				// working directory name causes the test
@@ -199,7 +188,7 @@ func (c actionTests) actionOciShell(t *testing.T) {
 		},
 		{
 			name: "ShellBadCommand",
-			argv: []string{"oci-archive:" + c.env.OCIImagePath},
+			argv: []string{"oci-archive:" + c.env.OCIArchivePath},
 			consoleOps: []e2e.ApptainerConsoleOp{
 				e2e.ConsoleSendLine("_a_fake_command"),
 				e2e.ConsoleSendLine("exit"),
@@ -226,8 +215,8 @@ func (c actionTests) actionOciShell(t *testing.T) {
 }
 
 func (c actionTests) actionOciNetwork(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
-	imageRef := "oci-archive:" + c.env.OCIImagePath
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
 	tests := []struct {
 		name       string
@@ -287,8 +276,8 @@ func (c actionTests) actionOciNetwork(t *testing.T) {
 
 //nolint:maintidx
 func (c actionTests) actionOciBinds(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
-	imageRef := "oci-archive:" + c.env.OCIImagePath
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
 	workspace, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "bind-workspace-", "")
 	defer e2e.Privileged(cleanup)

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -384,18 +384,18 @@ func (c *ctx) actionApply(t *testing.T, profile e2e.Profile, imageRef string) {
 
 func (c *ctx) actionApplyRoot(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
 	t.Run(e2e.RootProfile.String(), func(t *testing.T) {
 		c.actionApply(t, e2e.RootProfile, c.env.ImagePath)
 	})
 	t.Run(e2e.OCIRootProfile.String(), func(t *testing.T) {
-		c.actionApply(t, e2e.OCIRootProfile, "oci-archive:"+c.env.OCIImagePath)
+		c.actionApply(t, e2e.OCIRootProfile, "oci-archive:"+c.env.OCIArchivePath)
 	})
 }
 
 func (c *ctx) actionApplyRootless(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
 	for _, profile := range []e2e.Profile{e2e.UserProfile, e2e.UserNamespaceProfile, e2e.FakerootProfile} {
 		t.Run(profile.String(), func(t *testing.T) {
 			c.actionApply(t, profile, c.env.ImagePath)
@@ -403,7 +403,7 @@ func (c *ctx) actionApplyRootless(t *testing.T) {
 	}
 	for _, profile := range []e2e.Profile{e2e.OCIUserProfile, e2e.OCIFakerootProfile} {
 		t.Run(profile.String(), func(t *testing.T) {
-			c.actionApply(t, profile, "oci-archive:"+c.env.OCIImagePath)
+			c.actionApply(t, profile, "oci-archive:"+c.env.OCIArchivePath)
 		})
 	}
 }
@@ -626,18 +626,18 @@ func (c *ctx) actionFlagV2(t *testing.T, tt resourceFlagTest, profile e2e.Profil
 
 func (c *ctx) actionFlagsRoot(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
 	t.Run(e2e.RootProfile.String(), func(t *testing.T) {
 		c.actionFlags(t, e2e.RootProfile, c.env.ImagePath)
 	})
 	t.Run(e2e.OCIRootProfile.String(), func(t *testing.T) {
-		c.actionFlags(t, e2e.OCIRootProfile, "oci-archive:"+c.env.OCIImagePath)
+		c.actionFlags(t, e2e.OCIRootProfile, "oci-archive:"+c.env.OCIArchivePath)
 	})
 }
 
 func (c *ctx) actionFlagsRootless(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
 	for _, profile := range []e2e.Profile{e2e.UserProfile, e2e.UserNamespaceProfile, e2e.FakerootProfile} {
 		t.Run(profile.String(), func(t *testing.T) {
 			c.actionFlags(t, profile, c.env.ImagePath)
@@ -645,7 +645,7 @@ func (c *ctx) actionFlagsRootless(t *testing.T) {
 	}
 	for _, profile := range []e2e.Profile{e2e.OCIUserProfile, e2e.OCIFakerootProfile} {
 		t.Run(profile.String(), func(t *testing.T) {
-			c.actionFlags(t, profile, "oci-archive:"+c.env.OCIImagePath)
+			c.actionFlags(t, profile, "oci-archive:"+c.env.OCIArchivePath)
 		})
 	}
 }

--- a/e2e/env/oci.go
+++ b/e2e/env/oci.go
@@ -19,8 +19,8 @@ import (
 )
 
 func (c ctx) ociApptainerEnv(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
-	defaultImage := "oci-archive:" + c.env.OCIImagePath
+	e2e.EnsureOCIArchive(t, c.env)
+	defaultImage := "oci-archive:" + c.env.OCIArchivePath
 
 	// Append or prepend this path.
 	partialPath := "/foo"
@@ -87,8 +87,8 @@ func (c ctx) ociApptainerEnv(t *testing.T) {
 }
 
 func (c ctx) ociEnvOption(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
-	defaultImage := "oci-archive:" + c.env.OCIImagePath
+	e2e.EnsureOCIArchive(t, c.env)
+	defaultImage := "oci-archive:" + c.env.OCIArchivePath
 
 	tests := []struct {
 		name     string
@@ -197,8 +197,8 @@ func (c ctx) ociEnvOption(t *testing.T) {
 }
 
 func (c ctx) ociEnvFile(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
-	defaultImage := "oci-archive:" + c.env.OCIImagePath
+	e2e.EnsureOCIArchive(t, c.env)
+	defaultImage := "oci-archive:" + c.env.OCIArchivePath
 
 	dir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "envfile-", "")
 	defer cleanup(t)

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -18,8 +18,9 @@ type TestEnv struct {
 	SingularityImagePath string // Path to a Singularity image for legacy tests
 	DebianImagePath      string // Path to an image containing a Debian distribution with libc compatible to the host libc
 	OrasTestImage        string // URI to SIF image pushed into local registry with ORAS
-	OCIImagePath         string
+	OCIArchivePath       string // Path to test OCI archive tar file
 	TestDir              string // Path to the directory from which an Apptainer command needs to be executed
+	DockerArchivePath    string // Path to test Docker archive tar file
 	TestRegistry         string // Host:Port of local registry
 	TestRegistryImage    string // URI to OCI image pushed into local registry
 	HomeDir              string // HomeDir sets the home directory that will be used for the execution of a command

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -164,12 +164,6 @@ func Run(t *testing.T) {
 	testenv.SingularityImagePath = path.Join(name, "test-singularity.sif")
 	defer os.Remove(testenv.SingularityImagePath)
 
-	// OCI Test image
-	ociImagePath := path.Join(name, "oci.tar")
-	t.Log("Path to test OCI image:", ociImagePath)
-	testenv.OCIImagePath = ociImagePath
-	defer os.Remove(ociImagePath)
-
 	testenv.DebianImagePath = path.Join(name, "test-debian.sif")
 	defer os.Remove(testenv.DebianImagePath)
 
@@ -194,11 +188,23 @@ func Run(t *testing.T) {
 	t.Log("Path to test image:", imagePath)
 	testenv.ImagePath = imagePath
 
+	// OCI Archive test image path, built on demand by e2e.EnsureOCIArchive
+	ociArchivePath := path.Join(name, "oci.tar")
+	t.Log("Path to test OCI archive:", ociArchivePath)
+	testenv.OCIArchivePath = ociArchivePath
+
+	// Docker Archive test image path, built on demand by e2e.EnsureDockerArhive
+	dockerArchivePath := path.Join(name, "docker.tar")
+	t.Log("Path to test Docker archive:", dockerArchivePath)
+	testenv.DockerArchivePath = dockerArchivePath
+
 	// Local registry ORAS SIF image, built on demand by e2e.EnsureORASImage
 	testenv.OrasTestImage = fmt.Sprintf("oras://%s/oras_test_sif:latest", testenv.TestRegistry)
 
 	t.Cleanup(func() {
 		os.Remove(imagePath)
+		os.Remove(ociArchivePath)
+		os.Remove(dockerArchivePath)
 	})
 
 	suite := testhelper.NewSuite(t, testenv)


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1368
 which fixed
- sylabs/singularity# 1364

The original PR description was:
> Fetch the OCI archive image used in tests from Docker Hub, so that it will match the host architecture.