### PR TITLE
fix: oci: Don't create cgroup for crun on v1 / cgroupfs, from sylabs 1570

### DIFF
--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -35,6 +35,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
 	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	"github.com/google/uuid"
+	lccgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -486,9 +487,10 @@ func (l *Launcher) getCgroup() (path string, resources *specs.LinuxResources, er
 	return path, resources, nil
 }
 
-// crunNestCgroup will check whether we are using crun, and enter a cgroup if running as a non-root user.
-// This is required to satisfy a common user-owned ancestor cgroup requirement on e.g. bare ssh logins.
-// See: https://github.com/sylabs/singularity/issues/1538
+// crunNestCgroup will check whether we are using crun, and enter a cgroup if
+// running as a non-root user under cgroups v2, with systemd. This is required
+// to satisfy a common user-owned ancestor cgroup requirement on e.g. bare ssh
+// logins. See: https://github.com/sylabs/singularity/issues/1538
 func (l *Launcher) crunNestCgroup() error {
 	r, err := runtime()
 	if err != nil {
@@ -502,6 +504,12 @@ func (l *Launcher) crunNestCgroup() error {
 
 	// No workaround required if we are run as root.
 	if os.Getuid() == 0 {
+		return nil
+	}
+
+	// We can only create a new cgroup under cgroups v2 with systemd as manager.
+	// Generally we won't hit the issue that needs a workaround under cgroups v1, so no-op instead of a warning here.
+	if !(lccgroups.IsCgroup2UnifiedMode() && l.apptainerConf.SystemdCgroups) {
 		return nil
 	}
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1570
 which fixed
- sylabs/singularity# 1569

The original PR description was:
> If we are running under cgroups v1 or with the cgroupfs manager (i.e. not systemd as cgroup manager), do not attempt to enter a cgroup at startup with crun. We cannot create a cgroup unprivileged in this situation.
> 
> Under cgroups v1, crun will not perform the cgroups manipulation that leads to the issue we worked around in sylabs/singularity# 1539. Any other issue with the cgroup that we are in at launch cannot be rectified, either.