### PR TITLE
Minor improvements to cdi support in oci, from sylabs 1503

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
   OCI mode (`--oci`). Currently supports passing one or more (comma-separated)
   fully-qualified CDI device names, and those devices will then be made
   available inside the container.
+- Added `--cdi-dirs` flag to override the default search locations for CDI
+  json files, allowing, for example, users who don't have root access on their
+  host machine to nevertheless create CDI mappings (into containers run with
+  `--fakeroot`, for example).
 - OCI mode now supports `--hostname` (requires UTS namespace, therefore this
   flag will infer `--uts`).
 - OCI mode now supports `--scratch` (shorthand: `-S`) to mount a tmpfs scratch

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -773,6 +773,8 @@ func (c actionTests) actionOciCdi(t *testing.T) {
 					// Generate the command to be executed in the container
 					// Start by printing all environment variables, to test using e2e.ContainMatch conditions later
 					execCmd := "/bin/env"
+
+					// Add commands to test the presence of mapped devices.
 					for _, d := range tt.DeviceNodes {
 						testFlag := "-f"
 						switch d.Type {
@@ -781,6 +783,8 @@ func (c actionTests) actionOciCdi(t *testing.T) {
 						}
 						execCmd += fmt.Sprintf(" && test %s %s", testFlag, d.Path)
 					}
+
+					// Add commands to test the presence, and functioning, of mounts.
 					for i, m := range tt.Mounts {
 						// Add a separate teststring echo statement for each mount
 						execCmd += fmt.Sprintf(" && echo %s > %s/testfile_%d", testfileStrings[i], m.ContainerPath, i)
@@ -809,6 +813,7 @@ func (c actionTests) actionOciCdi(t *testing.T) {
 						envExpects = append(envExpects, e2e.ExpectOutput(e2e.ContainMatch, e))
 					}
 
+					// Run the subtest.
 					c.env.RunApptainer(
 						t,
 						e2e.AsSubtest(tt.name),


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1503

The original PR description was: 
> Some really minor stuff that I neglected to include in PR sylabs/singularity# 1394:
> * Adding `--cdi-dirs` (with explanation) to CHANGELOG.md
> * Better commenting on the new code in `actionOciCdi()` in e2e/actions/oci.go