### PR TITLE
Bump example / debootstrap tests to Ubuntu jammy, from sylabs 1595

### DIFF
--- a/examples/ubuntu/Apptainer
+++ b/examples/ubuntu/Apptainer
@@ -1,5 +1,5 @@
 BootStrap: debootstrap
-OSVersion: trusty
+OSVersion: jammy
 MirrorURL: http://us.archive.ubuntu.com/ubuntu/
 
 

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
@@ -39,7 +39,7 @@ func TestDebootstrapConveyor(t *testing.T) {
 
 	b.Recipe.Header = map[string]string{
 		"bootstrap": "debootstrap",
-		"osversion": "bionic",
+		"osversion": "jammy",
 		"mirrorurl": "http://us.archive.ubuntu.com/ubuntu/",
 		"include":   "apt python ",
 	}
@@ -72,7 +72,7 @@ func TestDebootstrapPacker(t *testing.T) {
 
 	b.Recipe.Header = map[string]string{
 		"bootstrap": "debootstrap",
-		"osversion": "bionic",
+		"osversion": "jammy",
 		"mirrorurl": "http://us.archive.ubuntu.com/ubuntu/",
 		"include":   "apt python ",
 	}


### PR DESCRIPTION
This pulls in part of sylabs PR

- sylabs/singularity# 1595

The original PR description was:
> _Merge after 2024-04-30_
> 
> **ci: Drop Ubuntu 18.04 package builds**
> 
> Ubuntu 18.04 is EOL 2023-04-30
> 
> **Bump example / debootstrap tests to Ubuntu jammy**
> 
> Ensure we are using a currently supported Ubuntu in our example definition file, and debootstrap test code.