### PR TITLE
fix: oci: reverse uid/gid maps now honour target IDs, from sylabs 1537

### DIFF
--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -272,7 +272,7 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 	}
 
 	if targetUID != 0 && currentUID != 0 {
-		uidMap, gidMap, err := l.getReverseUserMaps(targetUID, targetGID)
+		uidMap, gidMap, err := getReverseUserMaps(currentUID, targetUID, targetGID)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -100,11 +100,9 @@ func (l *Launcher) getProcessCwd() (dir string, err error) {
 // userns from which the OCI runtime is launched.
 //
 //	e.g. host 1001 -> fakeroot userns 0 -> container targetUID
-func (l *Launcher) getReverseUserMaps(targetUID, targetGID uint32) (uidMap, gidMap []specs.LinuxIDMapping, err error) {
-	uid := uint32(os.Getuid())
-	gid := uint32(os.Getgid())
+func getReverseUserMaps(hostUID, targetUID, targetGID uint32) (uidMap, gidMap []specs.LinuxIDMapping, err error) {
 	// Get user's configured subuid & subgid ranges
-	subuidRange, err := fakeroot.GetIDRange(fakeroot.SubUIDFile, uid)
+	subuidRange, err := fakeroot.GetIDRange(fakeroot.SubUIDFile, hostUID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -112,7 +110,7 @@ func (l *Launcher) getReverseUserMaps(targetUID, targetGID uint32) (uidMap, gidM
 	if subuidRange.Size < 65536 {
 		return nil, nil, fmt.Errorf("subuid range size (%d) must be at least 65536", subuidRange.Size)
 	}
-	subgidRange, err := fakeroot.GetIDRange(fakeroot.SubGIDFile, uid)
+	subgidRange, err := fakeroot.GetIDRange(fakeroot.SubGIDFile, hostUID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -120,22 +118,27 @@ func (l *Launcher) getReverseUserMaps(targetUID, targetGID uint32) (uidMap, gidM
 		return nil, nil, fmt.Errorf("subuid range size (%d) must be at least 65536", subgidRange.Size)
 	}
 
-	if uid < subuidRange.Size {
+	uidMap, gidMap = reverseMapByRange(targetUID, targetGID, *subuidRange, *subgidRange)
+	return uidMap, gidMap, nil
+}
+
+func reverseMapByRange(targetUID, targetGID uint32, subuidRange, subgidRange specs.LinuxIDMapping) (uidMap, gidMap []specs.LinuxIDMapping) {
+	if targetUID < subuidRange.Size {
 		uidMap = []specs.LinuxIDMapping{
 			{
 				ContainerID: 0,
 				HostID:      1,
-				Size:        uid,
+				Size:        targetUID,
 			},
 			{
-				ContainerID: uid,
+				ContainerID: targetUID,
 				HostID:      0,
 				Size:        1,
 			},
 			{
-				ContainerID: uid + 1,
-				HostID:      uid + 1,
-				Size:        subuidRange.Size - uid,
+				ContainerID: targetUID + 1,
+				HostID:      targetUID + 1,
+				Size:        subuidRange.Size - targetUID,
 			},
 		}
 	} else {
@@ -146,29 +149,29 @@ func (l *Launcher) getReverseUserMaps(targetUID, targetGID uint32) (uidMap, gidM
 				Size:        subuidRange.Size,
 			},
 			{
-				ContainerID: uid,
+				ContainerID: targetUID,
 				HostID:      0,
 				Size:        1,
 			},
 		}
 	}
 
-	if gid < subgidRange.Size {
+	if targetGID < subgidRange.Size {
 		gidMap = []specs.LinuxIDMapping{
 			{
 				ContainerID: 0,
 				HostID:      1,
-				Size:        gid,
+				Size:        targetGID,
 			},
 			{
-				ContainerID: gid,
+				ContainerID: targetGID,
 				HostID:      0,
 				Size:        1,
 			},
 			{
-				ContainerID: gid + 1,
-				HostID:      gid + 1,
-				Size:        subgidRange.Size - gid,
+				ContainerID: targetGID + 1,
+				HostID:      targetGID + 1,
+				Size:        subgidRange.Size - targetGID,
 			},
 		}
 	} else {
@@ -179,14 +182,14 @@ func (l *Launcher) getReverseUserMaps(targetUID, targetGID uint32) (uidMap, gidM
 				Size:        subgidRange.Size,
 			},
 			{
-				ContainerID: gid,
+				ContainerID: targetGID,
 				HostID:      0,
 				Size:        1,
 			},
 		}
 	}
 
-	return uidMap, gidMap, nil
+	return uidMap, gidMap
 }
 
 // getProcessEnv combines the image config ENV with the ENV requested at runtime.

--- a/internal/pkg/runtime/launcher/oci/process_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func TestApptainerEnvMap(t *testing.T) {
@@ -376,6 +377,65 @@ func TestGetProcessEnv(t *testing.T) {
 
 			if !reflect.DeepEqual(env, tt.wantEnv) {
 				t.Errorf("want: %v, got: %v", tt.wantEnv, env)
+			}
+		})
+	}
+}
+
+func TestLauncher_reverseMapByRange(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetUID  uint32
+		targetGID  uint32
+		subUIDMap  specs.LinuxIDMapping
+		subGIDMap  specs.LinuxIDMapping
+		wantUIDMap []specs.LinuxIDMapping
+		wantGIDMap []specs.LinuxIDMapping
+		wantErr    bool
+	}{
+		{
+			// TargetID is smaller than size of subuid/subgid map.
+			name:      "LowTargetID",
+			targetUID: 1000,
+			targetGID: 2000,
+			subUIDMap: specs.LinuxIDMapping{HostID: 1000, ContainerID: 100000, Size: 65536},
+			subGIDMap: specs.LinuxIDMapping{HostID: 2000, ContainerID: 200000, Size: 65536},
+			wantUIDMap: []specs.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1, Size: 1000},
+				{ContainerID: 1000, HostID: 0, Size: 1},
+				{ContainerID: 1001, HostID: 1001, Size: 64536},
+			},
+			wantGIDMap: []specs.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1, Size: 2000},
+				{ContainerID: 2000, HostID: 0, Size: 1},
+				{ContainerID: 2001, HostID: 2001, Size: 63536},
+			},
+		},
+		{
+			// TargetID is higher than size of subuid/subgid map.
+			name:      "HighTargetID",
+			targetUID: 70000,
+			targetGID: 80000,
+			subUIDMap: specs.LinuxIDMapping{HostID: 1000, ContainerID: 100000, Size: 65536},
+			subGIDMap: specs.LinuxIDMapping{HostID: 2000, ContainerID: 200000, Size: 65536},
+			wantUIDMap: []specs.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1, Size: 65536},
+				{ContainerID: 70000, HostID: 0, Size: 1},
+			},
+			wantGIDMap: []specs.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1, Size: 65536},
+				{ContainerID: 80000, HostID: 0, Size: 1},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotUIDMap, gotGIDMap := reverseMapByRange(tt.targetUID, tt.targetGID, tt.subUIDMap, tt.subGIDMap)
+			if !reflect.DeepEqual(gotUIDMap, tt.wantUIDMap) {
+				t.Errorf("Launcher.getReverseUserMaps() gotUidMap = %v, want %v", gotUIDMap, tt.wantUIDMap)
+			}
+			if !reflect.DeepEqual(gotGIDMap, tt.wantGIDMap) {
+				t.Errorf("Launcher.getReverseUserMaps() gotGidMap = %v, want %v", gotGIDMap, tt.wantGIDMap)
 			}
 		})
 	}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1537
 which fixed
- sylabs/singularity# 1519

The original PR description was:
> In `getReverseUserMaps`,we were taking `targetUID` and `targetGID` parameters that define the UID and GID the container will be entereed as. However, the mappings returned were based on the current host UID and GID, and not the target IDs.
> 
> Ensure that the user maps use the `targetUID` and `targetGID`.
> 
> Split the function up so that the core computation of the user maps can be tested. The tests help to explain what the intended functionality here is... which is beneficial as it's somewhat complex.