### PR TITLE
replaced "[N/y]" with "[y/N]", from sylabs 1450

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -426,7 +426,7 @@ func checkBuildTarget(path string) error {
 				return fmt.Errorf("build target '%s' already exists. Use --force if you want to overwrite it", f.Name())
 			}
 
-			question := fmt.Sprintf("Build target '%s' already exists and will be deleted during the build process. Do you want to continue? [N/y] ", f.Name())
+			question := fmt.Sprintf("Build target '%s' already exists and will be deleted during the build process. Do you want to continue? [y/N] ", f.Name())
 
 			img, err := image.Init(abspath, false)
 			if err != nil {
@@ -434,7 +434,7 @@ func checkBuildTarget(path string) error {
 					return fmt.Errorf("while determining '%s' format: %s", f.Name(), err)
 				}
 				// unknown image file format
-				question = fmt.Sprintf("Build target '%s' may be a definition file or a text/binary file that will be overwritten. Do you still want to overwrite it? [N/y] ", f.Name())
+				question = fmt.Sprintf("Build target '%s' may be a definition file or a text/binary file that will be overwritten. Do you still want to overwrite it? [y/N] ", f.Name())
 			} else {
 				img.File.Close()
 			}

--- a/cmd/internal/cli/cache_clean_linux.go
+++ b/cmd/internal/cli/cache_clean_linux.go
@@ -119,9 +119,9 @@ func cleanCache() error {
 }
 
 func cleanCachePrompt() (bool, error) {
-	fmt.Print(`This will delete everything in your cache (containers from all sources and OCI blobs). 
+	fmt.Print(`This will delete everything in your cache (containers from all sources and OCI blobs).
 Hint: You can see exactly what would be deleted by canceling and using the --dry-run option.
-Do you want to continue? [N/y] `)
+Do you want to continue? [y/N] `)
 
 	r := bufio.NewReader(os.Stdin)
 	input, err := r.ReadString('\n')

--- a/cmd/internal/cli/delete.go
+++ b/cmd/internal/cli/delete.go
@@ -131,7 +131,7 @@ var deleteImageCmd = &cobra.Command{
 		r := fmt.Sprintf("%s:%s", imageRef.Path, imageRef.Tags[0])
 
 		if !deleteForce {
-			y, err := interactive.AskYNQuestion("n", "Are you sure you want to delete %s (%s) [N/y] ", r, deleteImageArch)
+			y, err := interactive.AskYNQuestion("n", "Are you sure you want to delete %s (%s) [y/N] ", r, deleteImageArch)
 			if err != nil {
 				sylog.Fatalf(err.Error())
 			}

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -172,7 +172,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 		{
 			name:               "clean normal confirmed",
 			options:            []string{"clean"},
-			expect:             "Do you want to continue? [N/y]",
+			expect:             "Do you want to continue? [y/N]",
 			send:               "y",
 			expectedEmptyCache: true,
 			exit:               0,
@@ -180,7 +180,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 		{
 			name:               "clean normal not confirmed",
 			options:            []string{"clean"},
-			expect:             "Do you want to continue? [N/y]",
+			expect:             "Do you want to continue? [y/N]",
 			send:               "n",
 			expectedEmptyCache: false,
 			exit:               0,
@@ -200,7 +200,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 		{
 			name:               "clean type confirmed",
 			options:            []string{"clean", "--type", "net"},
-			expect:             "Do you want to continue? [N/y]",
+			expect:             "Do you want to continue? [y/N]",
 			send:               "y",
 			expectedEmptyCache: true,
 			exit:               0,
@@ -208,7 +208,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 		{
 			name:               "clean type not confirmed",
 			options:            []string{"clean", "--type", "net"},
-			expect:             "Do you want to continue? [N/y]",
+			expect:             "Do you want to continue? [y/N]",
 			send:               "n",
 			expectedEmptyCache: false,
 			exit:               0,
@@ -216,7 +216,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 		{
 			name:               "clean days beyond age",
 			options:            []string{"clean", "--days", "30"},
-			expect:             "Do you want to continue? [N/y]",
+			expect:             "Do you want to continue? [y/N]",
 			send:               "y",
 			expectedEmptyCache: false,
 			exit:               0,
@@ -224,7 +224,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 		{
 			name:               "clean days within age",
 			options:            []string{"clean", "--days", "0"},
-			expect:             "Do you want to continue? [N/y]",
+			expect:             "Do you want to continue? [y/N]",
 			send:               "y",
 			expectedEmptyCache: true,
 			exit:               0,

--- a/internal/app/apptainer/remote_login.go
+++ b/internal/app/apptainer/remote_login.go
@@ -119,7 +119,7 @@ func endPointLogin(ep *endpoint.Config, args *LoginArgs) error {
 		// Interactive login
 		// If a token is already set, prompt to see if we want to replace it
 		if ep.Token != "" {
-			input, err := interactive.AskYNQuestion("n", "An access token is already set for this remote. Replace it? [N/y] ")
+			input, err := interactive.AskYNQuestion("n", "An access token is already set for this remote. Replace it? [y/N] ")
 			if err != nil {
 				return fmt.Errorf("while reading input: %s", err)
 			}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1450
 which fixed
- sylabs/singularity# 1429

The original PR description was:
> Various yes/no questions issued by `singularity` ended in `[N/y]` when "no" is the default response. This wasn't in line with the standard behavior of most command-line tools, which always maintain a yes-before-no order, and indicate the default response purely by means of capitalization.
> 
> To bring the behavior of `singularity` in line with this standard, occurrences of `[N/y]` in the following places have been replaced with `[y/N]`:
> 
> * e2e/cache/cache.go
> * internal/app/singularity/remote_login.go
> * cmd/internal/cli/cache_clean_linux.go
> * cmd/internal/cli/build.go
> * cmd/internal/cli/delete.go