### PR TITLE
fix: correct capability.Name for CAP_BLOCK_SUSPEND, from sylabs 1802

### DIFF
--- a/pkg/util/capabilities/capabilities.go
+++ b/pkg/util/capabilities/capabilities.go
@@ -374,7 +374,7 @@ var (
 	}
 
 	capBlockSuspend = &capability{
-		Name:  "CAP_WAKE_ALARM",
+		Name:  "CAP_BLOCK_SUSPEND",
 		Value: 36,
 		Description: `CAP_BLOCK_SUSPEND (since Linux 3.5)
 	Employ features that can block system suspend (epoll(7) EPOLLWAKEUP, /proc/sys/wake_lock).`,


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1802
 which fixed
- sylabs/singularity# 1801

The original PR description was:
> fix: correct capability.Name for CAP_BLOCK_SUSPEND