### PR TITLE
Improved discussion of LICENSE_DEPENDENCIES.md in CONTRIBUTING.md, from sylabs 1393

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,9 +84,10 @@ acknowledging that you agree to the [Developer Certificate of Origin](DCO.md).
    - Backwards incompatible changes
    - New features / functionalities
 1. PRs which introduce a new Go dependency to the project via `go get` and
-   additions to `go.mod` should explain why the dependency is required. Any
-   new dependency should be added to the `LICENSE_DEPENDENCIES.md` by
-   running `scripts/update-license-dependencies.md`.
+   additions to `go.mod` should explain why the dependency is required.
+1. Any new or updated dependency should be reflected in
+   `LICENSE_DEPENDENCIES.md`, by running
+   `scripts/update-license-dependencies.sh`
 
 ## Documentation
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1393
 which fixed
- sylabs/singularity# 1392

The original PR description was:
> Addresses two problems in `CONTRIBUTING.md`, specifically in the discussion of `LICENSE_DEPENDENCIES.md`:
> 
> * Replaced use of the phrase "Any new dependency" with the hopefully clearer "Any new or updated dependency". (The former could be misinterpreted to mean "only wholly new dependencies" excluding, e.g., version bumps, and that would be incorrect.)
> * Fixed typo in the name of the update script: its extension is `.sh` but was given as `.md`