### PR TITLE
pull HashingListSubtract into (new) high-level util package, from sylabs 1562

### DIFF
--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -611,6 +611,12 @@ The dependencies and their licenses are as follows:
 
 **Project URL:** <https://golang.org/x/crypto>
 
+## golang.org/x/exp/constraints
+
+**License:** BSD-3-Clause
+
+**Project URL:** <https://golang.org/x/exp/constraints>
+
 ## golang.org/x/mod/semver
 
 **License:** BSD-3-Clause
@@ -862,6 +868,12 @@ The dependencies and their licenses are as follows:
 **License:** MIT
 
 **License URL:** <https://github.com/rivo/uniseg/blob/master/LICENSE.txt>
+
+## github.com/samber/lo
+
+**License:** MIT
+
+**License URL:** <https://github.com/samber/lo/blob/master/LICENSE>
 
 ## github.com/secure-systems-lab/go-securesystemslib/dsse
 

--- a/internal/pkg/runtime/launcher/oci/cdi_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/cdi_linux_test.go
@@ -18,9 +18,9 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/apptainer/apptainer/pkg/util/slice"
 	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/samber/lo"
 )
 
 var specDirs = []string{filepath.Join("..", "..", "..", "..", "..", "test", "cdi")}
@@ -245,19 +245,10 @@ func Test_addCDIDevice(t *testing.T) {
 				}
 			}
 
-			envMissing := hashingListSubtract(tt.wantEnv, spec.Process.Env)
+			envMissing := slice.Subtract(tt.wantEnv, spec.Process.Env)
 			if len(envMissing) > 0 {
 				t.Errorf("addCDIDevices() mismatched environment variables; expected, but did not find, the following environment variables: %v", envMissing)
 			}
 		})
 	}
-}
-
-// hashingListSubtract is a utility-function for subtracting a list from another list, using map's internal hashing function to do this more efficiently than lo.Difference or lo.Without (which only assume comparable, and thus run in quadratic time).
-func hashingListSubtract[T comparable](toSubstractFrom []T, toSubstract []T) []T {
-	subtractionMap := lo.FromEntries(lo.Map(toSubstractFrom, func(item T, _ int) lo.Entry[T, bool] {
-		return lo.Entry[T, bool]{Key: item, Value: true}
-	}))
-
-	return lo.Keys(lo.OmitByKeys(subtractionMap, toSubstract))
 }

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -9,6 +9,8 @@
 
 package slice
 
+import "github.com/samber/lo"
+
 // ContainsString returns true if string slice s contains match
 func ContainsString(s []string, match string) bool {
 	for _, a := range s {
@@ -39,4 +41,18 @@ func ContainsInt(s []int, match int) bool {
 		}
 	}
 	return false
+}
+
+// Subtract removes items in slice b from slice a, returning the result.
+// Implemented using a map for greater efficiency than lo.Difference / lo.Without, when operating on large slices.
+func Subtract[T comparable](a []T, b []T) []T {
+	subtractionMap := lo.FromEntries(lo.Map(a, func(item T, _ int) lo.Entry[T, bool] {
+		return lo.Entry[T, bool]{Key: item, Value: true}
+	}))
+	subtractionMap = lo.OmitByKeys(subtractionMap, b)
+
+	return lo.Filter(a, func(x T, _ int) bool {
+		_, ok := subtractionMap[x]
+		return ok
+	})
 }

--- a/pkg/util/slice/slice_test.go
+++ b/pkg/util/slice/slice_test.go
@@ -9,7 +9,13 @@
 
 package slice
 
-import "testing"
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/samber/lo"
+)
 
 func TestContainsString(t *testing.T) {
 	type args struct {
@@ -186,6 +192,98 @@ func TestContainsInt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ContainsInt(tt.args.s, tt.args.match); got != tt.want {
 				t.Errorf("ContainsInt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubtract(t *testing.T) {
+	type args[T any] struct {
+		a    []T
+		b    []T
+		want []T
+	}
+	intTests := []struct {
+		name string
+		args args[int]
+	}{
+		{
+			name: "Identical",
+			args: args[int]{
+				a:    []int{3, 9, 5, 7, 2, 1, 0, 4},
+				b:    []int{3, 9, 5, 7, 2, 1, 0, 4},
+				want: []int{},
+			},
+		},
+		{
+			name: "EmptyA",
+			args: args[int]{
+				a:    []int{},
+				b:    []int{3, 9, 5, 7, 2, 1, 0, 4},
+				want: []int{},
+			},
+		},
+		{
+			name: "EmptyB",
+			args: args[int]{
+				a:    []int{3, 9, 5, 7, 2, 1, 0, 4},
+				b:    []int{},
+				want: []int{3, 9, 5, 7, 2, 1, 0, 4},
+			},
+		},
+		{
+			name: "EmptyBoth",
+			args: args[int]{
+				a:    []int{},
+				b:    []int{},
+				want: []int{},
+			},
+		},
+		{
+			name: "AsupersetofB",
+			args: args[int]{
+				a:    []int{3, 9, 5, 7, 2, 1, 0, 4},
+				b:    []int{3, 9, 7, 0, 4},
+				want: []int{5, 2, 1},
+			},
+		},
+		{
+			name: "AsubsetofB",
+			args: args[int]{
+				a:    []int{5, 2, 1},
+				b:    []int{5, 7, 2, 1, 0, 4},
+				want: []int{},
+			},
+		},
+		{
+			name: "Intersection",
+			args: args[int]{
+				a:    []int{3, 5, 2, 0},
+				b:    []int{3, 9, 7, 2, 4},
+				want: []int{5, 0},
+			},
+		},
+	}
+
+	convertor := func(x int, index int) string {
+		return fmt.Sprintf("Have an int whose value is %#v, why don't you", x)
+	}
+
+	for _, tt := range intTests {
+		t.Run("Int"+tt.name, func(t *testing.T) {
+			if got := Subtract(tt.args.a, tt.args.b); !reflect.DeepEqual(got, tt.args.want) {
+				t.Errorf("Subtract(%#v, %#v) = %#v, want %#v", tt.args.a, tt.args.b, got, tt.args.want)
+			}
+		})
+
+		strArgs := args[string]{
+			a:    lo.Map(tt.args.a, convertor),
+			b:    lo.Map(tt.args.b, convertor),
+			want: lo.Map(tt.args.want, convertor),
+		}
+		t.Run("String"+tt.name, func(t *testing.T) {
+			if got := Subtract(strArgs.a, strArgs.b); !reflect.DeepEqual(got, strArgs.want) {
+				t.Errorf("Subtract(%#v, %#v) = %#v, want %#v", strArgs.a, strArgs.b, got, strArgs.want)
 			}
 		})
 	}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1562
 which fixed
- sylabs/singularity# 1485

The original PR description was:
> Now that we can safely assume Go 1.18+ (see [here](https://github.com/sylabs/singularity/issues/1485#issuecomment-1503000209)), I have moved a [`lo`](https://github.com/samber/lo)-based utility function (`HashingListSubtract()`) that was buried inside the test code into a more general-purpose utility package.