### PR TITLE
oci: support --home, from sylabs 1500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - OCI mode now supports `--scratch` (shorthand: `-S`) to mount a tmpfs scratch
   directory in the container.
 - Support `--pwd` in OCI mode.
+- OCI mode now supports `--home`. Supplying a single location (e.g.
+  `--home /myhomedir`) will result in a new tmpfs directory being created at the
+  specified location inside the container, and that dir being set as the
+  in-container user's home dir. Supplying two locations separated by a colon
+  (e.g. `--home /home/user:/myhomedir`) will result in the first location on the
+  host being bind-mounted as the second location in-container, and set as
+  the in-container user's home dir.
 
 ### Other changes
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -104,7 +104,11 @@ func (c actionTests) actionExec(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(testdata)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.RemoveAll(testdata)
+		}
+	})
 
 	testdataTmp := filepath.Join(testdata, "tmp")
 	if err := os.Mkdir(testdataTmp, 0o755); err != nil {
@@ -233,7 +237,10 @@ func (c actionTests) actionExec(t *testing.T) {
 		},
 		{
 			name: "Home",
-			argv: []string{"--home", testdata, c.env.ImagePath, "test", "-f", tmpfile.Name()},
+			argv: []string{"--home", "/myhomeloc", c.env.ImagePath, "env"},
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `\bHOME=/myhomeloc\b`),
+			},
 			exit: 0,
 		},
 		{

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -97,6 +97,32 @@ func (c actionTests) actionOciExec(t *testing.T) {
 
 	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
+	// Create a temp testfile
+	testdata, err := fs.MakeTmpDir(c.env.TestDir, "testdata", 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.RemoveAll(testdata)
+		}
+	})
+
+	testdataTmp := filepath.Join(testdata, "tmp")
+	if err := os.Mkdir(testdataTmp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a temp testfile
+	tmpfile, err := fs.MakeTmpFile(testdataTmp, "testApptainerExec.", 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpfile.Close()
+
+	basename := filepath.Base(tmpfile.Name())
+	homePath := filepath.Join("/home", basename)
+
 	tests := []struct {
 		name        string
 		argv        []string
@@ -141,6 +167,30 @@ func (c actionTests) actionOciExec(t *testing.T) {
 		{
 			name: "TouchHome",
 			argv: []string{imageRef, "/bin/sh", "-c", "touch $HOME"},
+			exit: 0,
+		},
+		{
+			name: "Home",
+			argv: []string{"--home", "/myhomeloc", imageRef, "sh", "-c", "env; mount"},
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `\bHOME=/myhomeloc\b`),
+				e2e.ExpectOutput(e2e.RegexMatch, `\btmpfs on /myhomeloc\b`),
+			},
+			exit: 0,
+		},
+		{
+			name: "HomePath",
+			argv: []string{"--home", testdataTmp + ":/home", imageRef, "test", "-f", homePath},
+			exit: 0,
+		},
+		{
+			name: "HomeTmp",
+			argv: []string{"--home", "/tmp", imageRef, "true"},
+			exit: 0,
+		},
+		{
+			name: "HomeTmpExplicit",
+			argv: []string{"--home", "/tmp:/home", imageRef, "true"},
 			exit: 0,
 		},
 		{
@@ -315,10 +365,15 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 	canaryDirBind := hostCanaryDir + ":" + contCanaryDir
 	canaryDirMount := "type=bind,source=" + hostCanaryDir + ",destination=" + contCanaryDir
 
+	hostHomeDir := filepath.Join(workspace, "home")
+
 	createWorkspaceDirs := func(t *testing.T) {
 		e2e.Privileged(func(t *testing.T) {
 			if err := os.RemoveAll(hostCanaryDir); err != nil && !os.IsNotExist(err) {
 				t.Fatalf("failed to delete canary_dir: %s", err)
+			}
+			if err := os.RemoveAll(hostHomeDir); err != nil && !os.IsNotExist(err) {
+				t.Fatalf("failed to delete workspace home: %s", err)
 			}
 		})(t)
 
@@ -330,6 +385,9 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 		}
 		if err := os.Chmod(hostCanaryFile, 0o777); err != nil {
 			t.Fatalf("failed to apply permissions on canary_file: %s", err)
+		}
+		if err := fs.Mkdir(hostHomeDir, 0o777); err != nil {
+			t.Fatalf("failed to create workspace home directory: %s", err)
 		}
 	}
 
@@ -488,6 +546,28 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 				"test", "-f", "/scratch/dir/file",
 			},
 			exit: 0,
+		},
+		{
+			name: "CustomHomeOneToOne",
+			args: []string{
+				"--home", hostHomeDir + ":" + hostHomeDir,
+				"--bind", hostCanaryDir + ":" + filepath.Join(hostHomeDir, "canary121RO"),
+				imageRef,
+				"test", "-f", filepath.Join(hostHomeDir, "canary121RO/file"),
+			},
+			postRun: checkHostDir(filepath.Join(hostHomeDir, "canary121RO")),
+			exit:    0,
+		},
+		{
+			name: "CustomHomeBind",
+			args: []string{
+				"--home", hostHomeDir + ":/home/e2e",
+				"--bind", hostCanaryDir + ":/home/e2e/canaryRO",
+				imageRef,
+				"test", "-f", "/home/e2e/canaryRO/file",
+			},
+			postRun: checkHostDir(filepath.Join(hostHomeDir, "canaryRO")),
+			exit:    0,
 		},
 		// For the --mount variants we are really just verifying the CLI
 		// acceptance of one or more --mount flags. Translation from --mount

