### PR TITLE
fix: oci: explicitly request userns for inner reverse idmap, from sylabs 1518

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2604,5 +2604,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociNetwork": c.actionOciNetwork, // apptainer exec --oci --net
 		"ociBinds":   c.actionOciBinds,   // apptainer exec --oci --bind / --mount
 		"ociCdi":     c.actionOciCdi,     // apptainer exec --oci --cdi
+		"ociIDMaps":  c.actionOciIDMaps,  // check uid/gid mapping on host for --oci as user / --fakeroot
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -830,3 +830,46 @@ func (c actionTests) actionOciCdi(t *testing.T) {
 		})
 	}
 }
+
+// Check that both root via fakeroot and user without fakeroot are mapped to
+// uid/gid on host, by writing a file out to host and checking ownership.
+func (c actionTests) actionOciIDMaps(t *testing.T) {
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	bindDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "usermap", "")
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
+
+	for _, profile := range []e2e.Profile{e2e.OCIUserProfile, e2e.OCIFakerootProfile} {
+		t.Run(profile.String(), func(t *testing.T) {
+			cmdArgs := []string{
+				"-B", fmt.Sprintf("%s:/test", bindDir),
+				imageRef,
+				"/bin/touch", fmt.Sprintf("/test/%s", profile.String()),
+			}
+			c.env.RunApptainer(
+				t,
+				e2e.AsSubtest(profile.String()),
+				e2e.WithProfile(profile),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs(cmdArgs...),
+				e2e.ExpectExit(0),
+				e2e.PostRun(func(t *testing.T) {
+					fp := filepath.Join(bindDir, profile.String())
+					expectUID := profile.HostUser(t).UID
+					expectGID := profile.HostUser(t).GID
+					if !fs.IsOwner(fp, expectUID) {
+						t.Errorf("%s not owned by uid %d", fp, expectUID)
+					}
+					if !fs.IsGroup(fp, expectGID) {
+						t.Errorf("%s not owned by gid %d", fp, expectGID)
+					}
+				}),
+			)
+		})
+	}
+}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -278,6 +278,11 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 		}
 		spec.Linux.UIDMappings = uidMap
 		spec.Linux.GIDMappings = gidMap
+		// Must add userns to the runc/crun applied config for the inner reverse uid/gid mapping to work.
+		spec.Linux.Namespaces = append(
+			spec.Linux.Namespaces,
+			specs.LinuxNamespace{Type: specs.UserNamespace},
+		)
 	}
 
 	u := specs.User{

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -92,13 +92,22 @@ func IsLink(name string) bool {
 	return info.Mode()&os.ModeSymlink != 0
 }
 
-// IsOwner check if name component is owned by user identified with uid.
+// IsOwner checks if named file is owned by user identified with uid.
 func IsOwner(name string, uid uint32) bool {
 	info, err := os.Stat(name)
 	if err != nil {
 		return false
 	}
 	return info.Sys().(*syscall.Stat_t).Uid == uid
+}
+
+// IsGroup checks if named file is owned by group identified with gid.
+func IsGroup(name string, gid uint32) bool {
+	info, err := os.Stat(name)
+	if err != nil {
+		return false
+	}
+	return info.Sys().(*syscall.Stat_t).Gid == gid
 }
 
 // IsExec check if name component has executable bit permission set.

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -167,7 +167,16 @@ func TestIsOwner(t *testing.T) {
 	defer test.ResetPrivilege(t)
 
 	if IsOwner("/etc/passwd", 0) != true {
-		t.Errorf("IsOwner returns false for /etc/passwd owner")
+		t.Errorf("IsOwner returns false for /etc/passwd root ownership")
+	}
+}
+
+func TestIsGroup(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	if IsGroup("/etc/passwd", 0) != true {
+		t.Errorf("IsGroup returns false for /etc/passwd root group ownership")
 	}
 }
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1518
 which fixed
- sylabs/singularity# 1517

The original PR description was:
> When running in --oci mode as a normal user, Singularity sets up an outer userns that provides an unprivileged root. When --fakeroot is not also requested, runc / crun then map back to the user's own uid/gid via an inner reverse mapping specified in config.json.
> 
> This mapping was not being applied correctly, as a userns was not requested in the config.json for all situations where a reverse mapping was requested.
> 
> Ensure that if we specify a mapping in config.json then we request a userns so that it is applied.
> 
> Cover this behavior in an e2e-test by writing to a host dir from the container, and checking ownership of the file on the host.