### PR TITLE
oci: Improve testing of overlay cleanup, from sylabs 1678

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2924,14 +2924,15 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		//
 		// OCI Runtime Mode
 		//
-		"ociRun":     c.actionOciRun,        // apptainer run --oci
-		"ociExec":    c.actionOciExec,       // apptainer exec --oci
-		"ociShell":   c.actionOciShell,      // apptainer shell --oci
-		"ociNetwork": c.actionOciNetwork,    // apptainer exec --oci --net
-		"ociBinds":   c.actionOciBinds,      // apptainer exec --oci --bind / --mount
-		"ociCdi":     c.actionOciCdi,        // apptainer exec --oci --cdi
-		"ociIDMaps":  c.actionOciIDMaps,     // check uid/gid mapping on host for --oci as user / --fakeroot
-		"ociCompat":  np(c.actionOciCompat), // --oci equivalence to native mode --compat
-		"ociOverlay": (c.actionOciOverlay),  // --overlay in OCI mode
+		"ociRun":             c.actionOciRun,                 // apptainer run --oci
+		"ociExec":            c.actionOciExec,                // apptainer exec --oci
+		"ociShell":           c.actionOciShell,               // apptainer shell --oci
+		"ociNetwork":         c.actionOciNetwork,             // apptainer exec --oci --net
+		"ociBinds":           c.actionOciBinds,               // apptainer exec --oci --bind / --mount
+		"ociCdi":             c.actionOciCdi,                 // apptainer exec --oci --cdi
+		"ociIDMaps":          c.actionOciIDMaps,              // check uid/gid mapping on host for --oci as user / --fakeroot
+		"ociCompat":          np(c.actionOciCompat),          // --oci equivalence to native mode --compat
+		"ociOverlay":         (c.actionOciOverlay),           // --overlay in OCI mode
+		"ociOverlayTeardown": np(c.actionOciOverlayTeardown), // proper overlay unmounting in OCI mode
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -10,6 +10,7 @@
 package actions
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -23,6 +24,7 @@ import (
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	cdispecs "github.com/container-orchestrated-devices/container-device-interface/specs-go"
+	"gotest.tools/v3/assert"
 )
 
 func (c actionTests) actionOciRun(t *testing.T) {
@@ -1064,4 +1066,57 @@ func (c actionTests) actionOciOverlay(t *testing.T) {
 			}
 		})
 	}
+}
+
+// actionOciOverlayTeardown checks that OCI-mode overlays are correctly
+// unmounted even in root mode (i.e., when user namespaces are not involved).
+func (c actionTests) actionOciOverlayTeardown(t *testing.T) {
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	const mountInfoPath string = "/proc/self/mountinfo"
+	numMountLinesPre, err := countLines(mountInfoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "oci_overlay_teardown-", "")
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.OCIRootProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--overlay", tmpDir+":ro", imageRef, "/bin/true"),
+		e2e.ExpectExit(0),
+	)
+
+	numMountLinesPost, err := countLines(mountInfoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(
+		t, numMountLinesPost, numMountLinesPre,
+		"Number of mounts after running in OCI-mode with overlays (%d) does not match the number before the run (%d)", numMountLinesPost, numMountLinesPre)
+}
+
+func countLines(path string) (int, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return -1, err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	scanner.Split(bufio.ScanLines)
+	lines := 0
+	for scanner.Scan() {
+		lines++
+	}
+
+	return lines, nil
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1678

The original PR description was:
> In working on sylabs/singularity# 1659 and sylabs/singularity# 1671 , it emerged that in some scenarios (esp. when running as root), our cleanup of overlay mounts was incomplete. Importantly, that cleanup process intentionally logs errors and proceeds (rather than erroring out), in order to clean up as much as possible even under error conditions; but that means that we can't rely simply on exit codes to detect problems in the cleanup of overlay mounts.
> 
> This PR adds an e2e test specifically dedicated to detecting such problems, by running an OCI-mode container as root, and comparing the number of current mounts before & after the run.