--- a/e2e/internal/e2e/apptainercmd.go
+++ b/e2e/internal/e2e/apptainercmd.go
@@ -108,7 +108,7 @@ func (r *ApptainerCmdResult) expectMatch(mt MatchType, stream streamType, patter
 		// get rid of the trailing newline
 		if strings.TrimSuffix(output, "\n") != pattern {
 			return errors.Errorf(
-				"Command %q:\nExpect %s stream exact match:\n%s\nCommand %s output:\n%s",
+				"Command %q:\nExpect %s stream exact match:\n%s\nCommand %s stream:\n%s",
 				r.FullCmd, streamName, pattern, streamName, output,
 			)
 		}
@@ -122,7 +122,7 @@ func (r *ApptainerCmdResult) expectMatch(mt MatchType, stream streamType, patter
 	case UnwantedExactMatch:
 		if strings.TrimSuffix(output, "\n") == pattern {
 			return errors.Errorf(
-				"Command %q:\nExpect %s stream not matching:\n%s\nCommand %s output:\n%s",
+				"Command %q:\nExpect %s stream not matching:\n%s\nCommand %s stream:\n%s",
 				r.FullCmd, streamName, pattern, streamName, output,
 			)
 		}
@@ -136,7 +136,7 @@ func (r *ApptainerCmdResult) expectMatch(mt MatchType, stream streamType, patter
 		}
 		if !matched {
 			return errors.Errorf(
-				"Command %q:\nExpect %s stream match regular expression:\n%s\nCommand %s output:\n%s",
+				"Command %q:\nExpect %s stream match regular expression:\n%s\nCommand %s stream:\n%s",
 				r.FullCmd, streamName, pattern, streamName, output,
 			)
 		}

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -783,8 +783,8 @@ func (l *Launcher) setHome() error {
 
 	// Handle any user request to override the home directory source/dest
 	homeSlice := strings.Split(l.cfg.HomeDir, ":")
-	if len(homeSlice) > 2 || len(homeSlice) == 0 {
-		return fmt.Errorf("home argument has incorrect number of elements: %v", len(homeSlice))
+	if len(homeSlice) < 1 || len(homeSlice) > 2 {
+		return fmt.Errorf("home argument has incorrect number of elements: %v", homeSlice)
 	}
 	l.engineConfig.SetHomeSource(homeSlice[0])
 	if len(homeSlice) == 1 {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -27,7 +27,6 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/cgroups"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs/files"
-	"github.com/apptainer/apptainer/internal/pkg/util/user"
 	"github.com/apptainer/apptainer/pkg/ocibundle"
 	"github.com/apptainer/apptainer/pkg/ocibundle/native"
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
@@ -90,12 +89,6 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "WorkDir")
 	}
 
-	// Home is always sent from the CLI, and must be valid as an option, but
-	// CustomHome signifies if it was a user specified value which we don't
-	// support (yet).
-	if lo.CustomHome {
-		badOpt = append(badOpt, "CustomHome")
-	}
 	if lo.NoHome {
 		badOpt = append(badOpt, "NoHome")
 	}
@@ -316,7 +309,7 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 	if targetUID == 0 || containerUser {
 		return nil
 	}
-	// Otherewise, add to the passwd and group files in the container.
+	// Otherwise, add to the passwd and group files in the container.
 	if err := l.updatePasswdGroup(tools.RootFs(b.Path()).Path(), targetUID, targetGID); err != nil {
 		return err
 	}
@@ -331,13 +324,8 @@ func (l *Launcher) updatePasswdGroup(rootfs string, uid, gid uint32) error {
 	containerPasswd := filepath.Join(rootfs, "etc", "passwd")
 	containerGroup := filepath.Join(rootfs, "etc", "group")
 
-	pw, err := user.CurrentOriginal()
-	if err != nil {
-		return err
-	}
-
 	sylog.Debugf("Updating passwd file: %s", containerPasswd)
-	content, err := files.Passwd(containerPasswd, pw.Dir, int(uid))
+	content, err := files.Passwd(containerPasswd, l.cfg.HomeDir, int(uid))
 	if err != nil {
 		sylog.Warningf("%s", err)
 	} else if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -176,29 +176,61 @@ func (l *Launcher) addSysMount(mounts *[]specs.Mount) {
 // emulating `--compat` / `--containall`, so the user must specifically bind in
 // their home directory from the host for it to be available.
 func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
-	if l.cfg.Fakeroot {
-		*mounts = append(*mounts,
-			specs.Mount{
-				Destination: "/root",
-				Type:        "tmpfs",
-				Source:      "tmpfs",
-				Options: []string{
-					"nosuid",
-					"relatime",
-					"mode=755",
-					fmt.Sprintf("size=%dm", l.apptainerConf.SessiondirMaxSize),
-				},
-			})
-		return nil
-	}
-
+	// Get the host user's data
 	pw, err := user.CurrentOriginal()
 	if err != nil {
 		return err
 	}
+
+	if l.cfg.CustomHome {
+		// Handle any user request to override the home directory source/dest
+		homeSlice := strings.Split(l.cfg.HomeDir, ":")
+		if len(homeSlice) < 1 || len(homeSlice) > 2 {
+			return fmt.Errorf("home argument has incorrect number of elements: %v", homeSlice)
+		}
+		homeSrc := homeSlice[0]
+		l.cfg.HomeDir = homeSrc
+
+		// User requested more than just a custom home dir; they want to bind-mount a directory in the host to this custom home dir.
+		// This means the home dir, as viewed from inside the container, is actually the second member of the ":"-separated slice. The first member is actually just the source portion of the requested bind-mount.
+		if len(homeSlice) > 1 {
+			homeDest := homeSlice[1]
+			l.cfg.HomeDir = homeDest
+
+			// Since the home dir is a bind-mount in this case, we don't have to mount a tmpfs directory for the in-container home dir, and we can just do the bind-mount & return.
+			return addBindMount(mounts, bind.Path{
+				Source:      homeSrc,
+				Destination: homeDest,
+			})
+		}
+	} else {
+		// If we're running in fake-root mode (and we haven't requested a custom home dir), we do need to create a tmpfs mount for the home dir, but it's a special case (because of its location & permissions), so we handle that here & return.
+		if l.cfg.Fakeroot {
+			l.cfg.HomeDir = "/root"
+			*mounts = append(*mounts,
+				specs.Mount{
+					Destination: "/root",
+					Type:        "tmpfs",
+					Source:      "tmpfs",
+					Options: []string{
+						"nosuid",
+						"relatime",
+						"mode=755",
+						fmt.Sprintf("size=%dm", l.apptainerConf.SessiondirMaxSize),
+					},
+				})
+
+			return nil
+		}
+
+		// No fakeroot and no custom home dir - so the in-container home dir will be named the same as the host user's home dir. (Though note that it'll still be a tmpfs mount! It'll get mounted by the catch-all mount append, below.)
+		l.cfg.HomeDir = pw.Dir
+	}
+
+	// If we've not hit a special case (bind-mounted custom home dir, or fakeroot), then create a tmpfs mount as a home dir in the requested location (whether it's custom or not; by this point, l.cfg.HomeDir will reflect the right value).
 	*mounts = append(*mounts,
 		specs.Mount{
-			Destination: pw.Dir,
+			Destination: l.cfg.HomeDir,
 			Type:        "tmpfs",
 			Source:      "tmpfs",
 			Options: []string{
@@ -210,6 +242,7 @@ func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
 				fmt.Sprintf("gid=%d", pw.GID),
 			},
 		})
+
 	return nil
 }
 

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -20,7 +20,6 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/shell/interpreter"
-	"github.com/apptainer/apptainer/internal/pkg/util/user"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/term"
@@ -91,20 +90,9 @@ func getProcessArgs(imageSpec imgspecv1.Image, process string, args []string) []
 
 // getProcessCwd computes the Cwd that the container process should start in.
 // Currently this is the user's tmpfs home directory (see --containall).
+// Because this is called after mounts have already been computed, we can count on l.cfg.HomeDir containing the right value, incorporating any custom home dir overrides (i.e., --home).
 func (l *Launcher) getProcessCwd() (dir string, err error) {
-	if len(l.cfg.PwdPath) > 1 {
-		return l.cfg.PwdPath, nil
-	}
-
-	if l.cfg.Fakeroot {
-		return "/root", nil
-	}
-
-	pw, err := user.CurrentOriginal()
-	if err != nil {
-		return "", err
-	}
-	return pw.Dir, nil
+	return l.cfg.HomeDir, nil
 }
 
 // getReverseUserMaps returns uid and gid mappings that re-map container uid to target


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1500
 which fixed
- sylabs/singularity# 1473

The original PR description was:
> Adds support for `--home` in OCI mode.
> 
> Specifically, supplying a single location (e.g. `--home /myhomedir`) will result in a new tmpfs directory being created at the specified location inside the container, and that dir being set as the in-container user's home dir. Supplying two locations separated by a colon (e.g. `--home /home/user:/myhomedir`) will result in the first location on the host being bind-mounted as the second location in-container, and set as the in-container user's home dir.
> ### Testing notes
> 
> Added e2e tests in e2e/actions/oci.go to largely mirror how we test the corresponding native-mode functionality, with the caveat that the tests now look for a tmpfs mounted dir inside the container when appropriate. Also made a minor improvement inside the native-mode `--home` tests, to make sure we have `$HOME` correctly set in the environment (and not just that we start the container in the right directory).