### PR TITLE
oci: support resolv.conf and --dns, from sylabs 1551

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
   (e.g. `--home /home/user:/myhomedir`) will result in the first location on the
   host being bind-mounted as the second location in-container, and set as
   the in-container user's home dir.
+- OCI mode now handles `--dns` and `resolv.conf` on par with native mode: the
+  `--dns` flag can be used to pass a comma-separated list of DNS servers that
+  will be used in the container; if this flag is not used, the container will
+  use the same `resolv.conf` settings as the host.
 
 ### Other changes
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -281,6 +281,22 @@ func (c actionTests) actionExec(t *testing.T) {
 				e2e.ExpectOutput(e2e.ExactMatch, "whats-in-a-native-name"),
 			},
 		},
+		{
+			name: "ResolvConfGoogle",
+			argv: []string{"--dns", "8.8.8.8,8.8.4.4", c.env.ImagePath, "nslookup", "w3.org"},
+			exit: 0,
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `^(\s*)Server:(\s+)(8\.8\.8\.8|8\.8\.4\.4)(\s*)\n`),
+			},
+		},
+		{
+			name: "ResolvConfCloudflare",
+			argv: []string{"--dns", "1.1.1.1", c.env.ImagePath, "nslookup", "w3.org"},
+			exit: 0,
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `^(\s*)Server:(\s+)(1\.1\.1\.1)(\s*)\n`),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -214,6 +214,22 @@ func (c actionTests) actionOciExec(t *testing.T) {
 				e2e.ExpectOutput(e2e.ExactMatch, "/tmp"),
 			},
 		},
+		{
+			name: "ResolvConfGoogle",
+			argv: []string{"--dns", "8.8.8.8,8.8.4.4", imageRef, "nslookup", "w3.org"},
+			exit: 0,
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `^(\s*)Server:(\s+)(8\.8\.8\.8|8\.8\.4\.4)(\s*)\n`),
+			},
+		},
+		{
+			name: "ResolvConfCloudflare",
+			argv: []string{"--dns", "1.1.1.1", imageRef, "nslookup", "w3.org"},
+			exit: 0,
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `^(\s*)Server:(\s+)(1\.1\.1\.1)(\s*)\n`),
+			},
+		},
 	}
 	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -354,6 +354,7 @@ func (l *Launcher) updatePasswdGroup(rootfs string, uid, gid uint32) error {
 
 func (l *Launcher) prepareResolvConf(rootfs string) error {
 	hostResolvConfPath := "/etc/resolv.conf"
+	containerEtc := filepath.Join(rootfs, "etc")
 	containerResolvConfPath := filepath.Join(rootfs, "etc", "resolv.conf")
 
 	var resolvConfData []byte
@@ -373,6 +374,12 @@ func (l *Launcher) prepareResolvConf(rootfs string) error {
 		if err != nil {
 			return fmt.Errorf("could not read host's resolv.conf file: %w", err)
 		}
+	}
+
+	stat, err := os.Stat(containerEtc)
+	if os.IsNotExist(err) || !stat.IsDir() {
+		sylog.Warningf("container does not contain an /etc directory; skipping resolve.conf configuration")
+		return nil
 	}
 
 	if err := os.WriteFile(containerResolvConfPath, resolvConfData, 0o755); err != nil {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -124,9 +125,6 @@ func checkOpts(lo launcher.Options) error {
 
 	if len(lo.NetworkArgs) > 0 {
 		badOpt = append(badOpt, "NetworkArgs")
-	}
-	if lo.DNS != "" {
-		badOpt = append(badOpt, "DNS")
 	}
 
 	if lo.AddCaps != "" {
@@ -309,6 +307,11 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 		return err
 	}
 
+	// Prepare DNS settings for the container.
+	if err := l.prepareResolvConf(tools.RootFs(b.Path()).Path()); err != nil {
+		return err
+	}
+
 	// If we are entering as root, or a USER defined in the container, then passwd/group
 	// information should be present already.
 	if targetUID == 0 || containerUser {
@@ -318,6 +321,7 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 	if err := l.updatePasswdGroup(tools.RootFs(b.Path()).Path(), targetUID, targetGID); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -343,6 +347,36 @@ func (l *Launcher) updatePasswdGroup(rootfs string, uid, gid uint32) error {
 		sylog.Warningf("%s", err)
 	} else if err := os.WriteFile(containerGroup, content, 0o755); err != nil {
 		return fmt.Errorf("while writing passwd file: %w", err)
+	}
+
+	return nil
+}
+
+func (l *Launcher) prepareResolvConf(rootfs string) error {
+	hostResolvConfPath := "/etc/resolv.conf"
+	containerResolvConfPath := filepath.Join(rootfs, "etc", "resolv.conf")
+
+	var resolvConfData []byte
+	var err error
+	if len(l.cfg.DNS) > 0 {
+		dns := strings.Replace(l.cfg.DNS, " ", "", -1)
+		ips := strings.Split(dns, ",")
+		for _, ip := range ips {
+			if net.ParseIP(ip) == nil {
+				return fmt.Errorf("DNS nameserver %v is not a valid IP address", ip)
+			}
+			line := fmt.Sprintf("nameserver %s\n", ip)
+			resolvConfData = append(resolvConfData, line...)
+		}
+	} else {
+		resolvConfData, err = os.ReadFile(hostResolvConfPath)
+		if err != nil {
+			return fmt.Errorf("could not read host's resolv.conf file: %w", err)
+		}
+	}
+
+	if err := os.WriteFile(containerResolvConfPath, resolvConfData, 0o755); err != nil {
+		return fmt.Errorf("while writing container's resolv.conf file: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1551
 which fixed
- sylabs/singularity# 1472

The original PR description was:
> Brought handling of `resolv.conf` and `--dns` flag in OCI mode on par with their behavior in native mode.
> 
> In particular: an `/etc/resolv.conf` file is always created in the OCI container. If a `--dns` argument is provided, its contents (a comma-separated list of IPs of nameservers) determines the content of this `resolv.conf` file. Otherwise, the content is taken from the host's `/etc/resolv.conf` file.