### PR TITLE
fix: TERM not set in OCI containers, from sylabs 1553

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -957,6 +957,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			// Regressions
 			t.Run("issue 4524", c.issue4524)
 			t.Run("issue 1286", c.issue1286)
+			t.Run("issue 1528", c.issue1528)
 		},
 		// Tests that are especially slow, or run against a local docker
 		// registry, can be run in parallel, with `--disable-cache` used within

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -184,3 +184,62 @@ func (c ctx) issue1286(t *testing.T) {
 		)
 	}
 }
+
+// https://github.com/sylabs/singularity/issues/1528
+// Check that host's TERM value gets passed to OCI container.
+func (c ctx) issue1528(t *testing.T) {
+	e2e.EnsureOCIArchive(t, c.env)
+
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	_, wasHostTermSet := os.LookupEnv("TERM")
+	if !wasHostTermSet {
+		if err := os.Setenv("TERM", "xterm"); err != nil {
+			t.Errorf("could not set TERM environment variable on host")
+		}
+		defer os.Unsetenv("TERM")
+	}
+
+	singEnvTermPrevious, wasHostSingEnvTermSet := os.LookupEnv("APPTAINERENV_TERM")
+	if wasHostSingEnvTermSet {
+		if err := os.Unsetenv("APPTAINERENV_TERM"); err != nil {
+			t.Errorf("could not unset APPTAINERENV_TERM environment variable on host")
+		}
+		defer os.Setenv("APPTAINERENV_TERM", singEnvTermPrevious)
+	} else {
+		defer os.Unsetenv("APPTAINERENV_TERM")
+	}
+
+	envTerm := os.Getenv("TERM")
+	wantTermString := fmt.Sprintf("TERM=%s\n", envTerm)
+	for _, profile := range e2e.OCIProfiles {
+		t.Run(profile.String(), func(t *testing.T) {
+			c.env.RunApptainer(
+				t,
+				e2e.AsSubtest("issue1528"),
+				e2e.WithProfile(profile),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs(imageRef, "env"),
+				e2e.ExpectExit(0, e2e.ExpectOutput(e2e.ContainMatch, wantTermString)),
+			)
+		})
+	}
+
+	singEnvTerm := envTerm + "testsuffix"
+	if err := os.Setenv("APPTAINERENV_TERM", singEnvTerm); err != nil {
+		t.Errorf("could not set APPTAINERENV_TERM environment variable on host")
+	}
+	wantTermString = fmt.Sprintf("TERM=%s\n", singEnvTerm)
+	for _, profile := range e2e.OCIProfiles {
+		t.Run(profile.String(), func(t *testing.T) {
+			c.env.RunApptainer(
+				t,
+				e2e.AsSubtest("issue1528override"),
+				e2e.WithProfile(profile),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs(imageRef, "env"),
+				e2e.ExpectExit(0, e2e.ExpectOutput(e2e.ContainMatch, wantTermString)),
+			)
+		})
+	}
+}

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -31,6 +31,13 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, imag
 	// Assemble the runtime & user-requested environment, which will be merged
 	// with the image ENV and set in the container at runtime.
 	rtEnv := defaultEnv(image, bundle)
+
+	// Propagate TERM from host. Doing this here means it can be overridden by APPTAINERENV_TERM.
+	hostTerm, isHostTermSet := os.LookupEnv("TERM")
+	if isHostTermSet {
+		rtEnv["TERM"] = hostTerm
+	}
+
 	// APPTAINERENV_ has lowest priority
 	rtEnv = mergeMap(rtEnv, apptainerEnvMap())
 	// --env-file can override APPTAINERENV_


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1553
 which fixed
- sylabs/singularity# 1528

The original PR description was:
> Pass host's `TERM` environment variable to container in OCI mode. Can be overridden by setting `SINGULARITYENV_TERM` on host.