### PR TITLE
--no-setgroups option for --fakeroot, from sylabs 1757

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
   of the logged-in user, if available.
 - New option `--warn-unused-build-args` is provided to output warnings rather than
   fatal errors for any unused variables given in --build-arg or --build-arg-file.
+- Added `--no-setgroups` flag for `--fakeroot` builds and run/shell/exec. This
+  prevents the `setgroups` syscall being used on the container process in the
+  fakeroot user namespace. Maintains access from within the user namespace to
+  files on the host that have permissions based on supplementary group
+  membership. Note that supplementary groups are mapped to `nobody` in the
+  container, and `chgrp`, `newgrp`, etc. cannot be used.
 
 ### New Features & Functionality
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -45,6 +45,7 @@ var (
 
 	isBoot          bool
 	isFakeroot      bool
+	noSetgroups     bool
 	isCleanEnv      bool
 	isCompat        bool
 	isContained     bool
@@ -371,6 +372,16 @@ var actionFakerootFlag = cmdline.Flag{
 	ShortHand:    "f",
 	Usage:        "run container with the appearance of running as root",
 	EnvKeys:      []string{"FAKEROOT"},
+}
+
+// --no-setgroups
+var actionNoSetgroupsFlag = cmdline.Flag{
+	ID:           "actionNoSetgroupsFlag",
+	Value:        &noSetgroups,
+	DefaultValue: false,
+	Name:         "no-setgroups",
+	Usage:        "disable setgroups when entering --fakeroot user namespace",
+	EnvKeys:      []string{"NO_SETGROUPS"},
 }
 
 // -e|--cleanenv
@@ -907,6 +918,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionDNSFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionDropCapsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionFakerootFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoSetgroupsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionFuseMountFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionHomeFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionHostnameFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -344,6 +344,7 @@ func launchContainer(cmd *cobra.Command, image string, args []string, instanceNa
 		launch.OptShellPath(shellPath),
 		launch.OptCwdPath(cwdPath),
 		launch.OptFakeroot(isFakeroot),
+		launch.OptNoSetgroups(noSetgroups),
 		launch.OptBoot(isBoot),
 		launch.OptNoInit(noInit),
 		launch.OptContain(isContained),

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -125,10 +125,11 @@ func fakerootExec(isDeffile, unprivEncrypt bool) {
 	}
 
 	engineConfig := &fakerootConfig.EngineConfig{
-		Args:     args,
-		Envs:     os.Environ(),
-		Home:     user.Dir,
-		BuildEnv: true,
+		Args:        args,
+		Envs:        os.Environ(),
+		Home:        user.Dir,
+		BuildEnv:    true,
+		NoSetgroups: buildArgs.noSetgroups,
 	}
 
 	cfg := &config.Common{

--- a/cmd/starter/c/include/starter.h
+++ b/cmd/starter/c/include/starter.h
@@ -3,7 +3,7 @@
     Apptainer a Series of LF Projects LLC.
     For website terms of use, trademark policy, privacy policy and other
     project policies see https://lfprojects.org/policies
-  Copyright (c) 2018-2019, Sylabs, Inc. All rights reserved.
+  Copyright (c) 2018-2023, Sylabs, Inc. All rights reserved.
 
   This software is licensed under a 3-clause BSD license.  Please
   consult LICENSE.md file distributed with the sources of this project regarding
@@ -117,6 +117,10 @@ struct privileges {
     char uidMap[MAX_MAP_SIZE];
     char gidMap[MAX_MAP_SIZE];
     bool allowSetgroups;
+    /* skip setgroups call even if allowed. May be used with fakeroot engine to
+    access files with pre-userns supplementary group membership.
+    See https://github.com/sylabs/singularity/issues/1748 */
+    bool noSetgroups;
 
     /* path to external newuidmap/newgidmap binaries */
     char newuidmapPath[MAX_PATH_SIZE];

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -3,7 +3,7 @@
     Apptainer a Series of LF Projects LLC.
     For website terms of use, trademark policy, privacy policy and other
     project policies see https://lfprojects.org/policies
-  Copyright (c) 2018-2020, Sylabs, Inc. All rights reserved.
+  Copyright (c) 2018-2023, Sylabs, Inc. All rights reserved.
 
   This software is licensed under a 3-clause BSD license.  Please
   consult LICENSE.md file distributed with the sources of this project regarding
@@ -316,7 +316,9 @@ static void apply_privileges(struct privileges *privileges, struct capabilities 
                 fatalf("Failed to set GID %d: %s\n", targetGID, strerror(errno));
             }
 
-            if ( privileges->numGID > 1 ) {
+            if ( privileges->noSetgroups ) {
+                debugf("Skipping setgroups due to configuration.\n");
+            } else {
                 debugf("Set %d additional group IDs\n", privileges->numGID);
                 if ( setgroups(privileges->numGID, privileges->targetGID) < 0 ) {
                     fatalf("Failed to set additional groups: %s\n", strerror(errno));

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2819,6 +2819,26 @@ func (c actionTests) actionFakerootHome(t *testing.T) {
 	}
 }
 
+// actionNoSetgoups checks that supplementary groups are visible, mapped to
+// nobody, in the container with --fakeroot --no-setgroups.
+func (c actionTests) actionNoSetgroups(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	// Inside the e2e-tests we will be a member of our user group + single supplementary group.
+	// With `--fakeroot --no-setgroups` we should see these map to:
+	//    root nobody
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.FakerootProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--no-setgroups", c.env.ImagePath, "sh", "-c", "groups"),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.ExactMatch, "root nobody"),
+		),
+	)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := actionTests{
@@ -2862,6 +2882,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"bind image":                c.bindImage,               // test bind image with --bind and --mount
 		"unsquash":                  c.actionUnsquash,          // test --unsquash
 		"no-mount":                  c.actionNoMount,           // test --no-mount
+		"no-setgroups":              c.actionNoSetgroups,       // test --no-setgroups
 		"compat":                    np(c.actionCompat),        // test --compat
 		"umask":                     np(c.actionUmask),         // test umask propagation
 		"invalidRemote":             np(c.invalidRemote),       // GHSA-5mv9-q7fq-9394

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -2193,6 +2193,45 @@ func (c imgBuildTests) testGocryptfsSIFBuild(t *testing.T) {
 	}
 }
 
+// actionNoSetgoups checks that supplementary groups are visible, mapped to
+// nobody, in the container with --fakeroot --no-setgroups.
+func (c imgBuildTests) buildNoSetgroups(t *testing.T) {
+	tmpdir, cleanup := c.tempDir(t, "build-nosetgroups-test")
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
+
+	definition := `Bootstrap: localimage
+From: %s
+
+%%post
+    groups`
+
+	definition = fmt.Sprintf(definition, e2e.BusyboxSIF(t))
+
+	defFile := e2e.RawDefFile(t, tmpdir, strings.NewReader(definition))
+	imagePath := filepath.Join(tmpdir, "image-nosetgroups")
+
+	// Inside the e2e-tests we will be a member of our user group + single supplementary group.
+	// With `--fakeroot --no-setgroups` we should see these map to:
+	//    root nobody
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.FakerootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--no-setgroups", "-F", imagePath, defFile),
+		e2e.PostRun(func(t *testing.T) {
+			os.Remove(defFile)
+			os.Remove(imagePath)
+		}),
+		e2e.ExpectExit(0,
+			e2e.ExpectOutput(e2e.ExactMatch, "root nobody"),
+		),
+	)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := imgBuildTests{
@@ -2216,6 +2255,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"test with writable tmpfs":               c.testWritableTmpfs,                    // build image, using writable tmpfs in the test step
 		"test build system environment":          c.testBuildEnvironmentVariables,        // build image with build system environment variables set in definition
 		"test build under fakeroot modes":        c.testContainerBuildUnderFakerootModes, // build image under different fakeroot modes
+		"no-setgroups":                           c.buildNoSetgroups,                     // build with --fakeroot --no-setgroups
 		"issue 3848":                             c.issue3848,                            // https://github.com/apptainer/singularity/issues/3848
 		"issue 4203":                             c.issue4203,                            // https://github.com/apptainer/singularity/issues/4203
 		"issue 4407":                             c.issue4407,                            // https://github.com/apptainer/singularity/issues/4407

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -616,6 +616,7 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 
 		starterConfig.SetHybridWorkflow(true)
 		starterConfig.SetAllowSetgroups(true)
+		starterConfig.SetNoSetgroups(e.EngineConfig.GetNoSetgroups())
 
 		starterConfig.SetTargetUID(0)
 		starterConfig.SetTargetGID([]int{0})

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -191,6 +191,18 @@ func (c *Config) SetAllowSetgroups(allow bool) {
 		c.config.container.privileges.allowSetgroups = C.true
 	} else {
 		c.config.container.privileges.allowSetgroups = C.false
+	}
+}
+
+// SetNoSetgroups disables the setgroups call for the container process in the
+// starter. Preserves access to files that depends on supplementary groups
+// outside of the user namespace. The supplementary groups will map to 'nobody'
+// inside the container.
+func (c *Config) SetNoSetgroups(noSetgroups bool) {
+	if noSetgroups {
+		c.config.container.privileges.noSetgroups = C.true
+	} else {
+		c.config.container.privileges.noSetgroups = C.false
 	}
 }
 

--- a/internal/pkg/runtime/engine/fakeroot/config/config.go
+++ b/internal/pkg/runtime/engine/fakeroot/config/config.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,8 +15,9 @@ const Name = "fakeroot"
 // EngineConfig is the config for the fakeroot engine used to execute
 // a command in a fakeroot context
 type EngineConfig struct {
-	Args     []string `json:"args"`
-	Envs     []string `json:"envs"`
-	Home     string   `json:"home"`
-	BuildEnv bool     `json:"buildEnv"`
+	Args        []string `json:"args"`
+	Envs        []string `json:"envs"`
+	Home        string   `json:"home"`
+	BuildEnv    bool     `json:"buildEnv"`
+	NoSetgroups bool     `json:"NoSetgroups"`
 }

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -137,6 +137,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 
 	starterConfig.SetHybridWorkflow(true)
 	starterConfig.SetAllowSetgroups(true)
+	starterConfig.SetNoSetgroups(e.EngineConfig.NoSetgroups)
 
 	starterConfig.SetTargetUID(0)
 	starterConfig.SetTargetGID([]int{0})

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -323,6 +323,14 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 	if l.cfg.Fakeroot {
 		l.cfg.Namespaces.User = !l.cfg.IgnoreUserns
 	}
+	// Allow optional skipping of setgroups in --fakeroot mode.
+	if l.cfg.NoSetgroups {
+		if l.cfg.Fakeroot {
+			l.engineConfig.SetNoSetgroups(l.cfg.NoSetgroups)
+		} else {
+			sylog.Warningf("--no-setgroups only applies to --fakeroot mode")
+		}
+	}
 
 	l.setCgroups(instanceName)
 

--- a/internal/pkg/runtime/launch/options.go
+++ b/internal/pkg/runtime/launch/options.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -120,6 +120,8 @@ type launchOptions struct {
 
 	// Fakeroot enables the fake root mode, using user namespaces and subuid / subgid mapping.
 	Fakeroot bool
+	// NoSetgroups disables calling setgroups for the fakeroot user namespace.
+	NoSetgroups bool
 	// Boot enables execution of /sbin/init on startup of an instance container.
 	Boot bool
 	// NoInit disables shim process when PID namespace is used.
@@ -435,6 +437,14 @@ func OptCwdPath(p string) Option {
 func OptFakeroot(b bool) Option {
 	return func(lo *launchOptions) error {
 		lo.Fakeroot = b
+		return nil
+	}
+}
+
+// OptNoSetgroups disables calling setgroups for the fakeroot user namespace.
+func OptNoSetgroups(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.NoSetgroups = b
 		return nil
 	}
 }

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -151,6 +151,7 @@ type JSONConfig struct {
 	NoEval                bool              `json:"noEval,omitempty"`
 	Underlay              bool              `json:"underlay,omitempty"`
 	UserInfo              UserInfo          `json:"userInfo,omitempty"`
+	NoSetgroups           bool              `json:"noSetgroups,omitempty"`
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.
@@ -903,4 +904,16 @@ func (e *EngineConfig) SetUnderlay(underlay bool) {
 // GetUnderlay gets the value of whether to use underlay instead of overlay
 func (e *EngineConfig) GetUnderlay() bool {
 	return e.JSON.Underlay
+}
+
+// SetNoSetgroups sets whether to skip the setgroups call for a container in a
+// user namespace.
+func (e *EngineConfig) SetNoSetgroups(noSetgroups bool) {
+	e.JSON.NoSetgroups = noSetgroups
+}
+
+// GetNoSetgroups gets whether to skip the setgroups call for a container in a
+// user namespace.
+func (e *EngineConfig) GetNoSetgroups() bool {
+	return e.JSON.NoSetgroups
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1757
 which fixed
- sylabs/singularity# 1748

The original PR description was:
> When we run in `--fakeroot` mode, the `starter` will call `setgroups` and reduce the group membership of the container process to `gid=0` only, inside the fakeroot id-mapped user namespace.
> 
> This removes supplementary group membership, and therefore prevents access to files on the host that are restricted by group ownership where the group is a supplementary group of the current user.
> 
> If, for example, `$HOME` is accessed via a supplementary group then it cannot be mounted inside the id-mapped user namespace created at the start of a `singularity build --fakeroot`. The build will then fail.
> 
> This PR adds a new flag `--no-setgroups` to skip the `setgroups` call in `--fakeroot` mode. This results in the container process _not_ having its group membership changed. Host files accessible via host supplementary groups will remain accessible.
> 
> This does not make the supplementary groups fully available in the container. Inside the id-mapped user namespace they will be mapped to `nobody`. The output of `id` may be confusing, and we still cannot e.g. `chgrp` a file to one of the user's supplementary groups.
> 
> On host...
> 
> ```
> $ groups
> dtrudg-sylabs wheel mock docker libvirt
> ```
> 
> In container with `--fakeroot --no-setgroups`...
> 
> ```
> Singularity> groups
> root nobody nobody nobody nobody
> ```
> 