### PR TITLE
oci: implemented CDI device mapping, from sylabs 1459

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,12 @@ pkg/library/client/test[0-9]*
 /debian
 
 LICENSE_DEPENDENCIES.csv
+
+# VSCode debugging build targets
+__debug_bin
+*/__debug_bin
+*/*/__debug_bin
+*/*/*/__debug_bin
+*/*/*/*/__debug_bin
+*/*/*/*/*/__debug_bin
+*/*/*/*/*/*/__debug_bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
       the container.
     - `--apply-cgroups`, and the `--cpu*`, `--blkio*`, `--memory*`,
       `--pids-limit` flags to apply resource limits.
+- Added `--device` flag to "action" commands (`run`/`exec`/`shell`) when run in
+  OCI mode (`--oci`). Currently supports passing one or more (comma-separated)
+  fully-qualified CDI device names, and those devices will then be made
+  available inside the container.
 
 ### Other changes
 

--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -17,6 +17,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/Netflix/go-expect/blob/master/LICENSE>
 
+## github.com/container-orchestrated-devices/container-device-interface
+
+**License:** Apache-2.0
+
+**License URL:** <https://github.com/container-orchestrated-devices/container-device-interface/blob/master/LICENSE>
+
 ## github.com/containerd/containerd
 
 **License:** Apache-2.0
@@ -281,6 +287,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/opencontainers/runtime-spec/blob/master/specs-go/LICENSE>
 
+## github.com/opencontainers/runtime-tools
+
+**License:** Apache-2.0
+
+**License URL:** <https://github.com/opencontainers/runtime-tools/blob/master/LICENSE>
+
 ## github.com/opencontainers/selinux
 
 **License:** Apache-2.0
@@ -497,6 +509,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/cyphar/filepath-securejoin/blob/master/LICENSE>
 
+## github.com/fsnotify/fsnotify
+
+**License:** BSD-3-Clause
+
+**License URL:** <https://github.com/fsnotify/fsnotify/blob/master/LICENSE>
+
 ## github.com/gogo/protobuf/proto
 
 **License:** BSD-3-Clause
@@ -592,6 +610,12 @@ The dependencies and their licenses are as follows:
 **License:** BSD-3-Clause
 
 **Project URL:** <https://golang.org/x/crypto>
+
+## golang.org/x/mod/semver
+
+**License:** BSD-3-Clause
+
+**Project URL:** <https://golang.org/x/mod/semver>
 
 ## golang.org/x/net
 
@@ -886,6 +910,12 @@ The dependencies and their licenses are as follows:
 **License:** MIT
 
 **Project URL:** <https://gopkg.in/yaml.v3>
+
+## sigs.k8s.io/yaml
+
+**License:** MIT
+
+**Project URL:** <https://sigs.k8s.io/yaml>
 
 ## github.com/gosimple/slug
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -42,6 +42,8 @@ var (
 	noMount          []string
 	dmtcpLaunch      string
 	dmtcpRestart     string
+	device           []string
+	cdiDirs          []string
 
 	isBoot          bool
 	isFakeroot      bool
@@ -114,7 +116,7 @@ var actionBindFlag = cmdline.Flag{
 	DefaultValue: cmdline.StringArray{}, // to allow commas in bind path
 	Name:         "bind",
 	ShortHand:    "B",
-	Usage:        "a user-bind path specification.  spec has the format src[:dest[:opts]], where src and dest are outside and inside paths.  If dest is not given, it is set equal to src.  Mount options ('opts') may be specified as 'ro' (read-only) or 'rw' (read/write, which is the default). Multiple bind paths can be given by a comma separated list.",
+	Usage:        "a user-bind path specification. spec has the format src[:dest[:opts]], where src and dest are outside and inside paths. If dest is not given, it is set equal to src. Mount options ('opts') may be specified as 'ro' (read-only) or 'rw' (read/write, which is the default). Multiple bind paths can be given by a comma separated list.",
 	EnvKeys:      []string{"BIND", "BINDPATH"},
 	Tag:          "<spec>",
 	EnvHandler:   cmdline.EnvAppendValue,
@@ -139,7 +141,7 @@ var actionHomeFlag = cmdline.Flag{
 	DefaultValue: CurrentUser.HomeDir,
 	Name:         "home",
 	ShortHand:    "H",
-	Usage:        "a home directory specification.  spec can either be a src path or src:dest pair.  src is the source path of the home directory outside the container and dest overrides the home directory within the container.",
+	Usage:        "a home directory specification. spec can either be a src path or src:dest pair. src is the source path of the home directory outside the container and dest overrides the home directory within the container.",
 	EnvKeys:      []string{"HOME"},
 	Tag:          "<spec>",
 }
@@ -862,6 +864,24 @@ var actionOCIFlag = cmdline.Flag{
 	EnvKeys:      []string{"OCI"},
 }
 
+// --device
+var actionDevice = cmdline.Flag{
+	ID:           "actionDevice",
+	Value:        &device,
+	DefaultValue: []string{},
+	Name:         "device",
+	Usage:        "fully-qualified CDI device name(s). A fully-qualified CDI device name consists of a VENDOR, CLASS, and NAME, which are combined as follows: <VENDOR>/<CLASS>=<NAME> (e.g. vendor.com/device=mydevice). Multiple fully-qualified CDI device names can be given as a comma separated list.",
+}
+
+// --cdi-dirs
+var actionCdiDirs = cmdline.Flag{
+	ID:           "actionCdiDirs",
+	Value:        &cdiDirs,
+	DefaultValue: []string{},
+	Name:         "cdi-dirs",
+	Usage:        "comma-separated list of directories in which CDI should look for device definition JSON files. If omitted, default will be: /etc/cdi,/var/run/cdi",
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -958,5 +978,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionIgnoreFakerootCommand, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionIgnoreUsernsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionOCIFlag, actionsCmd...)
+		cmdManager.RegisterFlagForCmd(&actionDevice, actionsCmd...)
+		cmdManager.RegisterFlagForCmd(&actionCdiDirs, actionsCmd...)
 	})
 }

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -406,6 +406,8 @@ func launchContainer(cmd *cobra.Command, image string, containerCmd string, cont
 		launcher.OptIgnoreUserns(ignoreUserns),
 		launcher.OptUseBuildConfig(useBuildConfig),
 		launcher.OptTmpDir(tmpDir),
+		launcher.OptDevice(device),
+		launcher.OptCdiDirs(cdiDirs),
 	}
 
 	var l launcher.Launcher

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2564,5 +2564,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociShell":   c.actionOciShell,   // apptainer shell --oci
 		"ociNetwork": c.actionOciNetwork, // apptainer exec --oci --net
 		"ociBinds":   c.actionOciBinds,   // apptainer exec --oci --bind / --mount
+		"ociCdi":     c.actionOciCdi,     // apptainer exec --oci --cdi
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -10,13 +10,18 @@
 package actions
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
+	cdispecs "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 )
 
 func (c actionTests) actionOciRun(t *testing.T) {
@@ -476,6 +481,221 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 					e2e.PostRun(tt.postRun),
 					e2e.ExpectExit(tt.exit),
 				)
+			}
+		})
+	}
+}
+
+func (c actionTests) actionOciCdi(t *testing.T) {
+	// Grab the reference OCI archive we're going to use
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	// Set up a custom subtestWorkspace object that will holds the collection of temporary directories (nested under the main temporary directory, mainDir) that each test will use.
+	type subtestWorkspace struct {
+		mainDir   string
+		jsonsDir  string
+		mountDirs []string
+	}
+
+	// Create a function to create a fresh subtestWorkspace, with distinct temporary directories, that each individual subtest will use
+	setupIndivSubtestWorkspace := func(t *testing.T, numMountDirs int) *subtestWorkspace {
+		stws := subtestWorkspace{}
+		mainDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "", "")
+		t.Cleanup(func() {
+			if !t.Failed() {
+				e2e.Privileged(cleanup)
+			}
+		})
+		stws.mainDir = mainDir
+
+		// No need to do anything with the cleanup functions returned here, because the directories created are all going to be children of (tw.)mainDir, whose cleanup was already registered above.
+		stws.jsonsDir, _ = e2e.MakeTempDir(t, stws.mainDir, "cdi-jsons-", "")
+		stws.mountDirs = make([]string, 0, numMountDirs)
+		for len(stws.mountDirs) < numMountDirs {
+			dir, _ := e2e.MakeTempDir(t, stws.mainDir, fmt.Sprintf("mount-dir-%d-", len(stws.mountDirs)+1), "")
+			// Make writable to all, due to current nested userns mapping restrictions.
+			// Will work without this once crun-specific single mapping is present.
+			os.Chmod(dir, 0o777)
+			stws.mountDirs = append(stws.mountDirs, dir)
+		}
+
+		return &stws
+	}
+
+	// Set up the JSON template that we're going to populate on a per-subtest basis with particular CDI spec values
+	e2eMountTemplateFilename := "cditemplate.json.tpl"
+	cdiJSONTemplateFilePath := filepath.Join("..", "test", "cdi", e2eMountTemplateFilename)
+	funcMap := template.FuncMap{
+		// The name "title" is what the function will be called in the template text.
+		"tojson": func(o any) string {
+			s, _ := json.Marshal(o)
+			return string(s)
+		},
+	}
+	cdiJSONTemplate, err := template.New(e2eMountTemplateFilename).Funcs(funcMap).ParseFiles(cdiJSONTemplateFilePath)
+	if err != nil {
+		t.Errorf("Could not read JSON template for CDI e2e tests from file %#v", cdiJSONTemplateFilePath)
+		return
+	}
+
+	// The set of actual subtests
+	var wantUID uint32 = 1000
+	var wantGID uint32 = 1000
+	tests := []struct {
+		name        string
+		devices     []string
+		wantExit    int
+		postRun     func(t *testing.T)
+		DeviceNodes []cdispecs.DeviceNode
+		Mounts      []cdispecs.Mount
+		Env         []string
+	}{
+		{
+			name: "ValidMounts",
+			devices: []string{
+				"apptainertesting.sylabs.io/device=TesterDevice",
+			},
+			wantExit:    0,
+			DeviceNodes: []cdispecs.DeviceNode{},
+			Mounts: []cdispecs.Mount{
+				{
+					ContainerPath: "/tmp/mount1",
+					Options:       []string{"rw", "bind", "users"},
+				},
+				{
+					ContainerPath: "/tmp/mount3",
+					Options:       []string{"rw", "bind", "users"},
+				},
+				{
+					ContainerPath: "/tmp/mount13",
+					Options:       []string{"rw", "bind", "users"},
+				},
+				{
+					ContainerPath: "/tmp/mount17",
+					Options:       []string{"rw", "bind", "users"},
+				},
+			},
+			Env: []string{
+				"ABCD=QWERTY",
+				"EFGH=ASDFGH",
+				"IJKL=ZXCVBN",
+			},
+		},
+		{
+			name: "InvalidDevice",
+			devices: []string{
+				"apptainertesting.sylabs.io/device=DoesNotExist",
+			},
+			wantExit:    255,
+			DeviceNodes: []cdispecs.DeviceNode{},
+			Mounts:      []cdispecs.Mount{},
+			Env:         []string{},
+		},
+		{
+			name: "KmsgDevice",
+			devices: []string{
+				"apptainertesting.sylabs.io/device=TesterDevice",
+			},
+			wantExit: 0,
+			DeviceNodes: []cdispecs.DeviceNode{
+				{
+					HostPath:    "/dev/kmsg",
+					Path:        "/dev/kmsg",
+					Permissions: "rw",
+					Type:        "c",
+					UID:         &wantUID,
+					GID:         &wantGID,
+				},
+			},
+		},
+	}
+
+	for _, profile := range e2e.OCIProfiles {
+		t.Run(profile.String(), func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					stws := setupIndivSubtestWorkspace(t, len(tt.Mounts))
+
+					// Populate the HostPath values we're going to feed into the CDI JSON template, based on the subtestWorkspace we just created
+					for i, d := range stws.mountDirs {
+						tt.Mounts[i].HostPath = d
+					}
+
+					// Inject this subtest's values into the template to create the CDI JSON file
+					cdiJSONFilePath := filepath.Join(stws.jsonsDir, fmt.Sprintf("%s-cdi.json", tt.name))
+					cdiJSONFile, err := os.OpenFile(cdiJSONFilePath, os.O_CREATE|os.O_WRONLY, 0o644)
+					if err != nil {
+						t.Errorf("could not create file %#v for writing CDI JSON: %v", cdiJSONFilePath, err)
+					}
+					if err = cdiJSONTemplate.Execute(cdiJSONFile, tt); err != nil {
+						t.Errorf("error executing template %#v to create CDI JSON: %v", cdiJSONTemplateFilePath, err)
+						return
+					}
+					cdiJSONFile.Close()
+
+					// Create a list of test strings, each of which will be echoed into a separate file in a separate mount in the container.
+					testfileStrings := make([]string, 0, len(tt.Mounts))
+					for i := range tt.Mounts {
+						testfileStrings = append(testfileStrings, fmt.Sprintf("test_string_for_mount_%d_in_test_%s", i, tt.name))
+					}
+
+					// Generate the command to be executed in the container
+					// Start by printing all environment variables, to test using e2e.ContainMatch conditions later
+					execCmd := "/bin/env"
+					for _, d := range tt.DeviceNodes {
+						testFlag := "-f"
+						switch d.Type {
+						case "c":
+							testFlag = "-c"
+						}
+						execCmd += fmt.Sprintf(" && test %s %s", testFlag, d.Path)
+					}
+					for i, m := range tt.Mounts {
+						// Add a separate teststring echo statement for each mount
+						execCmd += fmt.Sprintf(" && echo %s > %s/testfile_%d", testfileStrings[i], m.ContainerPath, i)
+					}
+
+					// Create a postRun function to check that the testfiles written to the container mounts made their way to the right host temporary directories
+					testMountsAndEnv := func(t *testing.T) {
+						for i, m := range tt.Mounts {
+							testfileFilename := filepath.Join(m.HostPath, fmt.Sprintf("testfile_%d", i))
+							b, err := os.ReadFile(testfileFilename)
+							if err != nil {
+								t.Errorf("could not read testfile %s", testfileFilename)
+								return
+							}
+
+							s := string(b)
+							if s != testfileStrings[i]+"\n" {
+								t.Errorf("mismatched testfileString; expected %#v, got %#v (mount: %#v)", s, testfileStrings[i], m)
+							}
+						}
+					}
+
+					// Create a set of e2e.ApptainerCmdResultOp objects to test that environment variables have been correctly injected into the container
+					envExpects := make([]e2e.ApptainerCmdResultOp, 0, len(tt.Env))
+					for _, e := range tt.Env {
+						envExpects = append(envExpects, e2e.ExpectOutput(e2e.ContainMatch, e))
+					}
+
+					c.env.RunApptainer(
+						t,
+						e2e.AsSubtest(tt.name),
+						e2e.WithCommand("exec"),
+						e2e.WithArgs(
+							"--device",
+							strings.Join(tt.devices, ","),
+							"--cdi-dirs",
+							stws.jsonsDir,
+							imageRef,
+							"/bin/sh", "-c", execCmd),
+						e2e.WithProfile(profile),
+						e2e.ExpectExit(tt.wantExit, envExpects...),
+						e2e.PostRun(tt.postRun),
+						e2e.PostRun(testMountsAndEnv),
+					)
+				})
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/buger/goterm v1.0.4
 	github.com/buger/jsonparser v1.1.1
 	github.com/cenkalti/backoff/v4 v4.2.0
+	github.com/container-orchestrated-devices/container-device-interface v0.5.4
 	github.com/containerd/containerd v1.6.19
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.2.0
@@ -32,11 +33,12 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/opencontainers/runc v1.1.5
 	github.com/opencontainers/runtime-spec v1.1.0-rc.1
-	github.com/opencontainers/runtime-tools v0.9.1-0.20210326182921-59cdde06764b
+	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626
 	github.com/opencontainers/selinux v1.11.0
 	github.com/opencontainers/umoci v0.4.7
 	github.com/pelletier/go-toml/v2 v2.0.7
 	github.com/pkg/errors v0.9.1
+	github.com/samber/lo v1.38.1
 	github.com/seccomp/containers-golang v0.6.0
 	github.com/seccomp/libseccomp-golang v0.10.0
 	github.com/shopspring/decimal v1.3.1
@@ -74,7 +76,6 @@ require (
 	github.com/alexflint/go-filemutex v1.2.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/bugsnag/bugsnag-go v1.5.1 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -95,6 +96,7 @@ require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect
@@ -170,6 +172,7 @@ require (
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.mongodb.org/mongo-driver v1.11.1 // indirect
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 // indirect
+	golang.org/x/exp v0.0.0-20220823124025-807a23277127 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
@@ -179,6 +182,7 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 // Temporarily force an image-spec that has the main branch commits not in 1.0.2 which is being brought in by oras-go

--- a/go.sum
+++ b/go.sum
@@ -166,7 +166,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
@@ -226,6 +225,8 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
+github.com/container-orchestrated-devices/container-device-interface v0.5.4 h1:PqQGqJqQttMP5oJ/qNGEg8JttlHqGY3xDbbcKb5T9E8=
+github.com/container-orchestrated-devices/container-device-interface v0.5.4/go.mod h1:DjE95rfPiiSmG7uVXtg0z6MnPm/Lx4wxKCIts0ZE0vg=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
 github.com/containerd/aufs v0.0.0-20210316121734-20793ff83c97/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=
@@ -461,6 +462,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 h1:LofdAjjjqCSXMwLGgOgnE+rdPuvX9DxCqaHwKy7i/ko=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
@@ -880,6 +882,7 @@ github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
+github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34fGzaAZGFW22KVZDfyrYW+QABMrWnJBnSs=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/patternmatcher v0.5.0 h1:YCZgJOeULcxLw1Q+sVR636pmS7sPEn1Qo2iAN6M7DBo=
@@ -977,15 +980,17 @@ github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-spec v1.0.3-0.20200710190001-3e4195d92445/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.1.0-rc.1 h1:wHa9jroFfKGQqFHj0I1fMRKLl0pfj+ynAqBxo3v6u9w=
 github.com/opencontainers/runtime-spec v1.1.0-rc.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
-github.com/opencontainers/runtime-tools v0.9.1-0.20210326182921-59cdde06764b h1:BDT83NWjBPS3Esj/BS1Cf9F4NYzYmiitJZ0TlXx5M4w=
-github.com/opencontainers/runtime-tools v0.9.1-0.20210326182921-59cdde06764b/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
+github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 h1:DmNGcqH3WDbV5k8OJ+esPWbqUOX5rMLR2PMvziDMJi0=
+github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
+github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
@@ -1082,6 +1087,8 @@ github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiB
 github.com/safchain/ethtool v0.2.0 h1:dILxMBqDnQfX192cCAPjZr9v2IgVXeElHPy435Z/IdE=
 github.com/safchain/ethtool v0.2.0/go.mod h1:WkKB1DnNtvsMlDmQ50sgwowDJV/hGbJSOvJoEXs1AJQ=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
+github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
+github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
@@ -1202,6 +1209,7 @@ github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0o
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli v1.19.1/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
@@ -1339,6 +1347,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220823124025-807a23277127 h1:S4NrSKDfihhl3+4jSTgwoIevKxX9p7Iv9x++OEIptDo=
+golang.org/x/exp v0.0.0-20220823124025-807a23277127/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -1584,6 +1594,7 @@ golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220909162455-aba9fc2a8ff2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1945,3 +1956,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -79,6 +79,13 @@ func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
 			return nil, fmt.Errorf("%w", err)
 		}
 	}
+	if len(lo.Devices) > 0 {
+		return nil, fmt.Errorf("CDI device mappings unsupported in native launcher")
+	}
+
+	if len(lo.CdiDirs) > 0 {
+		return nil, fmt.Errorf("CDI device mappings unsupported in native launcher")
+	}
 
 	// Initialize empty default Apptainer Engine and OCI configuration
 	engineConfig := apptainerConfig.NewConfig()

--- a/internal/pkg/runtime/launcher/oci/cdi_linux.go
+++ b/internal/pkg/runtime/launcher/oci/cdi_linux.go
@@ -1,0 +1,60 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// Includes code from https://github.com/containers/podman
+// Released under the Apache License Version 2.0
+
+package oci
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// A container to hold the CDI registry, plus a sync.Once object to ensure we only have to ask for it once
+var regSyncContainer struct {
+	reg      cdi.Registry
+	initOnce sync.Once
+	err      error
+}
+
+// addCDIDevices adds an array of CDI devices to an existing spec.
+// Accepts optional, variable number of cdi.Option arguments (to which cdi.WithAutoRefresh(false) will be prepended). Note that due to the use of a sync.Once initialization strategy, these options will only have an effect if this is the first call made to addCDIDevices().
+func addCDIDevices(spec *specs.Spec, cdiDevices []string, cdiRegOptions ...cdi.Option) error {
+	regSyncContainer.initOnce.Do(func() {
+		// Get the CDI registry, passing a cdi.WithAutoRefresh(false) option so that CDI registry files are not scanned asynchronously. (We are about to call a manual refresh, below.)
+		realCDIOptions := append([]cdi.Option{cdi.WithAutoRefresh(false)}, cdiRegOptions...)
+		regSyncContainer.reg = cdi.GetRegistry(realCDIOptions...)
+		regSyncContainer.err = regSyncContainer.reg.Refresh()
+	})
+
+	if regSyncContainer.err != nil {
+		return fmt.Errorf("Error encountered refreshing the CDI registry during initialization: %v", regSyncContainer.err)
+	}
+
+	for _, cdiDevice := range cdiDevices {
+		if !isCDIDevice(cdiDevice) {
+			return fmt.Errorf("string %#v does not represent a valid CDI device", cdiDevice)
+		}
+	}
+
+	if _, err := regSyncContainer.reg.InjectDevices(spec, cdiDevices...); err != nil {
+		return fmt.Errorf("Error encountered setting up CDI devices: %w", err)
+	}
+
+	return nil
+}
+
+// isCDIDevice checks whether a string is a valid CDI device selector.
+func isCDIDevice(str string) bool {
+	return cdi.IsQualifiedName(str)
+}

--- a/internal/pkg/runtime/launcher/oci/cdi_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/cdi_linux_test.go
@@ -1,0 +1,263 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// Package oci implements a Launcher that will configure and launch a container
+// with an OCI runtime. It also provides implementations of OCI state
+// transitions that can be called directly, Create/Start/Kill etc.
+package oci
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/samber/lo"
+)
+
+var specDirs = []string{filepath.Join("..", "..", "..", "..", "..", "test", "cdi")}
+
+type mountsList []specs.Mount
+
+func (a mountsList) Len() int           { return len(a) }
+func (a mountsList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a mountsList) Less(i, j int) bool { return a[i].Destination < a[j].Destination }
+
+func Test_addCDIDevice(t *testing.T) {
+	var wantUID uint32 = 1000
+	var wantGID uint32 = 1000
+	tests := []struct {
+		name        string
+		devices     []string
+		wantDevices []specs.LinuxDevice
+		wantMounts  mountsList
+		wantErr     bool
+		wantEnv     []string
+	}{
+		{
+			name: "ValidOneDeviceKmsg",
+			devices: []string{
+				"apptainertesting.sylabs.io/device=kmsgDevice",
+			},
+			wantDevices: []specs.LinuxDevice{
+				{
+					Path:     "/dev/kmsg",
+					Type:     "c",
+					Major:    1,
+					Minor:    11,
+					FileMode: nil,
+					UID:      &wantUID,
+					GID:      &wantGID,
+				},
+			},
+			wantMounts: mountsList{
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmountforkmsg",
+					Type:        "",
+					Options:     []string{"rw"},
+				},
+			},
+			wantEnv: []string{
+				"FOO=VALID_SPEC",
+				"BAR=BARVALUE1",
+			},
+		},
+		{
+			name: "ValidTmpDevices",
+			devices: []string{
+				"apptainertesting.sylabs.io/device=tmpmountDevice17",
+				"apptainertesting.sylabs.io/device=tmpmountDevice1",
+			},
+			wantDevices: []specs.LinuxDevice{},
+			wantMounts: mountsList{
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmount1",
+					Type:        "",
+					Options:     []string{"ro"},
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmount3",
+					Type:        "",
+					Options:     []string{"rbind", "nosuid", "nodev"},
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmount13",
+					Type:        "",
+					Options:     []string{"rw"},
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmount17",
+					Type:        "",
+					Options:     []string{"r"},
+				},
+			},
+			wantEnv: []string{
+				"ABCD=QWERTY",
+				"EFGH=ASDFGH",
+				"IJKL=ZXCVBN",
+				"FOO=VALID_SPEC",
+				"BAR=BARVALUE1",
+			},
+		},
+		{
+			name: "ValidTmpDevicesFromOneJSON",
+			devices: []string{
+				"apptainertesting.sylabs.io/device=tmpmountDevice1",
+			},
+			wantDevices: []specs.LinuxDevice{},
+			wantMounts: mountsList{
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmount1",
+					Type:        "",
+					Options:     []string{"ro"},
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmount3",
+					Type:        "",
+					Options:     []string{"rbind", "nosuid", "nodev"},
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmount13",
+					Type:        "",
+					Options:     []string{"rw"},
+				},
+			},
+			wantEnv: []string{
+				"ABCD=QWERTY",
+				"EFGH=ASDFGH",
+				"IJKL=ZXCVBN",
+			},
+		},
+		{
+			name: "ValidMixedDevices",
+			devices: []string{
+				"apptainertesting.sylabs.io/device=tmpmountDevice17",
+				"apptainertesting.sylabs.io/device=kmsgDevice",
+				"apptainertesting.sylabs.io/device=tmpmountDevice1",
+			},
+			wantDevices: []specs.LinuxDevice{
+				{
+					Path:     "/dev/kmsg",
+					Type:     "c",
+					Major:    1,
+					Minor:    11,
+					FileMode: nil,
+					UID:      &wantUID,
+					GID:      &wantGID,
+				},
+			},
+			wantMounts: mountsList{
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmount1",
+					Type:        "",
+					Options:     []string{"ro"},
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmount3",
+					Type:        "",
+					Options:     []string{"rbind", "nosuid", "nodev"},
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmount13",
+					Type:        "",
+					Options:     []string{"rw"},
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmount17",
+					Type:        "",
+					Options:     []string{"r"},
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/tmpmountforkmsg",
+					Type:        "",
+					Options:     []string{"rw"},
+				},
+			},
+			wantEnv: []string{
+				"ABCD=QWERTY",
+				"EFGH=ASDFGH",
+				"IJKL=ZXCVBN",
+				"FOO=VALID_SPEC",
+				"BAR=BARVALUE1",
+			},
+		},
+		{
+			name: "InvalidNameOneDevice",
+			devices: []string{
+				"apptainertesting.sylabs.io/device=noSuchDevice",
+			},
+			wantErr: true,
+		},
+		{
+			name: "InvalidNameSeveralDevices",
+			devices: []string{
+				"apptainertesting.sylabs.io/device=noSuchDevice",
+				"apptainertesting.sylabs.io/device=noSuchDeviceEither",
+			},
+			wantErr: true,
+		},
+		{
+			name: "InvalidNameAmongValids",
+			devices: []string{
+				"apptainertesting.sylabs.io/device=tmpmountDevice17",
+				"apptainertesting.sylabs.io/device=noSuchDevice",
+				"apptainertesting.sylabs.io/device=tmpmountDevice1",
+				"apptainertesting.sylabs.io/device=kmsgDevice",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := minimalSpec()
+			err := addCDIDevices(&spec, tt.devices, cdi.WithSpecDirs(specDirs...))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("addCDIDevices() mismatched error values; expected %v, got %v.", tt.wantErr, err)
+			}
+
+			// We need this if-statement because the comparison below is done with reflection, and so a nil array and a non-nil but zero-length array will be considered different (which is not what we want here)
+			if (len(tt.wantMounts) > 0) || (len(spec.Mounts) > 0) {
+				// Note that the current implementation of OCI/CDI sorts the mounts generated by the set of mapped devices, therefore we compare against a sorted list.
+				sort.Sort(tt.wantMounts)
+				if !reflect.DeepEqual(mountsList(spec.Mounts), tt.wantMounts) {
+					t.Errorf("addCDIDevices() mismatched mounts; expected %v, got %v.", tt.wantMounts, spec.Mounts)
+				}
+			}
+
+			envMissing := hashingListSubtract(tt.wantEnv, spec.Process.Env)
+			if len(envMissing) > 0 {
+				t.Errorf("addCDIDevices() mismatched environment variables; expected, but did not find, the following environment variables: %v", envMissing)
+			}
+		})
+	}
+}
+
+// hashingListSubtract is a utility-function for subtracting a list from another list, using map's internal hashing function to do this more efficiently than lo.Difference or lo.Without (which only assume comparable, and thus run in quadratic time).
+func hashingListSubtract[T comparable](toSubstractFrom []T, toSubstract []T) []T {
+	subtractionMap := lo.FromEntries(lo.Map(toSubstractFrom, func(item T, _ int) lo.Entry[T, bool] {
+		return lo.Entry[T, bool]{Key: item, Value: true}
+	}))
+
+	return lo.Keys(lo.OmitByKeys(subtractionMap, toSubstract))
+}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	"github.com/google/uuid"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -210,7 +211,7 @@ func checkOpts(lo launcher.Options) error {
 // createSpec creates an initial OCI runtime specification, suitable to launch a
 // container. This spec excludes the Process config, as this has to be computed
 // where the image config is available, to account for the image's CMD /
-// ENTRYPOINT / ENV / USER.
+// ENTRYPOINT / ENV / USER. See finalizeSpec() function.
 func (l *Launcher) createSpec() (*specs.Spec, error) {
 	spec := minimalSpec()
 
@@ -296,6 +297,16 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 		return err
 	}
 	spec.Process = specProcess
+
+	if len(l.cfg.CdiDirs) > 0 {
+		err = addCDIDevices(spec, l.cfg.Devices, cdi.WithSpecDirs(l.cfg.CdiDirs...))
+	} else {
+		err = addCDIDevices(spec, l.cfg.Devices)
+	}
+	if err != nil {
+		return err
+	}
+
 	if err := b.Update(ctx, spec); err != nil {
 		return err
 	}

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
 	"github.com/apptainer/apptainer/pkg/sylog"
+
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -152,6 +152,12 @@ type Options struct {
 	// SysContext holds Docker/OCI image handling configuration.
 	// This will be used by a launcher handling OCI images directly.
 	SysContext *types.SystemContext
+
+	// Devices contains the list of device mappings (if any), e.g. CDI mappings.
+	Devices []string
+
+	// CdiDirs contains the list of directories in which CDI should look for device definition JSON files
+	CdiDirs []string
 }
 
 type Option func(co *Options) error
@@ -546,6 +552,22 @@ func OptTmpDir(a string) Option {
 func OptSysContext(sc *types.SystemContext) Option {
 	return func(lo *Options) error {
 		lo.SysContext = sc
+		return nil
+	}
+}
+
+// OptDevice sets CDI device mappings to apply.
+func OptDevice(op []string) Option {
+	return func(lo *Options) error {
+		lo.Devices = op
+		return nil
+	}
+}
+
+// OptCdiDirs sets CDI spec search-directories to apply.
+func OptCdiDirs(op []string) Option {
+	return func(lo *Options) error {
+		lo.CdiDirs = op
 		return nil
 	}
 }

--- a/test/cdi/cditemplate.json.tpl
+++ b/test/cdi/cditemplate.json.tpl
@@ -1,0 +1,18 @@
+{
+	"cdiVersion": "0.5.0",
+	"kind": "apptainertesting.sylabs.io/device",
+
+	"devices": [
+		{
+			"name": "TesterDevice",
+			"containerEdits": {
+				"deviceNodes": {{tojson .DeviceNodes}},
+				"mounts": {{tojson .Mounts}}
+			}
+		}
+	],
+
+	"containerEdits": {
+		"env": {{tojson .Env}}
+	}
+}

--- a/test/cdi/kmsg.json
+++ b/test/cdi/kmsg.json
@@ -1,0 +1,51 @@
+{
+	"cdiVersion": "0.5.0",
+	"kind": "apptainertesting.sylabs.io/device",
+
+	"devices": [
+		{
+			"name": "kmsgDevice",
+			"containerEdits": {
+				"deviceNodes": [
+					{
+						"hostPath": "/dev/kmsg",
+						"path": "/dev/kmsg",
+						"permissions": "rw",
+						"uid": 1000,
+						"gid": 1000
+					}
+				],
+				"mounts": [
+					{
+						"containerPath": "/tmpmountforkmsg",
+						"options": [
+							"rw"
+						],
+						"hostPath": "/tmp"
+					}
+				]
+			}
+		},
+		{
+			"name": "tmpmountDevice17",
+			"containerEdits": {
+				"mounts": [
+					{
+						"containerPath": "/tmpmount17",
+						"options": [
+							"r"
+						],
+						"hostPath": "/tmp"
+					}
+				]
+			}
+		}
+	],
+
+	"containerEdits": {
+		"env": [
+			"FOO=VALID_SPEC",
+			"BAR=BARVALUE1"
+		  ]
+	  }
+}

--- a/test/cdi/tmpmount.json
+++ b/test/cdi/tmpmount.json
@@ -1,0 +1,45 @@
+{
+	"cdiVersion": "0.5.0",
+	"kind": "apptainertesting.sylabs.io/device",
+
+	"devices": [
+		{
+			"name": "tmpmountDevice1",
+			"containerEdits": {
+				"mounts": [
+					{
+						"containerPath": "/tmpmount13",
+						"options": [
+							"rw"
+						],
+						"hostPath": "/tmp"
+					},
+					{
+						"containerPath": "/tmpmount3",
+						"options": [
+							"rbind",
+							"nosuid",
+							"nodev"
+						],
+						"hostPath": "/tmp"
+					},
+					{
+						"containerPath": "/tmpmount1",
+						"options": [
+							"ro"
+						],
+						"hostPath": "/tmp"
+					}
+				]
+			}
+		}
+	],
+
+	"containerEdits": {
+		"env": [
+			"ABCD=QWERTY",
+			"EFGH=ASDFGH",
+			"IJKL=ZXCVBN"
+		  ]
+	}
+}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1459
 which fixed
- sylabs/singularity# 1394

The original PR description was:
> Added a `--device` flag to the experimental `--oci` runtime mode, allowing the user to make a device available in the contained using a CDI configuration.