### PR TITLE
oci: support --scratch, from sylabs 1498

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   fully-qualified CDI device names, and those devices will then be made
   available inside the container.
 - OCI mode now supports `--hostname` (requires UTS namespace, therefore this
-  flag will infer `--uts` if running in OCI mode).
+  flag will infer `--uts`).
+- OCI mode now supports `--scratch` (shorthand: `-S`) to mount a tmpfs scratch
+  directory in the container.
 
 ### Other changes
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1162,10 +1162,11 @@ func (c actionTests) actionBinds(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		args    []string
-		postRun func(*testing.T)
-		exit    int
+		name        string
+		args        []string
+		wantOutputs []e2e.ApptainerCmdResultOp
+		postRun     func(*testing.T)
+		exit        int
 	}{
 		{
 			name: "NonExistentSource",
@@ -1476,6 +1477,28 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit:    0,
 		},
 		{
+			name: "IsScratchTmpfs",
+			args: []string{
+				"--scratch", "/name-of-a-scratch",
+				sandbox,
+				"mount",
+			},
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `\btmpfs on /name-of-a-scratch\b`),
+			},
+			exit: 0,
+		},
+		{
+			name: "BindOverScratch",
+			args: []string{
+				"--scratch", "/name-of-a-scratch",
+				"--bind", hostCanaryDir + ":/name-of-a-scratch",
+				sandbox,
+				"test", "-f", "/name-of-a-scratch/file",
+			},
+			exit: 0,
+		},
+		{
 			name: "ScratchTmpfsBind",
 			args: []string{
 				"--scratch", "/scratch",
@@ -1573,7 +1596,7 @@ func (c actionTests) actionBinds(t *testing.T) {
 					e2e.WithCommand("exec"),
 					e2e.WithArgs(tt.args...),
 					e2e.PostRun(tt.postRun),
-					e2e.ExpectExit(tt.exit),
+					e2e.ExpectExit(tt.exit, tt.wantOutputs...),
 				)
 			}
 		})

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -346,10 +346,11 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		args    []string
-		postRun func(*testing.T)
-		exit    int
+		name        string
+		args        []string
+		wantOutputs []e2e.ApptainerCmdResultOp
+		postRun     func(*testing.T)
+		exit        int
 	}{
 		{
 			name: "NonExistentSource",
@@ -448,6 +449,38 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 			postRun: checkHostFile(filepath.Join(hostCanaryDir, "nested")),
 			exit:    0,
 		},
+		{
+			name: "IsScratchTmpfs",
+			args: []string{
+				"--scratch", "/name-of-a-scratch",
+				imageRef,
+				"mount",
+			},
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `\btmpfs on /name-of-a-scratch\b`),
+			},
+			exit: 0,
+		},
+		{
+			name: "BindOverScratch",
+			args: []string{
+				"--scratch", "/name-of-a-scratch",
+				"--bind", hostCanaryDir + ":/name-of-a-scratch",
+				imageRef,
+				"test", "-f", "/name-of-a-scratch/file",
+			},
+			exit: 0,
+		},
+		{
+			name: "ScratchTmpfsBind",
+			args: []string{
+				"--scratch", "/scratch",
+				"--bind", hostCanaryDir + ":/scratch/dir",
+				imageRef,
+				"test", "-f", "/scratch/dir/file",
+			},
+			exit: 0,
+		},
 		// For the --mount variants we are really just verifying the CLI
 		// acceptance of one or more --mount flags. Translation from --mount
 		// strings to BindPath structs is checked in unit tests. The
@@ -488,7 +521,7 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 					e2e.WithCommand("exec"),
 					e2e.WithArgs(tt.args...),
 					e2e.PostRun(tt.postRun),
-					e2e.ExpectExit(tt.exit),
+					e2e.ExpectExit(tt.exit, tt.wantOutputs...),
 				)
 			}
 		})

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -86,9 +86,6 @@ func checkOpts(lo launcher.Options) error {
 	if len(lo.OverlayPaths) > 0 {
 		badOpt = append(badOpt, "OverlayPaths")
 	}
-	if len(lo.ScratchDirs) > 0 {
-		badOpt = append(badOpt, "ScratchDirs")
-	}
 	if lo.WorkDir != "" {
 		badOpt = append(badOpt, "WorkDir")
 	}

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -40,6 +40,9 @@ func (l *Launcher) getMounts() ([]specs.Mount, error) {
 	if err := l.addHomeMount(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring home mount: %w", err)
 	}
+	if err := l.addScratchMounts(mounts); err != nil {
+		return nil, fmt.Errorf("while configuring scratch mount(s): %w", err)
+	}
 	if err := l.addBindMounts(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring bind mount(s): %w", err)
 	}
@@ -207,6 +210,27 @@ func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
 				fmt.Sprintf("gid=%d", pw.GID),
 			},
 		})
+	return nil
+}
+
+// addScratchMounts adds tmpfs mounts for scratch directories in the container.
+func (l *Launcher) addScratchMounts(mounts *[]specs.Mount) error {
+	for _, s := range l.cfg.ScratchDirs {
+		*mounts = append(*mounts,
+			specs.Mount{
+				Destination: s,
+				Type:        "tmpfs",
+				Source:      "tmpfs",
+				Options: []string{
+					"nosuid",
+					"relatime",
+					"nodev",
+					fmt.Sprintf("size=%dm", l.apptainerConf.SessiondirMaxSize),
+				},
+			},
+		)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1498
 which fixed
- sylabs/singularity# 1482

The original PR description was:
> Support `--scratch` (shorthand: `-S`) for mounting a tmpfs scratch directory in the container in oci mode, just like we do in native mode.
> ### Testing notes
> 
> Added e2e tests for this functionality in oci mode, mirroring and extending the e2e tests for the corresponding native-mode functionality. Added a couple of tests to both modes:
> 
> * Test that a scratch-mounted dir is indeed present in the container as a mount with `tmpfs` filesystem
> * Test that when a bind-mounted dir shares a path with a scratch-mounted dir, the bind-mounted one will override the scratch-mounted one. (This was already behavior in native mode, though it wasn't being tested, as far as I could tell. Now it's enforced by the e2e tests for each of the two modes.)