### PR TITLE
1481 support pwd in oci mode, from sylabs 1496

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -216,6 +216,14 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			},
 		},
 		{
+			name: "Cwd",
+			argv: []string{"--cwd", "/tmp", imageRef, "pwd"},
+			exit: 0,
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.ExactMatch, "/tmp"),
+			},
+		},
+		{
 			name: "ResolvConfGoogle",
 			argv: []string{"--dns", "8.8.8.8,8.8.4.4", imageRef, "nslookup", "w3.org"},
 			exit: 0,


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1496
 which fixed
- sylabs/singularity# 1481

The original PR description was:
> 1. Support `--pwd` in OCI mode.
> 2. Replace `--pwd` with `--cwd` (see comments by @ dtrudg on [Support `--pwd` in `--oci` mode # 1481](https://github.com/sylabs/singularity/issues/ 1481)), and adjust code throughout to reflect this (i.e., misleading references to "{p,P}wd" in the code replaced with "{c,C}wd"). Keep `--pwd` flag as a synonym, for backwards compatibility.