### PR TITLE
oci: fix --home when running as root or fakeroot, from sylabs 1530

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -178,10 +178,6 @@ func (c actionTests) actionOciExec(t *testing.T) {
 				e2e.ExpectOutput(e2e.RegexMatch, `\bHOME=/myhomeloc\b`),
 				e2e.ExpectOutput(e2e.RegexMatch, `\btmpfs on /myhomeloc\b`),
 			},
-			skipProfiles: map[string]bool{
-				e2e.OCIRootProfile.String():     true,
-				e2e.OCIFakerootProfile.String(): true,
-			},
 			exit: 0,
 		},
 		{

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -51,6 +51,9 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, imag
 	// --env flag can override --env-file and APPTAINERENV_
 	rtEnv = mergeMap(rtEnv, l.cfg.Env)
 
+	// Ensure HOME points to the required home directory, even if it is a custom one.
+	rtEnv["HOME"] = l.cfg.HomeDir
+
 	cwd, err := l.getProcessCwd()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1530
 which fixed
- sylabs/singularity# 1529

The original PR description was:
> Fix `--home` functionality in OCI-mode, so it works even when running as root (e.g. under `sudo`) or when running with `--fakeroot`.