### PR TITLE
oci: support --pwd, from sylabs 1558

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   flag will infer `--uts`).
 - OCI mode now supports `--scratch` (shorthand: `-S`) to mount a tmpfs scratch
   directory in the container.
+- Support `--pwd` in OCI mode.
 
 ### Other changes
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -156,6 +156,14 @@ func (c actionTests) actionOciExec(t *testing.T) {
 				e2e.ExpectOutput(e2e.ExactMatch, "whats-in-an-oci-name"),
 			},
 		},
+		{
+			name: "Pwd",
+			argv: []string{"--pwd", "/tmp", imageRef, "pwd"},
+			exit: 0,
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.ExactMatch, "/tmp"),
+			},
+		},
 	}
 	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -166,9 +166,6 @@ func checkOpts(lo launcher.Options) error {
 	if lo.ShellPath != "" {
 		badOpt = append(badOpt, "ShellPath")
 	}
-	if lo.PwdPath != "" {
-		badOpt = append(badOpt, "PwdPath")
-	}
 
 	if lo.Boot {
 		badOpt = append(badOpt, "Boot")

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -92,6 +92,10 @@ func getProcessArgs(imageSpec imgspecv1.Image, process string, args []string) []
 // getProcessCwd computes the Cwd that the container process should start in.
 // Currently this is the user's tmpfs home directory (see --containall).
 func (l *Launcher) getProcessCwd() (dir string, err error) {
+	if len(l.cfg.PwdPath) > 1 {
+		return l.cfg.PwdPath, nil
+	}
+
 	if l.cfg.Fakeroot {
 		return "/root", nil
 	}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1558
 which fixed
- sylabs/singularity# 1481

The original PR description was:
> Cherry-pick first half of sylabs/singularity# 1496
>
> Support --pwd in OCI mode.