### PR TITLE
oci: wrap run in writable tmpfs overlay if there's only read-only overlay(s), from sylabs 1671

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -976,7 +976,7 @@ func (c actionTests) actionOciOverlay(t *testing.T) {
 	e2e.EnsureOCIArchive(t, c.env)
 	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
-	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIFakerootProfile} {
+	for _, profile := range e2e.OCIProfiles {
 		testDir, err := fs.MakeTmpDir(c.env.TestDir, "overlaytestdir", 0o755)
 		if err != nil {
 			t.Fatal(err)
@@ -1036,6 +1036,11 @@ func (c actionTests) actionOciOverlay(t *testing.T) {
 				name:     "NonExistReadonly",
 				args:     []string{"--overlay", filepath.Join(testDir, "my_ro_ol_dir_nonexistent:ro"), imageRef, "echo", "hi"},
 				exitCode: 255,
+			},
+			{
+				name:     "ReadonlyAddsTmpfs",
+				args:     []string{"--overlay", filepath.Join(testDir, "my_ro_ol_dir1:ro"), imageRef, "sh", "-c", "echo this_should_disappear > /my_test_file"},
+				exitCode: 0,
 			},
 			{
 				name:     "SeveralReadonly",

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -1008,6 +1008,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("issue 1286", c.issue1286)
 			t.Run("issue 1528", c.issue1528)
 			t.Run("issue 1586", c.issue1586)
+			t.Run("issue 1670", c.issue1670)
 		},
 		// Tests that are especially slow, or run against a local docker
 		// registry, can be run in parallel, with `--disable-cache` used within

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -318,3 +318,26 @@ func (c ctx) issue1586(t *testing.T) {
 		t.Errorf("TMPDIR is not empty after apptainer exited")
 	}
 }
+
+// https://github.com/sylabs/singularity/issues/1670
+// Check that runc/crun can add directories the rootfs before entering the
+// container, by running a container based on busybox that lacks, e.g., /proc
+func (c ctx) issue1670(t *testing.T) {
+	for _, profile := range e2e.OCIProfiles {
+		tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, fmt.Sprintf("issue1670-%s-", profile.String()), "")
+		t.Cleanup(func() {
+			if !t.Failed() {
+				cleanup(t)
+			}
+		})
+
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(profile.String()),
+			e2e.WithProfile(profile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs("--overlay", fmt.Sprintf("%s:ro", tmpDir), "docker://busybox", "echo", "hi"),
+			e2e.ExpectExit(0),
+		)
+	}
+}

--- a/internal/pkg/runtime/launcher/oci/oci_overlay.go
+++ b/internal/pkg/runtime/launcher/oci/oci_overlay.go
@@ -24,6 +24,7 @@ func WrapWithWritableTmpFs(f func() error, bundleDir string) error {
 	// TODO: --oci mode always emulating --compat, which uses --writable-tmpfs.
 	//       Provide a way of disabling this, for a read only rootfs.
 	overlayDir, err := prepareWritableTmpfs(bundleDir)
+	sylog.Debugf("Done with prepareWritableTmpfs; overlayDir is: %q", overlayDir)
 	if err != nil {
 		return err
 	}
@@ -70,7 +71,11 @@ func WrapWithOverlays(f func() error, bundleDir string, overlayPaths []string) e
 		return err
 	}
 
-	err = f()
+	if writableOverlayFound {
+		err = f()
+	} else {
+		err = WrapWithWritableTmpFs(f, bundleDir)
+	}
 
 	// Cleanup actions log errors, but don't return - so we get as much cleanup done as possible.
 	if cleanupErr := tools.UnmountOverlay(rootFsDir); cleanupErr != nil {

--- a/internal/pkg/runtime/launcher/oci/oci_overlay.go
+++ b/internal/pkg/runtime/launcher/oci/oci_overlay.go
@@ -78,7 +78,7 @@ func WrapWithOverlays(f func() error, bundleDir string, overlayPaths []string) e
 	}
 
 	// Cleanup actions log errors, but don't return - so we get as much cleanup done as possible.
-	if cleanupErr := tools.UnmountOverlay(rootFsDir); cleanupErr != nil {
+	if cleanupErr := tools.UnmountOverlay(rootFsDir, ovs); cleanupErr != nil {
 		sylog.Errorf("While unmounting rootfs overlay: %v", cleanupErr)
 	}
 

--- a/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
@@ -226,7 +226,7 @@ func Run(ctx context.Context, containerID, bundlePath, pidFile string, systemdCg
 // RunWrapped runs a container via the OCI runtime, wrapped with prep / cleanup steps.
 func RunWrapped(ctx context.Context, containerID, bundlePath, pidFile string, overlayPaths []string, systemdCgroups bool) error {
 	runFunc := func() error {
-		return Run(ctx, containerID, bundlePath, "", systemdCgroups)
+		return Run(ctx, containerID, bundlePath, pidFile, systemdCgroups)
 	}
 
 	if len(overlayPaths) > 0 {

--- a/pkg/ocibundle/tools/overlay_linux.go
+++ b/pkg/ocibundle/tools/overlay_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/apptainer/apptainer/pkg/sylog"
 )
 
 // OverlaySet represents a set of overlay directories which will be overlain on
@@ -53,6 +55,7 @@ func CreateOverlay(bundlePath string) error {
 	// delete overlay directory in case of error
 	defer func() {
 		if err != nil {
+			sylog.Debugf("Encountered error in CreateOverlay; attempting to remove overlayDir %q", overlayDir)
 			os.RemoveAll(overlayDir)
 		}
 	}()
@@ -68,7 +71,12 @@ func CreateOverlay(bundlePath string) error {
 func DeleteOverlay(bundlePath string) error {
 	overlayDir := filepath.Join(bundlePath, "overlay")
 	rootFsDir := RootFs(bundlePath).Path()
-	return unmountAndDeleteOverlay(rootFsDir, overlayDir)
+
+	if err := detachMount(rootFsDir); err != nil {
+		return err
+	}
+
+	return detachAndDelete(overlayDir)
 }
 
 // CreateOverlay creates a writable overlay using tmpfs.
@@ -86,6 +94,7 @@ func CreateOverlayTmpfs(bundlePath string, sizeMiB int) (string, error) {
 	// delete overlay directory in case of error
 	defer func() {
 		if err != nil {
+			sylog.Debugf("Encountered error in CreateOverlay; attempting to remove overlayDir %q", overlayDir)
 			os.RemoveAll(overlayDir)
 		}
 	}()
@@ -98,6 +107,7 @@ func CreateOverlayTmpfs(bundlePath string, sizeMiB int) (string, error) {
 	// best effort to cleanup mount
 	defer func() {
 		if err != nil {
+			sylog.Debugf("Encountered error in CreateOverlayTmpfs; attempting to detach overlayDir %q", overlayDir)
 			syscall.Unmount(overlayDir, syscall.MNT_DETACH)
 		}
 	}()
@@ -116,7 +126,18 @@ func CreateOverlayTmpfs(bundlePath string, sizeMiB int) (string, error) {
 // DeleteOverlayTmpfs deletes an overlay previously created using tmpfs.
 func DeleteOverlayTmpfs(bundlePath, overlayDir string) error {
 	rootFsDir := RootFs(bundlePath).Path()
-	return unmountAndDeleteOverlay(rootFsDir, overlayDir)
+
+	if err := detachMount(rootFsDir); err != nil {
+		return err
+	}
+
+	// Because CreateOverlayTmpfs() mounts the tmpfs on overlayDir, and then
+	// calls ApplyOverlay(), there needs to be an extra unmount in the this case
+	if err := detachMount(overlayDir); err != nil {
+		return err
+	}
+
+	return detachAndDelete(overlayDir)
 }
 
 // ApplyOverlay prepares and mounts the specified overlay
@@ -142,19 +163,17 @@ func ApplyOverlay(rootFsDir string, ovs OverlaySet) error {
 
 // UnmountOverlay umounts an overlay
 func UnmountOverlay(rootFsDir string) error {
-	if err := syscall.Unmount(rootFsDir, syscall.MNT_DETACH); err != nil {
-		return fmt.Errorf("failed to unmount %s: %s", rootFsDir, err)
-	}
-
-	return nil
+	return detachMount(rootFsDir)
 }
 
 // prepareWritableOverlay ensures that the upper and work subdirs of a writable
 // overlay dir exist, and if not, creates them.
 func prepareWritableOverlay(dir string) error {
+	sylog.Debugf("Ensuring %q exists", upperSubdirOf(dir))
 	if err := ensureOverlayDir(upperSubdirOf(dir), true, 0o755); err != nil {
 		return fmt.Errorf("err encountered while preparing upper subdir of overlay dir %q: %w", upperSubdirOf(dir), err)
 	}
+	sylog.Debugf("Ensuring %q exists", workSubdirOf(dir))
 	if err := ensureOverlayDir(workSubdirOf(dir), true, 0o700); err != nil {
 		return fmt.Errorf("err encountered while preparing work subdir of overlay dir %q: %w", workSubdirOf(dir), err)
 	}
@@ -186,6 +205,7 @@ func performIdentityMounts(ovs OverlaySet) error {
 			return fmt.Errorf("error accessing directory %s: %s", d, err)
 		}
 
+		sylog.Debugf("Performing identity bind-mount of %q", d)
 		if err = syscall.Mount(d, d, "", syscall.MS_BIND, ""); err != nil {
 			return fmt.Errorf("failed to bind %s: %s", d, err)
 		}
@@ -193,11 +213,13 @@ func performIdentityMounts(ovs OverlaySet) error {
 		// best effort to cleanup mount
 		defer func() {
 			if err != nil {
+				sylog.Debugf("Encountered error with current OverlaySet; attempting to unmount %q", d)
 				syscall.Unmount(d, syscall.MNT_DETACH)
 			}
 		}()
 
 		// Try to perform remount
+		sylog.Debugf("Performing remount of %q", d)
 		if err = syscall.Mount("", d, "", syscall.MS_REMOUNT|syscall.MS_BIND, ""); err != nil {
 			return fmt.Errorf("failed to remount %s: %s", d, err)
 		}
@@ -221,6 +243,7 @@ func overlayOptions(rootFsDir string, ovs OverlaySet) string {
 // performOverlayMount mounts an overlay atop a given rootfs directory
 func performOverlayMount(rootFsDir, options string) error {
 	// Try to perform actual mount
+	sylog.Debugf("Mounting overlay with rootFsDir %q, options: %q", rootFsDir, options)
 	if err := syscall.Mount("overlay", rootFsDir, "overlay", 0, options); err != nil {
 		return fmt.Errorf("failed to mount %s: %s", rootFsDir, err)
 	}
@@ -265,18 +288,23 @@ func workSubdirOf(overlayDir string) string {
 	return filepath.Join(overlayDir, "work")
 }
 
-// unmountAndDeleteOverlay unmounts and deletes a previously-created overlay.
-func unmountAndDeleteOverlay(rootFsDir, overlayDir string) error {
-	if err := UnmountOverlay(rootFsDir); err != nil {
-		return err
-	}
-
+func detachAndDelete(overlayDir string) error {
+	sylog.Debugf("Detaching overlayDir %q", overlayDir)
 	if err := syscall.Unmount(overlayDir, syscall.MNT_DETACH); err != nil {
 		return fmt.Errorf("failed to unmount %s: %s", overlayDir, err)
 	}
 
+	sylog.Debugf("Removing overlayDir %q", overlayDir)
 	if err := os.RemoveAll(overlayDir); err != nil {
 		return fmt.Errorf("failed to remove %s: %s", overlayDir, err)
+	}
+	return nil
+}
+
+func detachMount(dir string) error {
+	sylog.Debugf("Calling syscall.Unmount() to detach %q", dir)
+	if err := syscall.Unmount(dir, syscall.MNT_DETACH); err != nil {
+		return fmt.Errorf("failed to detach %s: %s", dir, err)
 	}
 
 	return nil

--- a/pkg/ocibundle/tools/overlay_linux.go
+++ b/pkg/ocibundle/tools/overlay_linux.go
@@ -162,8 +162,12 @@ func ApplyOverlay(rootFsDir string, ovs OverlaySet) error {
 }
 
 // UnmountOverlay umounts an overlay
-func UnmountOverlay(rootFsDir string) error {
-	return detachMount(rootFsDir)
+func UnmountOverlay(rootFsDir string, ovs OverlaySet) error {
+	if err := detachMount(rootFsDir); err != nil {
+		return err
+	}
+
+	return detachIdentityMounts(ovs)
 }
 
 // prepareWritableOverlay ensures that the upper and work subdirs of a writable
@@ -226,6 +230,32 @@ func performIdentityMounts(ovs OverlaySet) error {
 	}
 
 	return err
+}
+
+// detachIdentityMounts detaches mounts created by the bind-mount & remount
+// pattern (as implemented in performIdentityMounts())
+func detachIdentityMounts(ovs OverlaySet) error {
+	locsToDetach := ovs.ReadonlyLocs
+	if len(ovs.WritableLoc) > 0 {
+		locsToDetach = append(locsToDetach, ovs.WritableLoc)
+	}
+
+	// Don't stop on the first error; try to clean up as much as possible, and
+	// then return the first error encountered.
+	errors := []error{}
+	for _, d := range locsToDetach {
+		err := detachMount(d)
+		if err != nil {
+			sylog.Errorf("Error encountered trying to detach identity mount %s: %s", d, err)
+			errors = append(errors, err)
+		}
+	}
+
+	if len(errors) > 0 {
+		return errors[0]
+	}
+
+	return nil
 }
 
 // overlayOptions creates the options string to be used in an overlay mount


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1671
 which fixed
- sylabs/singularity# 1670

The original PR description was:
> In OCI mode, if there is one or more overlays specified but they are all read-only, wrap Run in an additional writable tmpfs overlay so that the filesystem in its entirety is writable inside the container (in alignment with the goals of sylabs/singularity# 1622 ).