### PR TITLE
oci: fix to not override HOME when container specifies USER (+ e2e test), from sylabs 1594

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -886,35 +886,86 @@ func (c ctx) testDockerCMDENTRYPOINT(t *testing.T) {
 
 // Check that the USER in a docker container is honored under --oci mode
 func (c ctx) testDockerUSER(t *testing.T) {
+	dockerURI := "docker://ghcr.io/apptainer/docker-user"
 	tests := []struct {
-		name         string
-		expectOutput string
-		profile      e2e.Profile
+		name          string
+		cmd           string
+		args          []string
+		expectOutputs []e2e.ApptainerCmdResultOp
+		profile       e2e.Profile
+		expectExit    int
 	}{
 		// Sanity check apptainer native engine... no support for USER
 		{
 			name:    "default",
+			cmd:     "run",
 			profile: e2e.UserProfile,
-			expectOutput: fmt.Sprintf("uid=%d(%s) gid=%d",
-				e2e.UserProfile.ContainerUser(t).UID,
-				e2e.UserProfile.ContainerUser(t).Name,
-				e2e.UserProfile.ContainerUser(t).GID),
+			args:    []string{dockerURI},
+			expectOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, fmt.Sprintf("uid=%d(%s) gid=%d",
+					e2e.UserProfile.ContainerUser(t).UID,
+					e2e.UserProfile.ContainerUser(t).Name,
+					e2e.UserProfile.ContainerUser(t).GID,
+				)),
+			},
 		},
 		// `--oci` modes (USER honored by default)
 		{
-			name:         "OCIUser",
-			profile:      e2e.OCIUserProfile,
-			expectOutput: `uid=2000(testuser) gid=2000(testgroup)`,
+			name:    "OCIUser",
+			cmd:     "run",
+			profile: e2e.OCIUserProfile,
+			args:    []string{dockerURI},
+			expectOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, `uid=2000(testuser) gid=2000(testgroup)`),
+			},
 		},
 		{
-			name:         "OCIFakeroot",
-			profile:      e2e.OCIFakerootProfile,
-			expectOutput: `uid=0(root) gid=0(root)`,
+			name:    "OCIFakeroot",
+			profile: e2e.OCIFakerootProfile,
+			args:    []string{dockerURI},
+			expectOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, `uid=0(root) gid=0(root)`),
+			},
 		},
 		{
-			name:         "OCIRoot",
-			profile:      e2e.OCIRootProfile,
-			expectOutput: `uid=2000(testuser) gid=2000(testgroup)`,
+			name:    "OCIRoot",
+			cmd:     "run",
+			profile: e2e.OCIRootProfile,
+			args:    []string{dockerURI},
+			expectOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, `uid=2000(testuser) gid=2000(testgroup)`),
+			},
+		},
+		// `--oci` modes: check that we don't override container-user's home directory
+		{
+			name:    "OrigHomeOCIUser",
+			cmd:     "exec",
+			profile: e2e.OCIUserProfile,
+			args:    []string{dockerURI, "env"},
+			expectOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `\bHOME=/home/testuser\b`),
+			},
+			expectExit: 0,
+		},
+		{
+			name:    "OrigHomeOCIFakeroot",
+			cmd:     "exec",
+			profile: e2e.OCIFakerootProfile,
+			args:    []string{dockerURI, "env"},
+			expectOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `\bHOME=/root\b`),
+			},
+			expectExit: 0,
+		},
+		{
+			name:    "OrigHomeOCIRoot",
+			cmd:     "exec",
+			profile: e2e.OCIRootProfile,
+			args:    []string{dockerURI, "env"},
+			expectOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `\bHOME=/home/testuser\b`),
+			},
+			expectExit: 0,
 		},
 	}
 
@@ -924,10 +975,8 @@ func (c ctx) testDockerUSER(t *testing.T) {
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(tt.profile),
 			e2e.WithCommand("run"),
-			e2e.WithArgs("docker://ghcr.io/apptainer/docker-user"),
-			e2e.ExpectExit(0,
-				e2e.ExpectOutput(e2e.ContainMatch, tt.expectOutput),
-			),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(tt.expectExit, tt.expectOutputs...),
 		)
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -51,8 +51,10 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, imag
 	// --env flag can override --env-file and APPTAINERENV_
 	rtEnv = mergeMap(rtEnv, l.cfg.Env)
 
-	// Ensure HOME points to the required home directory, even if it is a custom one.
-	rtEnv["HOME"] = l.cfg.HomeDir
+	// Ensure HOME points to the required home directory, even if it is a custom one, unless the container explicitly specifies its USER, in which case we don't want to touch HOME.
+	if imgSpec.Config.User == "" {
+		rtEnv["HOME"] = l.cfg.HomeDir
+	}
 
 	cwd, err := l.getProcessCwd()
 	if err != nil {


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1594
 which fixed
- sylabs/singularity# 1593

The original PR description was:
> In OCI mode, avoid overriding container's HOME environment variable if container specifies its own USER.
> 
> Also add e2e test of the above.