### PR TITLE
oci: fix custom cwd not respected when homedir set, from sylabs 1523

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -125,10 +125,11 @@ func (c actionTests) actionOciExec(t *testing.T) {
 	homePath := filepath.Join("/home", basename)
 
 	tests := []struct {
-		name        string
-		argv        []string
-		exit        int
-		wantOutputs []e2e.ApptainerCmdResultOp
+		name         string
+		argv         []string
+		exit         int
+		wantOutputs  []e2e.ApptainerCmdResultOp
+		skipProfiles map[string]bool
 	}{
 		{
 			name: "NoCommand",
@@ -177,6 +178,10 @@ func (c actionTests) actionOciExec(t *testing.T) {
 				e2e.ExpectOutput(e2e.RegexMatch, `\bHOME=/myhomeloc\b`),
 				e2e.ExpectOutput(e2e.RegexMatch, `\btmpfs on /myhomeloc\b`),
 			},
+			skipProfiles: map[string]bool{
+				e2e.OCIRootProfile.String():     true,
+				e2e.OCIFakerootProfile.String(): true,
+			},
 			exit: 0,
 		},
 		{
@@ -209,18 +214,18 @@ func (c actionTests) actionOciExec(t *testing.T) {
 		},
 		{
 			name: "Pwd",
-			argv: []string{"--pwd", "/tmp", imageRef, "pwd"},
+			argv: []string{"--pwd", "/etc", imageRef, "pwd"},
 			exit: 0,
 			wantOutputs: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.ExactMatch, "/tmp"),
+				e2e.ExpectOutput(e2e.ExactMatch, "/etc"),
 			},
 		},
 		{
 			name: "Cwd",
-			argv: []string{"--cwd", "/tmp", imageRef, "pwd"},
+			argv: []string{"--cwd", "/etc", imageRef, "pwd"},
 			exit: 0,
 			wantOutputs: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.ExactMatch, "/tmp"),
+				e2e.ExpectOutput(e2e.ExactMatch, "/etc"),
 			},
 		},
 		{
@@ -243,10 +248,15 @@ func (c actionTests) actionOciExec(t *testing.T) {
 	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tt := range tests {
+				skip, ok := tt.skipProfiles[profile.String()]
+				if ok && skip {
+					continue
+				}
+
 				c.env.RunApptainer(
 					t,
 					e2e.AsSubtest(tt.name),
-					e2e.WithProfile(e2e.UserProfile),
+					e2e.WithProfile(profile),
 					e2e.WithCommand("exec"),
 					e2e.WithDir("/tmp"),
 					e2e.WithArgs(tt.argv...),
@@ -377,7 +387,11 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
 	workspace, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "bind-workspace-", "")
-	defer e2e.Privileged(cleanup)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			e2e.Privileged(cleanup)
+		}
+	})
 
 	contCanaryDir := "/canary"
 	hostCanaryDir := filepath.Join(workspace, "canary")

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -202,9 +202,11 @@ func Run(t *testing.T) {
 	testenv.OrasTestImage = fmt.Sprintf("oras://%s/oras_test_sif:latest", testenv.TestRegistry)
 
 	t.Cleanup(func() {
-		os.Remove(imagePath)
-		os.Remove(ociArchivePath)
-		os.Remove(dockerArchivePath)
+		if !t.Failed() {
+			os.Remove(imagePath)
+			os.Remove(ociArchivePath)
+			os.Remove(dockerArchivePath)
+		}
 	})
 
 	suite := testhelper.NewSuite(t, testenv)

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -99,6 +99,10 @@ func getProcessArgs(imageSpec imgspecv1.Image, process string, args []string) []
 // Currently this is the user's tmpfs home directory (see --containall).
 // Because this is called after mounts have already been computed, we can count on l.cfg.HomeDir containing the right value, incorporating any custom home dir overrides (i.e., --home).
 func (l *Launcher) getProcessCwd() (dir string, err error) {
+	if len(l.cfg.CwdPath) > 0 {
+		return l.cfg.CwdPath, nil
+	}
+
 	return l.cfg.HomeDir, nil
 }
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1523

The original PR description was:
> There was a problem where, in OCI mode, a custom working directory (`--cwd`/`--pwd`) would not be respected, and the homedir would be used as the working directory instead.
> 
> Interestingly, this was not caught by our e2e tests, which (ultimately) revealed a problem in the way I was handling profiles in the `actionOciExec()` function (e2e/actions/oci.go:228).
> 
> This fixes both issues.