### PR TITLE
loop: refactor to use x/sys/unix, from sylabs 1506

### DIFF
--- a/internal/pkg/build/sources/packer_ext3.go
+++ b/internal/pkg/build/sources/packer_ext3.go
@@ -20,6 +20,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/archive"
 	"github.com/apptainer/apptainer/pkg/util/loop"
+	"golang.org/x/sys/unix"
 )
 
 // Ext3Packer holds the locations of where to back from and to, as well as image offset info
@@ -42,10 +43,10 @@ func (p *Ext3Packer) Pack(context.Context) (*types.Bundle, error) {
 
 // unpackExt3 mounts the ext3 image using a loop device and then copies its contents to the bundle
 func unpackExt3(b *types.Bundle, img *image.Image) error {
-	info := &loop.Info64{
+	info := &unix.LoopInfo64{
 		Offset:    img.Partitions[0].Offset,
-		SizeLimit: img.Partitions[0].Size,
-		Flags:     loop.FlagsAutoClear,
+		Sizelimit: img.Partitions[0].Size,
+		Flags:     unix.LO_FLAGS_AUTOCLEAR,
 	}
 
 	var number int

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -42,7 +42,6 @@ import (
 	apptainer "github.com/apptainer/apptainer/pkg/runtime/engine/apptainer/config"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/fs/proc"
-	"github.com/apptainer/apptainer/pkg/util/loop"
 	"github.com/apptainer/apptainer/pkg/util/namespaces"
 	"github.com/apptainer/apptainer/pkg/util/slice"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -834,16 +833,16 @@ func (c *container) mountImage(mnt *mount.Point) error {
 	}
 
 	attachFlag := os.O_RDWR
-	loopFlags := uint32(loop.FlagsAutoClear)
+	loopFlags := uint32(unix.LO_FLAGS_AUTOCLEAR)
 
 	if flags&syscall.MS_RDONLY == 1 {
-		loopFlags |= loop.FlagsReadOnly
+		loopFlags |= unix.LO_FLAGS_READ_ONLY
 		attachFlag = os.O_RDONLY
 	}
 
-	info := &loop.Info64{
+	info := &unix.LoopInfo64{
 		Offset:    offset,
-		SizeLimit: sizelimit,
+		Sizelimit: sizelimit,
 		Flags:     loopFlags,
 	}
 

--- a/internal/pkg/runtime/engine/apptainer/rpc/args.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/args.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -16,7 +16,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/apptainer/apptainer/pkg/util/loop"
+	"golang.org/x/sys/unix"
 )
 
 // MkdirArgs defines the arguments to mkdir.
@@ -29,7 +29,7 @@ type MkdirArgs struct {
 type LoopArgs struct {
 	Image      string
 	Mode       int
-	Info       loop.Info64
+	Info       unix.LoopInfo64
 	MaxDevices int
 	Shared     bool
 }

--- a/internal/pkg/runtime/engine/apptainer/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/client/client.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,7 +15,7 @@ import (
 	"os"
 
 	args "github.com/apptainer/apptainer/internal/pkg/runtime/engine/apptainer/rpc"
-	"github.com/apptainer/apptainer/pkg/util/loop"
+	"golang.org/x/sys/unix"
 )
 
 // RPC holds the state necessary for remote procedure calls.
@@ -81,7 +81,7 @@ func (t *RPC) Chroot(root string, method string) (int, error) {
 }
 
 // LoopDevice calls the loop device RPC using the supplied arguments.
-func (t *RPC) LoopDevice(image string, mode int, info loop.Info64, maxDevices int, shared bool) (int, error) {
+func (t *RPC) LoopDevice(image string, mode int, info unix.LoopInfo64, maxDevices int, shared bool) (int, error) {
 	arguments := &args.LoopArgs{
 		Image:      image,
 		Mode:       mode,

--- a/internal/pkg/util/crypt/crypt_dev.go
+++ b/internal/pkg/util/crypt/crypt_dev.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -25,6 +25,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/util/fs/lock"
 	"github.com/apptainer/apptainer/pkg/util/loop"
 	"github.com/google/uuid"
+	"golang.org/x/sys/unix"
 )
 
 // Device describes a crypt device
@@ -46,10 +47,10 @@ var (
 func createLoop(path string, offset, size uint64) (string, error) {
 	loopDev := &loop.Device{
 		MaxLoopDevices: loop.GetMaxLoopDevices(),
-		Info: &loop.Info64{
-			SizeLimit: size,
+		Info: &unix.LoopInfo64{
+			Sizelimit: size,
 			Offset:    offset,
-			Flags:     loop.FlagsAutoClear,
+			Flags:     unix.LO_FLAGS_AUTOCLEAR,
 		},
 	}
 	idx := 0

--- a/pkg/ocibundle/tools/loop.go
+++ b/pkg/ocibundle/tools/loop.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,6 +15,7 @@ import (
 	"os"
 
 	"github.com/apptainer/apptainer/pkg/util/loop"
+	"golang.org/x/sys/unix"
 )
 
 // CreateLoop associates a file to loop device and returns
@@ -23,10 +24,10 @@ func CreateLoop(file *os.File, offset, size uint64) (string, io.Closer, error) {
 	loopDev := &loop.Device{
 		MaxLoopDevices: loop.GetMaxLoopDevices(),
 		Shared:         true,
-		Info: &loop.Info64{
-			SizeLimit: size,
+		Info: &unix.LoopInfo64{
+			Sizelimit: size,
 			Offset:    offset,
-			Flags:     loop.FlagsAutoClear | loop.FlagsReadOnly,
+			Flags:     unix.LO_FLAGS_AUTOCLEAR | unix.LO_FLAGS_READ_ONLY,
 		},
 	}
 	idx := 0

--- a/pkg/util/loop/loop_test.go
+++ b/pkg/util/loop/loop_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -16,15 +16,16 @@ import (
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/test"
+	"golang.org/x/sys/unix"
 )
 
 func TestLoop(t *testing.T) {
 	test.EnsurePrivilege(t)
 
-	var i1 *Info64
+	var i1 *unix.LoopInfo64
 
-	info := &Info64{
-		Flags: FlagsAutoClear | FlagsReadOnly,
+	info := &unix.LoopInfo64{
+		Flags: unix.LO_FLAGS_AUTOCLEAR | unix.LO_FLAGS_READ_ONLY,
 	}
 	loopDevOne := &Device{
 		MaxLoopDevices: GetMaxLoopDevices(),


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1506
 which fixed
- sylabs/singularity# 1505

The original PR description was:
> Use x/sys/unix wrappers for ioctl operations.
> 
> Use x/sys/unix types and flag constants.
> 
> Not for backport. Changes public things under pkg