### PR TITLE
oci: support --overlay, from sylabs 1659

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `--dns` flag can be used to pass a comma-separated list of DNS servers that
   will be used in the container; if this flag is not used, the container will
   use the same `resolv.conf` settings as the host.
+- OCI-mode now supports `--overlay <dir>` flag, allowing writes to the
+  filesystem to persist across runs of the OCI container. If specified dir does
+  not exist, Apptainer will attempt to create it. Multiple overlays can be
+  specified, but all but one must be read-only (`--overlay <dir>:ro`).
 
 ## Changes since last pre-release
 

--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -37,6 +37,17 @@ var ociBundleFlag = cmdline.Flag{
 	EnvKeys:      []string{"BUNDLE"},
 }
 
+// -o|--overlay
+var ociOverlayFlag = cmdline.Flag{
+	ID:           "ociOverlayFlag",
+	Value:        &ociArgs.OverlayPaths,
+	DefaultValue: []string{},
+	Name:         "overlay",
+	ShortHand:    "o",
+	Usage:        "specify an overlay dir to use in lieu of a writable tmpfs",
+	Tag:          "<path>",
+}
+
 // -l|--log-path
 var ociLogPathFlag = cmdline.Flag{
 	ID:           "ociLogPathFlag",
@@ -130,6 +141,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&ociLogPathFlag, createRunCmd...)
 		cmdManager.RegisterFlagForCmd(&ociLogFormatFlag, createRunCmd...)
 		cmdManager.RegisterFlagForCmd(&ociPidFileFlag, createRunCmd...)
+		cmdManager.RegisterFlagForCmd(&ociOverlayFlag, OciRunWrappedCmd)
 		cmdManager.RegisterFlagForCmd(&ociKillForceFlag, OciKillCmd)
 		cmdManager.RegisterFlagForCmd(&ociKillSignalFlag, OciKillCmd)
 		cmdManager.RegisterFlagForCmd(&ociUpdateFromFileFlag, OciUpdateCmd)

--- a/docs/content.go
+++ b/docs/content.go
@@ -1025,7 +1025,7 @@ Enterprise Performance Computing (EPC)`
   $ apptainer oci delete mycontainer`
 
 	// Internal oci launcher use only - no user-facing docs
-	OciRunWrappedUse string = `run-wrapped -b <bundle_path> [run options...] <container_ID>`
+	OciRunWrappedUse string = `run-wrapped -b <bundle_path> [-o <overlay_dir>] [run options...] <container_ID>`
 
 	OciUpdateUse   string = `update [update options...] <container_ID>`
 	OciUpdateShort string = `Update container cgroups resources (root user only)`

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2932,5 +2932,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociCdi":     c.actionOciCdi,        // apptainer exec --oci --cdi
 		"ociIDMaps":  c.actionOciIDMaps,     // check uid/gid mapping on host for --oci as user / --fakeroot
 		"ociCompat":  np(c.actionOciCompat), // --oci equivalence to native mode --compat
