### PR TITLE
fix: apply allow kernel squashfs directive to encrypted squashfs, from sylabs 1617

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
   binding fakeroot into container during apptainer startup for --fakeroot
   with fakeroot command.
 
+## Bug Fixes
+
+- Ensure the `allow kernel squashfs` directive in `apptainer.conf` applies to
+  encrypted squashfs filesystems in a SIF.
+
 ## v1.1.8 - \[2023-04-25\]
 
 ### Security fix

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -650,6 +650,23 @@ func (c configTests) configGlobal(t *testing.T) {
 			directiveValue: "yes",
 			exit:           0,
 		},
+		// Encrypted squashFS rootfs in SIF
+		{
+			name:           "AllowKernelSquashfsNo_Encrypted",
+			argv:           []string{"--pem-path", c.pemPrivate, c.encryptedImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow kernel squashfs",
+			directiveValue: "no",
+			exit:           255,
+		},
+		{
+			name:           "AllowKernelSquashfsYes_Encrypted",
+			argv:           []string{"--pem-path", c.pemPrivate, c.encryptedImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow kernel squashfs",
+			directiveValue: "yes",
+			exit:           0,
+		},
 		{
 			name:           "AllowSetuidMountExtfsYesSif",
 			argv:           []string{c.ext3OverlayImage, "true"},

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -796,7 +796,7 @@ func (c *container) mountImage(mnt *mount.Point) error {
 
 	mountType := mnt.Type
 
-	if mountType == "encryptfs" || mountType == "gocryptfs" {
+	if mountType == "encrypted_squashfs" || mountType == "gocryptfs" {
 		key, err = mount.GetKey(mnt.InternalOptions)
 		if err != nil {
 			return err
@@ -849,7 +849,7 @@ func (c *container) mountImage(mnt *mount.Point) error {
 
 	sylog.Debugf("Mounting loop device %s to %s of type %s\n", path, mnt.Destination, mnt.Type)
 
-	if mountType == "encryptfs" {
+	if mountType == "encrypted_squashfs" {
 		// pass the master processus ID only if a container IPC
 		// namespace was requested because cryptsetup requires
 		// to run in the host IPC namespace
@@ -866,7 +866,6 @@ func (c *container) mountImage(mnt *mount.Point) error {
 
 		path = cryptDev
 
-		// Currently we only support encrypted squashfs file system
 		mountType = "squashfs"
 	}
 
@@ -920,7 +919,7 @@ func (c *container) addRootfsMount(system *mount.System) error {
 	case image.EXT3:
 		mountType = "ext3"
 	case image.ENCRYPTSQUASHFS:
-		mountType = "encryptfs"
+		mountType = "encrypted_squashfs"
 		key = c.engine.EngineConfig.GetEncryptionKey()
 	case image.GOCRYPTFSSQUASHFS:
 		mountType = "gocryptfs"


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1617
 which fixed
- sylabs/singularity# 1614

The original PR description was:
> The `allow kernel squashfs` directive was not applied correctly to limit mounts of encrypted squashfs images.
> 
> The `encryptfs` mount type is not a generic marker of a LUKS wrapping of a filesystem. It currently signifies only an encrypted squashfs mount, and the mount type is changed from `encryptfs -> squashfs` after the check implemented in `mount.image`.
> 
> The need for an encrypted SIF test in the e2e suite was overlooked.
> 
> This PR:
> 
> * Adds required e2e tests.
> * Changes `encryptfs` -> `encrypted_squashfs` for clarity.
>  * Gates `encrypted_squashfs` images on the `allow kernel squashfs` directive.