+		"ociOverlay": (c.actionOciOverlay),  // --overlay in OCI mode
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -807,7 +807,7 @@ func (c actionTests) actionOciCdi(t *testing.T) {
 
 					// Generate the command to be executed in the container
 					// Start by printing all environment variables, to test using e2e.ContainMatch conditions later
-					execCmd := "/bin/env"
+					execCmd := "/usr/bin/env"
 
 					// Add commands to test the presence of mapped devices.
 					for _, d := range tt.DeviceNodes {
@@ -968,5 +968,100 @@ func (c actionTests) actionOciCompat(t *testing.T) {
 				tt.expect,
 			),
 		)
+	}
+}
+
+// actionOciOverlay checks that --overlay functions correctly in OCI mode.
+func (c actionTests) actionOciOverlay(t *testing.T) {
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIFakerootProfile} {
+		testDir, err := fs.MakeTmpDir(c.env.TestDir, "overlaytestdir", 0o755)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if !t.Failed() {
+				os.RemoveAll(testDir)
+			}
+		})
+
+		// Create a few read-only overlay subdirs under testDir
+		for i := 0; i < 3; i++ {
+			dirName := fmt.Sprintf("my_ro_ol_dir%d", i)
+			fullPath := filepath.Join(testDir, dirName)
+			if err = os.Mkdir(fullPath, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if !t.Failed() {
+					os.RemoveAll(fullPath)
+				}
+			})
+			if err = os.WriteFile(
+				filepath.Join(fullPath, fmt.Sprintf("testfile.%d", i)),
+				[]byte(fmt.Sprintf("test_string_%d\n", i)),
+				0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err = os.WriteFile(
+				filepath.Join(fullPath, "maskable_testfile"),
+				[]byte(fmt.Sprintf("maskable_string_%d\n", i)),
+				0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		tests := []struct {
+			name        string
+			args        []string
+			exitCode    int
+			wantOutputs []e2e.ApptainerCmdResultOp
+		}{
+			{
+				name:     "NewWritable",
+				args:     []string{"--overlay", filepath.Join(testDir, "my_rw_ol_dir"), imageRef, "sh", "-c", "echo my_test_string > /my_test_file"},
+				exitCode: 0,
+			},
+			{
+				name:     "ExistWritable",
+				args:     []string{"--overlay", filepath.Join(testDir, "my_rw_ol_dir"), imageRef, "cat", "/my_test_file"},
+				exitCode: 0,
+				wantOutputs: []e2e.ApptainerCmdResultOp{
+					e2e.ExpectOutput(e2e.ExactMatch, "my_test_string"),
+				},
+			},
+			{
+				name:     "NonExistReadonly",
+				args:     []string{"--overlay", filepath.Join(testDir, "my_ro_ol_dir_nonexistent:ro"), imageRef, "echo", "hi"},
+				exitCode: 255,
+			},
+			{
+				name:     "SeveralReadonly",
+				args:     []string{"--overlay", filepath.Join(testDir, "my_ro_ol_dir2:ro"), "--overlay", filepath.Join(testDir, "my_ro_ol_dir1:ro"), imageRef, "cat", "/testfile.1", "/maskable_testfile"},
+				exitCode: 0,
+				wantOutputs: []e2e.ApptainerCmdResultOp{
+					e2e.ExpectOutput(e2e.ContainMatch, "test_string_1"),
+					e2e.ExpectOutput(e2e.ContainMatch, "maskable_string_2"),
+				},
+			},
+		}
+
+		t.Run(profile.String(), func(t *testing.T) {
+			for _, tt := range tests {
+				c.env.RunApptainer(
+					t,
+					e2e.AsSubtest(tt.name),
+					e2e.WithProfile(profile),
+					e2e.WithCommand("exec"),
+					e2e.WithArgs(tt.args...),
+					e2e.ExpectExit(
+						tt.exitCode,
+						tt.wantOutputs...,
+					),
+				)
+			}
+		})
 	}
 }

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -492,28 +492,28 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 		dfd  e2e.DefFileDetails
 	}{
 		{
-			name: "BusyBox",
+			name: "Alpine",
 			exit: 0,
 			dfd: e2e.DefFileDetails{
 				Bootstrap: "docker",
-				From:      fmt.Sprintf("%s/my-busybox", c.env.TestRegistry),
+				From:      fmt.Sprintf("%s/my-alpine", c.env.TestRegistry),
 			},
 		},
 		{
-			name: "BusyBoxRegistry",
+			name: "AlpineRegistry",
 			exit: 0,
 			dfd: e2e.DefFileDetails{
 				Bootstrap: "docker",
-				From:      "my-busybox",
+				From:      "my-alpine",
 				Registry:  c.env.TestRegistry,
 			},
 		},
 		{
-			name: "BusyBoxNamespace",
+			name: "AlpineNamespace",
 			exit: 255,
 			dfd: e2e.DefFileDetails{
 				Bootstrap: "docker",
-				From:      "my-busybox",
+				From:      "my-alpine",
 				Registry:  c.env.TestRegistry,
 				Namespace: "not-a-namespace",
 			},

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -84,7 +84,7 @@ func (c ctx) issue4943(t *testing.T) {
 
 func (c ctx) issue5172(t *testing.T) {
 	// create $HOME/.config/containers/registries.conf
-	regImage := fmt.Sprintf("docker://%s/my-busybox", c.env.TestRegistry)
+	regImage := fmt.Sprintf("docker://%s/my-alpine", c.env.TestRegistry)
 	imagePath := filepath.Join(c.env.TestDir, "issue-5172")
 
 	c.env.RunApptainer(

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1746,7 +1746,7 @@ func (c imgBuildTests) buildLibraryHost(t *testing.T) {
 	)
 }
 
-// testWritableTmpfs checks that we can run the build using a writeable tmpfs in the %test step
+// testWritableTmpfs checks that we can run the build using a writable tmpfs in the %test step
 func (c imgBuildTests) testWritableTmpfs(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -170,9 +170,9 @@ func Run(t *testing.T) {
 	testenv.OrasTestImage = fmt.Sprintf("oras://%s/oras_test_sif:latest", testenv.TestRegistry)
 
 	// Provision local registry
-	testenv.TestRegistryImage = fmt.Sprintf("docker://%s/my-busybox:latest", testenv.TestRegistry)
+	testenv.TestRegistryImage = fmt.Sprintf("docker://%s/my-alpine:latest", testenv.TestRegistry)
 
-	// Copy small test image (busybox:latest) into local registry from DockerHub
+	// Copy small test image (alpine:latest) into local registry from DockerHub
 	insecureSource := false
 	insecureValue := os.Getenv("E2E_DOCKER_MIRROR_INSECURE")
 	if insecureValue != "" {
@@ -181,7 +181,7 @@ func Run(t *testing.T) {
 			t.Fatalf("could not convert E2E_DOCKER_MIRROR_INSECURE=%s: %s", insecureValue, err)
 		}
 	}
-	e2e.CopyImage(t, "docker://busybox:latest", testenv.TestRegistryImage, insecureSource, true)
+	e2e.CopyImage(t, "docker://alpine:latest", testenv.TestRegistryImage, insecureSource, true)
 
 	// SIF base test path, built on demand by e2e.EnsureImage
 	imagePath := path.Join(name, "test.sif")

--- a/internal/app/apptainer/oci_linux.go
+++ b/internal/app/apptainer/oci_linux.go
@@ -27,6 +27,7 @@ import (
 // OciArgs contains CLI arguments
 type OciArgs struct {
 	BundlePath   string
+	OverlayPaths []string
 	LogPath      string
 	LogFormat    string
 	PidFile      string
@@ -52,7 +53,8 @@ func OciRunWrapped(ctx context.Context, containerID string, args *OciArgs) error
 	if err != nil {
 		return err
 	}
-	return oci.RunWrapped(ctx, containerID, args.BundlePath, args.PidFile, systemdCgroups)
+
+	return oci.RunWrapped(ctx, containerID, args.BundlePath, args.PidFile, args.OverlayPaths, systemdCgroups)
 }
 
 // OciCreate creates a container from an OCI bundle

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -85,9 +85,6 @@ func checkOpts(lo launcher.Options) error {
 	if lo.WritableTmpfs {
 		sylog.Infof("--oci mode uses --writable-tmpfs by default")
 	}
-	if len(lo.OverlayPaths) > 0 {
-		badOpt = append(badOpt, "OverlayPaths")
-	}
 	if lo.WorkDir != "" {
 		badOpt = append(badOpt, "WorkDir")
 	}
@@ -475,11 +472,11 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 
 	if os.Getuid() == 0 {
 		// Execution of runc/crun run, wrapped with prep / cleanup.
-		err = RunWrapped(ctx, id.String(), b.Path(), "", l.apptainerConf.SystemdCgroups)
+		err = RunWrapped(ctx, id.String(), b.Path(), "", l.cfg.OverlayPaths, l.apptainerConf.SystemdCgroups)
 	} else {
 		// Reexec apptainer oci run in a userns with mappings.
 		// Note - the oci run command will pull out the SystemdCgroups setting from config.
-		err = RunWrappedNS(ctx, id.String(), b.Path(), "")
+		err = RunWrappedNS(ctx, id.String(), b.Path(), l.cfg.OverlayPaths)
 	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {

--- a/internal/pkg/runtime/launcher/oci/oci_overlay.go
+++ b/internal/pkg/runtime/launcher/oci/oci_overlay.go
@@ -1,0 +1,112 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
+	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
+)
+
+// WrapWithWritableTmpFs runs a function wrapped with prep / cleanup steps for a writable tmpfs.
+func WrapWithWritableTmpFs(f func() error, bundleDir string) error {
+	// TODO: --oci mode always emulating --compat, which uses --writable-tmpfs.
+	//       Provide a way of disabling this, for a read only rootfs.
+	overlayDir, err := prepareWritableTmpfs(bundleDir)
+	if err != nil {
+		return err
+	}
+
+	err = f()
+
+	// Cleanup actions log errors, but don't return - so we get as much cleanup done as possible.
+	if cleanupErr := cleanupWritableTmpfs(bundleDir, overlayDir); cleanupErr != nil {
+		sylog.Errorf("While cleaning up writable tmpfs: %v", cleanupErr)
+	}
+
+	// Return any error from the actual container payload - preserve exit code.
+	return err
+}
+
+// WrapWithOverlays runs a function wrapped with prep / cleanup steps for overlays.
+func WrapWithOverlays(f func() error, bundleDir string, overlayPaths []string) error {
+	writableOverlayFound := false
+	ovs := tools.OverlaySet{}
+	for _, p := range overlayPaths {
+		writable := true
+		splitted := strings.SplitN(p, ":", 2)
+		barePath := splitted[0]
+		if len(splitted) > 1 {
+			if splitted[1] == "ro" {
+				writable = false
+			}
+		}
+
+		if writable && writableOverlayFound {
+			return fmt.Errorf("you can't specify more than one writable overlay; %#v has already been specified as a writable overlay; use '--overlay %s:ro' instead", ovs.WritableLoc, barePath)
+		}
+		if writable {
+			writableOverlayFound = true
+			ovs.WritableLoc = barePath
+		} else {
+			ovs.ReadonlyLocs = append(ovs.ReadonlyLocs, barePath)
+		}
+	}
+
+	rootFsDir := tools.RootFs(bundleDir).Path()
+	err := tools.ApplyOverlay(rootFsDir, ovs)
+	if err != nil {
+		return err
+	}
+
+	err = f()
+
+	// Cleanup actions log errors, but don't return - so we get as much cleanup done as possible.
+	if cleanupErr := tools.UnmountOverlay(rootFsDir); cleanupErr != nil {
+		sylog.Errorf("While unmounting rootfs overlay: %v", cleanupErr)
+	}
+
+	// Return any error from the actual container payload - preserve exit code.
+	return err
+}
+
+func prepareWritableTmpfs(bundleDir string) (string, error) {
+	sylog.Debugf("Configuring writable tmpfs overlay for %s", bundleDir)
+	c := apptainerconf.GetCurrentConfig()
+	if c == nil {
+		return "", fmt.Errorf("apptainer configuration is not initialized")
+	}
+	return tools.CreateOverlayTmpfs(bundleDir, int(c.SessiondirMaxSize))
+}
+
+func cleanupWritableTmpfs(bundleDir, overlayDir string) error {
+	sylog.Debugf("Cleaning up writable tmpfs overlay for %s", bundleDir)
+	return tools.DeleteOverlayTmpfs(bundleDir, overlayDir)
+}
+
+// absOverlay takes an overlay description string (a path, optionally followed by a colon with an option string, like ":ro" or ":rw"), and replaces any relative path in the description string with an absolute one.
+func absOverlay(desc string) (string, error) {
+	splitted := strings.SplitN(desc, ":", 2)
+	barePath := splitted[0]
+	absBarePath, err := filepath.Abs(barePath)
+	if err != nil {
+		return "", err
+	}
+	absDesc := absBarePath
+	if len(splitted) > 1 {
+		absDesc += ":" + splitted[1]
+	}
+
+	return absDesc, nil
+}

--- a/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -23,10 +23,8 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	fakerootConfig "github.com/apptainer/apptainer/internal/pkg/runtime/engine/fakeroot/config"
 	"github.com/apptainer/apptainer/internal/pkg/util/starter"
-	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
 	"github.com/apptainer/apptainer/pkg/runtime/engine/config"
 	"github.com/apptainer/apptainer/pkg/sylog"
-	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
 )
 
 // Delete deletes container resources
@@ -226,33 +224,23 @@ func Run(ctx context.Context, containerID, bundlePath, pidFile string, systemdCg
 }
 
 // RunWrapped runs a container via the OCI runtime, wrapped with prep / cleanup steps.
-func RunWrapped(ctx context.Context, containerID, bundlePath, pidFile string, systemdCgroups bool) error {
-	// TODO: --oci mode always emulating --compat, which uses --writable-tmpfs.
-	//       Provide a way of disabling this, for a read only rootfs.
-	if err := prepareWriteableTmpfs(bundlePath); err != nil {
-		return err
+func RunWrapped(ctx context.Context, containerID, bundlePath, pidFile string, overlayPaths []string, systemdCgroups bool) error {
+	runFunc := func() error {
+		return Run(ctx, containerID, bundlePath, "", systemdCgroups)
 	}
 
-	err := Run(ctx, containerID, bundlePath, pidFile, systemdCgroups)
-
-	// Cleanup actions log errors, but don't return - so we get as much cleanup done as possible.
-	if err := cleanupWritableTmpfs(bundlePath); err != nil {
-		sylog.Errorf("While cleaning up writable tmpfs: %v", err)
+	if len(overlayPaths) > 0 {
+		return WrapWithOverlays(runFunc, bundlePath, overlayPaths)
 	}
 
-	// Return any error from the actual container payload - preserve exit code.
-	return err
+	return WrapWithWritableTmpFs(runFunc, bundlePath)
 }
 
 // RunWrappedNS reexecs apptainer in a user namespace, with supplied uid/gid mapping, calling oci run.
-func RunWrappedNS(ctx context.Context, containerID, bundlePath, pidFile string) error {
+func RunWrappedNS(ctx context.Context, containerID, bundlePath string, overlayPaths []string) error {
 	absBundle, err := filepath.Abs(bundlePath)
 	if err != nil {
 		return fmt.Errorf("failed to determine bundle absolute path: %s", err)
-	}
-
-	if err := os.Chdir(absBundle); err != nil {
-		return fmt.Errorf("failed to change directory to %s: %s", absBundle, err)
 	}
 
 	args := []string{
@@ -260,10 +248,19 @@ func RunWrappedNS(ctx context.Context, containerID, bundlePath, pidFile string) 
 		"oci",
 		"run-wrapped",
 		"-b", absBundle,
-		containerID,
 	}
-	if pidFile != "" {
-		args = append(args, "--pid-file="+pidFile)
+	for _, p := range overlayPaths {
+		absPath, err := absOverlay(p)
+		if err != nil {
+			return fmt.Errorf("could not convert %q to absolute path: %w", p, err)
+		}
+
+		args = append(args, "--overlay", absPath)
+	}
+	args = append(args, containerID)
+
+	if err := os.Chdir(absBundle); err != nil {
+		return fmt.Errorf("failed to change directory to %s: %s", absBundle, err)
 	}
 
 	sylog.Debugf("Calling fakeroot engine to execute %q", strings.Join(args, " "))
@@ -366,18 +363,4 @@ func Update(containerID, cgFile string, systemdCgroups bool) error {
 	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
-}
-
-func prepareWriteableTmpfs(bundleDir string) error {
-	sylog.Debugf("Configuring writable tmpfs overlay for %s", bundleDir)
-	c := apptainerconf.GetCurrentConfig()
-	if c == nil {
-		return fmt.Errorf("apptainer configuration is not initialized")
-	}
-	return tools.CreateOverlayTmpfs(bundleDir, int(c.SessiondirMaxSize))
-}
-
-func cleanupWritableTmpfs(bundleDir string) error {
-	sylog.Debugf("Cleaning up writable tmpfs overlay for %s", bundleDir)
-	return tools.DeleteOverlay(bundleDir)
 }

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -29,7 +29,7 @@ type Namespaces struct {
 type Options struct {
 	// Writable marks the container image itself as writable.
 	Writable bool
-	// WriteableTmpfs applies an ephemeral writable overlay to the container.
+	// WritableTmpfs applies an ephemeral writable overlay to the container.
 	WritableTmpfs bool
 	// OverlayPaths holds paths to image or directory overlays to be applied.
 	OverlayPaths []string

--- a/pkg/ocibundle/tools/overlay_linux.go
+++ b/pkg/ocibundle/tools/overlay_linux.go
@@ -13,18 +13,41 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 )
 
-// CreateOverlay creates a writable overlay based on a directory.
-func CreateOverlay(bundlePath string) error {
-	var err error
+// OverlaySet represents a set of overlay directories which will be overlain on
+// top of some filesystem mount point. The actual mount point atop which these
+// directories will be overlain is not specified in the OverlaySet; it is left
+// implicit, to be chosen by whichever function consumes an OverlaySet. An
+// OverlaySet contains two types of directories: zero or more directories which
+// will be mounted as read-only overlays atop the (implicit) mount point, and
+// one directory which will be mounted as a writable overlay atop all the rest.
+// An empty WritableLoc field indicates that no writable overlay is to be
+// mounted.
+type OverlaySet struct {
+	// ReadonlyLocs is a list of directories to be mounted as read-only
+	// overlays. The mount point atop which these will be mounted is left
+	// implicit, to be chosen by whichever function consumes the OverlaySet.
+	ReadonlyLocs []string
 
+	// WritableLoc is the directory to be mounted as a writable overlay. The
+	// mount point atop which this will be mounted is left implicit, to be
+	// chosen by whichever function consumes the OverlaySet. Empty value
+	// indicates no writable overlay is to be mounted.
+	WritableLoc string
+}
+
+// CreateOverlay creates a writable overlay using a directory inside the OCI
+// bundle.
+func CreateOverlay(bundlePath string) error {
 	oldumask := syscall.Umask(0)
 	defer syscall.Umask(oldumask)
 
 	overlayDir := filepath.Join(bundlePath, "overlay")
-	if err = os.Mkdir(overlayDir, 0o700); err != nil {
+	var err error
+	if err = ensureOverlayDir(overlayDir, true, 0o700); err != nil {
 		return fmt.Errorf("failed to create %s: %s", overlayDir, err)
 	}
 	// delete overlay directory in case of error
@@ -34,35 +57,31 @@ func CreateOverlay(bundlePath string) error {
 		}
 	}()
 
-	err = syscall.Mount(overlayDir, overlayDir, "", syscall.MS_BIND, "")
-	if err != nil {
-		return fmt.Errorf("failed to bind %s: %s", overlayDir, err)
-	}
-	// best effort to cleanup mount
-	defer func() {
-		if err != nil {
-			syscall.Unmount(overlayDir, syscall.MNT_DETACH)
-		}
-	}()
-
-	if err = syscall.Mount("", overlayDir, "", syscall.MS_REMOUNT|syscall.MS_BIND, ""); err != nil {
-		return fmt.Errorf("failed to remount %s: %s", overlayDir, err)
-	}
-
-	err = prepareOverlay(bundlePath, overlayDir)
-	return err
+	return ApplyOverlay(
+		RootFs(bundlePath).Path(),
+		OverlaySet{WritableLoc: overlayDir},
+	)
 }
 
-// CreateOverlay creates a writable overlay based on a tmpfs.
-func CreateOverlayTmpfs(bundlePath string, sizeMiB int) error {
+// DeleteOverlay deletes an overlay previously created using a directory inside
+// the OCI bundle.
+func DeleteOverlay(bundlePath string) error {
+	overlayDir := filepath.Join(bundlePath, "overlay")
+	rootFsDir := RootFs(bundlePath).Path()
+	return unmountAndDeleteOverlay(rootFsDir, overlayDir)
+}
+
+// CreateOverlay creates a writable overlay using tmpfs.
+func CreateOverlayTmpfs(bundlePath string, sizeMiB int) (string, error) {
 	var err error
 
 	oldumask := syscall.Umask(0)
 	defer syscall.Umask(oldumask)
 
 	overlayDir := filepath.Join(bundlePath, "overlay")
-	if err = os.Mkdir(overlayDir, 0o700); err != nil {
-		return fmt.Errorf("failed to create %s: %s", overlayDir, err)
+	err = ensureOverlayDir(overlayDir, true, 0o700)
+	if err != nil {
+		return "", fmt.Errorf("failed to create %s: %s", overlayDir, err)
 	}
 	// delete overlay directory in case of error
 	defer func() {
@@ -74,7 +93,7 @@ func CreateOverlayTmpfs(bundlePath string, sizeMiB int) error {
 	options := fmt.Sprintf("mode=1777,size=%dm", sizeMiB)
 	err = syscall.Mount("tmpfs", overlayDir, "tmpfs", syscall.MS_NODEV, options)
 	if err != nil {
-		return fmt.Errorf("failed to bind %s: %s", overlayDir, err)
+		return "", fmt.Errorf("failed to bind %s: %s", overlayDir, err)
 	}
 	// best effort to cleanup mount
 	defer func() {
@@ -83,41 +102,182 @@ func CreateOverlayTmpfs(bundlePath string, sizeMiB int) error {
 		}
 	}()
 
-	err = prepareOverlay(bundlePath, overlayDir)
-	return err
+	err = ApplyOverlay(
+		RootFs(bundlePath).Path(),
+		OverlaySet{WritableLoc: overlayDir},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return overlayDir, nil
 }
 
-func prepareOverlay(bundlePath, overlayDir string) error {
-	upperDir := filepath.Join(overlayDir, "upper")
-	if err := os.Mkdir(upperDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create %s: %s", upperDir, err)
-	}
-	workDir := filepath.Join(overlayDir, "work")
-	if err := os.Mkdir(workDir, 0o700); err != nil {
-		return fmt.Errorf("failed to create %s: %s", workDir, err)
-	}
+// DeleteOverlayTmpfs deletes an overlay previously created using tmpfs.
+func DeleteOverlayTmpfs(bundlePath, overlayDir string) error {
 	rootFsDir := RootFs(bundlePath).Path()
-
-	options := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", rootFsDir, upperDir, workDir)
-	if err := syscall.Mount("overlay", rootFsDir, "overlay", 0, options); err != nil {
-		return fmt.Errorf("failed to mount %s: %s", overlayDir, err)
-	}
-	return nil
+	return unmountAndDeleteOverlay(rootFsDir, overlayDir)
 }
 
-// DeleteOverlay deletes overlay
-func DeleteOverlay(bundlePath string) error {
-	overlayDir := filepath.Join(bundlePath, "overlay")
-	rootFsDir := RootFs(bundlePath).Path()
+// ApplyOverlay prepares and mounts the specified overlay
+func ApplyOverlay(rootFsDir string, ovs OverlaySet) error {
+	// Prepare internal structure of writable overlay dir, if necessary
+	if len(ovs.WritableLoc) > 0 {
+		if err := ensureOverlayDir(ovs.WritableLoc, true, 0o755); err != nil {
+			return err
+		}
+		if err := prepareWritableOverlay(ovs.WritableLoc); err != nil {
+			return err
+		}
+	}
 
+	// Perform identity mounts for this OverlaySet
+	if err := performIdentityMounts(ovs); err != nil {
+		return err
+	}
+
+	// Perform actual overlay mount
+	return performOverlayMount(rootFsDir, overlayOptions(rootFsDir, ovs))
+}
+
+// UnmountOverlay umounts an overlay
+func UnmountOverlay(rootFsDir string) error {
 	if err := syscall.Unmount(rootFsDir, syscall.MNT_DETACH); err != nil {
 		return fmt.Errorf("failed to unmount %s: %s", rootFsDir, err)
 	}
+
+	return nil
+}
+
+// prepareWritableOverlay ensures that the upper and work subdirs of a writable
+// overlay dir exist, and if not, creates them.
+func prepareWritableOverlay(dir string) error {
+	if err := ensureOverlayDir(upperSubdirOf(dir), true, 0o755); err != nil {
+		return fmt.Errorf("err encountered while preparing upper subdir of overlay dir %q: %w", upperSubdirOf(dir), err)
+	}
+	if err := ensureOverlayDir(workSubdirOf(dir), true, 0o700); err != nil {
+		return fmt.Errorf("err encountered while preparing work subdir of overlay dir %q: %w", workSubdirOf(dir), err)
+	}
+
+	return nil
+}
+
+// performIdentityMounts creates the writable OverlaySet directory if it does
+// not exist, and performs a bind mount & remount of every OverlaySet dir onto
+// itself. The pattern of bind mount followed by remount allows application of
+// more restrictive mount flags than are in force on the underlying filesystem.
+func performIdentityMounts(ovs OverlaySet) error {
+	var err error
+
+	locsToBind := ovs.ReadonlyLocs
+	if len(ovs.WritableLoc) > 0 {
+		// Check if writable overlay dir already exists; if it doesn't, try to
+		// create it.
+		if err = ensureOverlayDir(ovs.WritableLoc, true, 0o755); err != nil {
+			return err
+		}
+
+		locsToBind = append(locsToBind, ovs.WritableLoc)
+	}
+
+	// Try to do initial bind-mounts
+	for _, d := range locsToBind {
+		if err = ensureOverlayDir(d, false, 0); err != nil {
+			return fmt.Errorf("error accessing directory %s: %s", d, err)
+		}
+
+		if err = syscall.Mount(d, d, "", syscall.MS_BIND, ""); err != nil {
+			return fmt.Errorf("failed to bind %s: %s", d, err)
+		}
+
+		// best effort to cleanup mount
+		defer func() {
+			if err != nil {
+				syscall.Unmount(d, syscall.MNT_DETACH)
+			}
+		}()
+
+		// Try to perform remount
+		if err = syscall.Mount("", d, "", syscall.MS_REMOUNT|syscall.MS_BIND, ""); err != nil {
+			return fmt.Errorf("failed to remount %s: %s", d, err)
+		}
+	}
+
+	return err
+}
+
+// overlayOptions creates the options string to be used in an overlay mount
+func overlayOptions(rootFsDir string, ovs OverlaySet) string {
+	// Create lowerdir argument of options string
+	lowerDirJoined := strings.Join(append(ovs.ReadonlyLocs, rootFsDir), ":")
+
+	if len(ovs.WritableLoc) > 0 {
+		return fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerDirJoined, upperSubdirOf(ovs.WritableLoc), workSubdirOf(ovs.WritableLoc))
+	}
+
+	return fmt.Sprintf("lowerdir=%s", lowerDirJoined)
+}
+
+// performOverlayMount mounts an overlay atop a given rootfs directory
+func performOverlayMount(rootFsDir, options string) error {
+	// Try to perform actual mount
+	if err := syscall.Mount("overlay", rootFsDir, "overlay", 0, options); err != nil {
+		return fmt.Errorf("failed to mount %s: %s", rootFsDir, err)
+	}
+
+	return nil
+}
+
+// ensureOverlayDir checks if a directory already exists; if it doesn't, and
+// createIfMissing is true, it attempts to create it with the specified
+// permissions.
+func ensureOverlayDir(dir string, createIfMissing bool, createPerm os.FileMode) error {
+	if len(dir) == 0 {
+		return fmt.Errorf("internal error: ensureOverlayDir() called with empty dir name")
+	}
+
+	_, err := os.Stat(dir)
+	if err == nil {
+		return nil
+	}
+
+	if !os.IsNotExist(err) {
+		return err
+	}
+
+	if !createIfMissing {
+		return fmt.Errorf("missing overlay dir %q", dir)
+	}
+
+	// Create the requested dir
+	if err := os.Mkdir(dir, createPerm); err != nil {
+		return fmt.Errorf("failed to create %q: %s", dir, err)
+	}
+
+	return nil
+}
+
+func upperSubdirOf(overlayDir string) string {
+	return filepath.Join(overlayDir, "upper")
+}
+
+func workSubdirOf(overlayDir string) string {
+	return filepath.Join(overlayDir, "work")
+}
+
+// unmountAndDeleteOverlay unmounts and deletes a previously-created overlay.
+func unmountAndDeleteOverlay(rootFsDir, overlayDir string) error {
+	if err := UnmountOverlay(rootFsDir); err != nil {
+		return err
+	}
+
 	if err := syscall.Unmount(overlayDir, syscall.MNT_DETACH); err != nil {
 		return fmt.Errorf("failed to unmount %s: %s", overlayDir, err)
 	}
+
 	if err := os.RemoveAll(overlayDir); err != nil {
 		return fmt.Errorf("failed to remove %s: %s", overlayDir, err)
 	}
+
 	return nil
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1659
 which fixed
- sylabs/singularity# 1478

The original PR description was:
> Support `--overlay <overlay_dir>` flag in OCI-mode (in "action" commands, i.e., run/exec/shell). This allows the user to mount a directory as a filesystem overlay, in lieu of using a writable tmpfs (which is the default behavior since version 3.11.3). This enables writes to the filesystem to persist across runs of the OCI container. If `<overlay_dir>` does not exist, Singularity will attempt to create it.