### PR TITLE
oci: support --workdir, from sylabs 1689

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
   filesystem to persist across runs of the OCI container. If specified dir does
   not exist, Apptainer will attempt to create it. Multiple overlays can be
   specified, but all but one must be read-only (`--overlay <dir>:ro`).
+- OCI-mode now supports the `--workdir <workdir>` option. If this option is
+  specified, `/tmp` and `/var/tmp` will be mapped, respectively, to
+  `<workdir>/tmp` and `<workdir>/var_tmp` on the host, rather than to tmpfs
+  storage. If `--scratch <scratchdir>` is used in conjunction with `--workdir`,
+  scratch directories will be mapped to subdirectories nested under
+  `<workdir>/scratch` on the host, rather than to tmpfs storage.
 
 ## Changes since last pre-release
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -179,7 +179,7 @@ var actionWorkdirFlag = cmdline.Flag{
 	DefaultValue: "",
 	Name:         "workdir",
 	ShortHand:    "W",
-	Usage:        "working directory to be used for /tmp, /var/tmp and $HOME (if -c/--contain was also used)",
+	Usage:        "working directory to be used for /tmp and /var/tmp (if -c/--contain was also used)",
 	EnvKeys:      []string{"WORKDIR"},
 	Tag:          "<path>",
 }

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1132,7 +1132,7 @@ func (c actionTests) actionBinds(t *testing.T) {
 	hostWorkDir := filepath.Join(workspace, "workdir")
 
 	createWorkspaceDirs := func(t *testing.T) {
-		workspaceDirsGenerator(t, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile, hostCanaryFileWithComma, hostCanaryFileWithColon)
+		mkWorkspaceDirs(t, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile, hostCanaryFileWithComma, hostCanaryFileWithColon)
 	}
 
 	// convert test image to sandbox

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -1132,39 +1132,7 @@ func (c actionTests) actionBinds(t *testing.T) {
 	hostWorkDir := filepath.Join(workspace, "workdir")
 
 	createWorkspaceDirs := func(t *testing.T) {
-		e2e.Privileged(func(t *testing.T) {
-			if err := os.RemoveAll(hostCanaryDir); err != nil && !os.IsNotExist(err) {
-				t.Fatalf("failed to delete canary_dir: %s", err)
-			}
-			if err := os.RemoveAll(hostHomeDir); err != nil && !os.IsNotExist(err) {
-				t.Fatalf("failed to delete workspace home: %s", err)
-			}
-			if err := os.RemoveAll(hostWorkDir); err != nil && !os.IsNotExist(err) {
-				t.Fatalf("failed to delete workspace work: %s", err)
-			}
-		})(t)
-
-		if err := fs.Mkdir(hostCanaryDir, 0o777); err != nil {
-			t.Fatalf("failed to create canary_dir: %s", err)
-		}
-		if err := fs.Touch(hostCanaryFile); err != nil {
-			t.Fatalf("failed to create canary_file: %s", err)
-		}
-		if err := fs.Touch(hostCanaryFileWithComma); err != nil {
-			t.Fatalf("failed to create canary_file_comma: %s", err)
-		}
-		if err := fs.Touch(hostCanaryFileWithColon); err != nil {
-			t.Fatalf("failed to create canary_file_colon: %s", err)
-		}
-		if err := os.Chmod(hostCanaryFile, 0o777); err != nil {
-			t.Fatalf("failed to apply permissions on canary_file: %s", err)
-		}
-		if err := fs.Mkdir(hostHomeDir, 0o777); err != nil {
-			t.Fatalf("failed to create workspace home directory: %s", err)
-		}
-		if err := fs.Mkdir(hostWorkDir, 0o777); err != nil {
-			t.Fatalf("failed to create workspace work directory: %s", err)
-		}
+		workspaceDirsGenerator(t, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile, hostCanaryFileWithComma, hostCanaryFileWithColon)
 	}
 
 	// convert test image to sandbox

--- a/e2e/actions/common.go
+++ b/e2e/actions/common.go
@@ -17,7 +17,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 )
 
-func workspaceDirsGenerator(t *testing.T, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile, hostCanaryFileWithComma, hostCanaryFileWithColon string) {
+func mkWorkspaceDirs(t *testing.T, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile, hostCanaryFileWithComma, hostCanaryFileWithColon string) {
 	e2e.Privileged(func(t *testing.T) {
 		if err := os.RemoveAll(hostCanaryDir); err != nil && !os.IsNotExist(err) {
 			t.Fatalf("failed to delete canary_dir: %s", err)

--- a/e2e/actions/common.go
+++ b/e2e/actions/common.go
@@ -1,0 +1,54 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package actions
+
+import (
+	"os"
+	"testing"
+
+	"github.com/apptainer/apptainer/e2e/internal/e2e"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs"
+)
+
+func workspaceDirsGenerator(t *testing.T, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile, hostCanaryFileWithComma, hostCanaryFileWithColon string) {
+	e2e.Privileged(func(t *testing.T) {
+		if err := os.RemoveAll(hostCanaryDir); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("failed to delete canary_dir: %s", err)
+		}
+		if err := os.RemoveAll(hostHomeDir); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("failed to delete workspace home: %s", err)
+		}
+		if err := os.RemoveAll(hostWorkDir); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("failed to delete workspace home: %s", err)
+		}
+	})(t)
+
+	if err := fs.Mkdir(hostCanaryDir, 0o777); err != nil {
+		t.Fatalf("failed to create canary_dir: %s", err)
+	}
+	if err := fs.Touch(hostCanaryFile); err != nil {
+		t.Fatalf("failed to create canary_file: %s", err)
+	}
+	if err := fs.Touch(hostCanaryFileWithComma); err != nil {
+		t.Fatalf("failed to create canary_file_comma: %s", err)
+	}
+	if err := fs.Touch(hostCanaryFileWithColon); err != nil {
+		t.Fatalf("failed to create canary_file_colon: %s", err)
+	}
+	if err := os.Chmod(hostCanaryFile, 0o777); err != nil {
+		t.Fatalf("failed to apply permissions on canary_file: %s", err)
+	}
+	if err := fs.Mkdir(hostHomeDir, 0o777); err != nil {
+		t.Fatalf("failed to create workspace home directory: %s", err)
+	}
+	if err := fs.Mkdir(hostWorkDir, 0o777); err != nil {
+		t.Fatalf("failed to create workspace home directory: %s", err)
+	}
+}

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -122,6 +122,7 @@ func (c actionTests) actionOciExec(t *testing.T) {
 	tmpfile.Close()
 
 	basename := filepath.Base(tmpfile.Name())
+	tmpfilePath := filepath.Join("/tmp", basename)
 	homePath := filepath.Join("/home", basename)
 
 	tests := []struct {
@@ -207,6 +208,11 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			wantOutputs: []e2e.ApptainerCmdResultOp{
 				e2e.ExpectOutput(e2e.ExactMatch, "whats-in-an-oci-name"),
 			},
+		},
+		{
+			name: "Workdir",
+			argv: []string{"--workdir", testdata, imageRef, "test", "-f", tmpfilePath},
+			exit: 0,
 		},
 		{
 			name: "Pwd",
@@ -394,6 +400,8 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 
 	contCanaryFile := "/canary/file"
 	hostCanaryFile := filepath.Join(hostCanaryDir, "file")
+	hostCanaryFileWithComma := filepath.Join(hostCanaryDir, "file,comma")
+	hostCanaryFileWithColon := filepath.Join(hostCanaryDir, "file:colon")
 
 	canaryFileBind := hostCanaryFile + ":" + contCanaryFile
 	canaryFileMount := "type=bind,source=" + hostCanaryFile + ",destination=" + contCanaryFile
@@ -401,29 +409,10 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 	canaryDirMount := "type=bind,source=" + hostCanaryDir + ",destination=" + contCanaryDir
 
 	hostHomeDir := filepath.Join(workspace, "home")
+	hostWorkDir := filepath.Join(workspace, "workdir")
 
 	createWorkspaceDirs := func(t *testing.T) {
-		e2e.Privileged(func(t *testing.T) {
-			if err := os.RemoveAll(hostCanaryDir); err != nil && !os.IsNotExist(err) {
-				t.Fatalf("failed to delete canary_dir: %s", err)
-			}
-			if err := os.RemoveAll(hostHomeDir); err != nil && !os.IsNotExist(err) {
-				t.Fatalf("failed to delete workspace home: %s", err)
-			}
-		})(t)
-
-		if err := fs.Mkdir(hostCanaryDir, 0o777); err != nil {
-			t.Fatalf("failed to create canary_dir: %s", err)
-		}
-		if err := fs.Touch(hostCanaryFile); err != nil {
-			t.Fatalf("failed to create canary_file: %s", err)
-		}
-		if err := os.Chmod(hostCanaryFile, 0o777); err != nil {
-			t.Fatalf("failed to apply permissions on canary_file: %s", err)
-		}
-		if err := fs.Mkdir(hostHomeDir, 0o777); err != nil {
-			t.Fatalf("failed to create workspace home directory: %s", err)
-		}
+		workspaceDirsGenerator(t, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile, hostCanaryFileWithComma, hostCanaryFileWithColon)
 	}
 
 	checkHostFn := func(path string, fn func(string) bool) func(*testing.T) {
@@ -434,9 +423,23 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 			if !fn(path) {
 				t.Errorf("%s not found on host", path)
 			}
-			if err := os.RemoveAll(path); err != nil {
-				t.Errorf("failed to delete %s: %s", path, err)
-			}
+			// This part needs to be in privileged mode because of the following
+			// case. Suppose X1 on the host is mounted as Y1 in-container; and
+			// you bind mount X2 on host to Y1/Z/Y2 in-container. This creates a
+			// situation where Y1/Z needs to be mkdir'd. Apparently, runc/crun
+			// mkdirs it with the uid and gid of the in-container user, leading
+			// to a dir whose owner & group on host are not those of the host
+			// user, but rather a uid and gid that's shifted according to the
+			// /etc/subuid and /etc/subgid specifications. That means that the
+			// host user can't then os.RemoveAll() the contents without root
+			// privileges.
+			// This scenario is precisely what arises with a test like
+			// WorkdirTmpBind, below.
+			e2e.Privileged(func(t *testing.T) {
+				if err := os.RemoveAll(path); err != nil {
+					t.Errorf("failed to delete %s: %s", path, err)
+				}
+			})(t)
 		}
 	}
 	checkHostFile := func(path string) func(*testing.T) {
@@ -551,6 +554,39 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 			exit:    0,
 		},
 		{
+			name: "WorkdirTmpBind",
+			args: []string{
+				"--workdir", hostWorkDir,
+				"--bind", hostCanaryDir + ":/tmp/canary/dir",
+				imageRef,
+				"test", "-f", "/tmp/canary/dir/file",
+			},
+			postRun: checkHostDir(filepath.Join(hostWorkDir, "tmp", "canary/dir")),
+			exit:    0,
+		},
+		{
+			name: "WorkdirVarTmpBind",
+			args: []string{
+				"--workdir", hostWorkDir,
+				"--bind", hostCanaryDir + ":/var/tmp/canary/dir",
+				imageRef,
+				"test", "-f", "/var/tmp/canary/dir/file",
+			},
+			postRun: checkHostDir(filepath.Join(hostWorkDir, "var_tmp", "canary/dir")),
+			exit:    0,
+		},
+		{
+			name: "WorkdirVarTmpBindWritable",
+			args: []string{
+				"--workdir", hostWorkDir,
+				"--bind", hostCanaryDir + ":/var/tmp/canary/dir",
+				imageRef,
+				"test", "-f", "/var/tmp/canary/dir/file",
+			},
+			postRun: checkHostDir(filepath.Join(hostWorkDir, "var_tmp", "canary/dir")),
+			exit:    0,
+		},
+		{
 			name: "IsScratchTmpfs",
 			args: []string{
 				"--scratch", "/name-of-a-scratch",
@@ -581,6 +617,18 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 				"test", "-f", "/scratch/dir/file",
 			},
 			exit: 0,
+		},
+		{
+			name: "ScratchWorkdirBind",
+			args: []string{
+				"--workdir", hostWorkDir,
+				"--scratch", "/scratch",
+				"--bind", hostCanaryDir + ":/scratch/dir",
+				imageRef,
+				"test", "-f", "/scratch/dir/file",
+			},
+			postRun: checkHostDir(filepath.Join(hostWorkDir, "scratch/scratch", "dir")),
+			exit:    0,
 		},
 		{
 			name: "CustomHomeOneToOne",

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -412,7 +412,7 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 	hostWorkDir := filepath.Join(workspace, "workdir")
 
 	createWorkspaceDirs := func(t *testing.T) {
-		workspaceDirsGenerator(t, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile, hostCanaryFileWithComma, hostCanaryFileWithColon)
+		mkWorkspaceDirs(t, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile, hostCanaryFileWithComma, hostCanaryFileWithColon)
 	}
 
 	checkHostFn := func(path string, fn func(string) bool) func(*testing.T) {
@@ -423,18 +423,12 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 			if !fn(path) {
 				t.Errorf("%s not found on host", path)
 			}
-			// This part needs to be in privileged mode because of the following
-			// case. Suppose X1 on the host is mounted as Y1 in-container; and
-			// you bind mount X2 on host to Y1/Z/Y2 in-container. This creates a
-			// situation where Y1/Z needs to be mkdir'd. Apparently, runc/crun
-			// mkdirs it with the uid and gid of the in-container user, leading
-			// to a dir whose owner & group on host are not those of the host
-			// user, but rather a uid and gid that's shifted according to the
-			// /etc/subuid and /etc/subgid specifications. That means that the
-			// host user can't then os.RemoveAll() the contents without root
-			// privileges.
-			// This scenario is precisely what arises with a test like
-			// WorkdirTmpBind, below.
+			// When a nested bind is performed under workdir, the bind
+			// destination will be created (if necessary) by runc/crun inside
+			// workdir on the host. The bind destination will be created with
+			// subuid:subgid ownership. This requires privilege, or a userns +
+			// id mapping, to remove. (Relevant to tests like WorkdirTmpBind,
+			// below.)
 			e2e.Privileged(func(t *testing.T) {
 				if err := os.RemoveAll(path); err != nil {
 					t.Errorf("failed to delete %s: %s", path, err)

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -85,10 +85,6 @@ func checkOpts(lo launcher.Options) error {
 	if lo.WritableTmpfs {
 		sylog.Infof("--oci mode uses --writable-tmpfs by default")
 	}
-	if lo.WorkDir != "" {
-		badOpt = append(badOpt, "WorkDir")
-	}
-
 	if lo.NoHome {
 		badOpt = append(badOpt, "NoHome")
 	}

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -334,7 +334,11 @@ func (l *Launcher) addScratchMounts(mounts *[]specs.Mount) error {
 	const scratchContainerDirName = "/scratch"
 
 	if len(l.cfg.WorkDir) > 0 {
-		scratchContainerDirPath := filepath.Join(l.cfg.WorkDir, scratchContainerDirName)
+		workdir, err := filepath.Abs(filepath.Clean(l.cfg.WorkDir))
+		if err != nil {
+			sylog.Warningf("Can't determine absolute path of workdir %s", l.cfg.WorkDir)
+		}
+		scratchContainerDirPath := filepath.Join(workdir, scratchContainerDirName)
 		if err := fs.Mkdir(scratchContainerDirPath, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
 			return fmt.Errorf("failed to create %s: %s", scratchContainerDirPath, err)
 		}

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/internal/pkg/util/gpu"
 	"github.com/apptainer/apptainer/internal/pkg/util/user"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -36,7 +37,9 @@ func (l *Launcher) getMounts() ([]specs.Mount, error) {
 	if err := l.addDevMounts(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring devpts mount: %w", err)
 	}
-	l.addTmpMounts(mounts)
+	if err := l.addTmpMounts(mounts); err != nil {
+		return nil, fmt.Errorf("while configuring tmp mounts: %w", err)
+	}
 	if err := l.addHomeMount(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring home mount: %w", err)
 	}
@@ -61,16 +64,73 @@ func (l *Launcher) getMounts() ([]specs.Mount, error) {
 }
 
 // addTmpMounts adds tmpfs mounts for /tmp and /var/tmp in the container.
-func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) {
+func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) error {
+	const (
+		tmpDest    = "/tmp"
+		vartmpDest = "/var/tmp"
+	)
+
 	if !l.apptainerConf.MountTmp {
 		sylog.Debugf("Skipping mount of /tmp due to apptainer.conf")
-		return
+		return nil
 	}
 
+	if len(l.cfg.WorkDir) > 0 {
+		sylog.Debugf("WorkDir specification provided: %s", l.cfg.WorkDir)
+		const (
+			tmpSrcSubdir    = "tmp"
+			vartmpSrcSubdir = "var_tmp"
+		)
+
+		workdir, err := filepath.Abs(filepath.Clean(l.cfg.WorkDir))
+		if err != nil {
+			sylog.Warningf("Can't determine absolute path of workdir %s", l.cfg.WorkDir)
+		}
+
+		tmpSrc := filepath.Join(workdir, tmpSrcSubdir)
+		vartmpSrc := filepath.Join(workdir, vartmpSrcSubdir)
+
+		if err := fs.Mkdir(tmpSrc, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to create %s: %s", tmpSrc, err)
+		}
+		if err := fs.Mkdir(vartmpSrc, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to create %s: %s", vartmpSrc, err)
+		}
+
+		*mounts = append(*mounts,
+
+			specs.Mount{
+				Destination: tmpDest,
+				Type:        "none",
+				Source:      tmpSrc,
+				Options: []string{
+					"rbind",
+					"nosuid",
+					"relatime",
+					"mode=777",
+				},
+			},
+			specs.Mount{
+				Destination: vartmpDest,
+				Type:        "none",
+				Source:      vartmpSrc,
+				Options: []string{
+					"rbind",
+					"nosuid",
+					"relatime",
+					"mode=777",
+				},
+			},
+		)
+
+		return nil
+	}
+
+	sylog.Debugf(("No workdir specification provided. Proceeding with tmpfs mounts for /tmp and /var/tmp"))
 	*mounts = append(*mounts,
 
 		specs.Mount{
-			Destination: "/tmp",
+			Destination: tmpDest,
 			Type:        "tmpfs",
 			Source:      "tmpfs",
 			Options: []string{
@@ -81,7 +141,7 @@ func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) {
 			},
 		},
 		specs.Mount{
-			Destination: "/var/tmp",
+			Destination: vartmpDest,
 			Type:        "tmpfs",
 			Source:      "tmpfs",
 			Options: []string{
@@ -90,7 +150,10 @@ func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) {
 				"mode=777",
 				fmt.Sprintf("size=%dm", l.apptainerConf.SessiondirMaxSize),
 			},
-		})
+		},
+	)
+
+	return nil
 }
 
 // addDevMounts adds mounts to assemble a minimal /dev in the container.
@@ -268,20 +331,50 @@ func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
 
 // addScratchMounts adds tmpfs mounts for scratch directories in the container.
 func (l *Launcher) addScratchMounts(mounts *[]specs.Mount) error {
-	for _, s := range l.cfg.ScratchDirs {
-		*mounts = append(*mounts,
-			specs.Mount{
-				Destination: s,
-				Type:        "tmpfs",
-				Source:      "tmpfs",
-				Options: []string{
-					"nosuid",
-					"relatime",
-					"nodev",
-					fmt.Sprintf("size=%dm", l.apptainerConf.SessiondirMaxSize),
+	const scratchContainerDirName = "/scratch"
+
+	if len(l.cfg.WorkDir) > 0 {
+		scratchContainerDirPath := filepath.Join(l.cfg.WorkDir, scratchContainerDirName)
+		if err := fs.Mkdir(scratchContainerDirPath, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to create %s: %s", scratchContainerDirPath, err)
+		}
+
+		for _, s := range l.cfg.ScratchDirs {
+			scratchDirPath := filepath.Join(scratchContainerDirPath, s)
+			if err := fs.Mkdir(scratchDirPath, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+				return fmt.Errorf("failed to create %s: %s", scratchDirPath, err)
+			}
+
+			*mounts = append(*mounts,
+				specs.Mount{
+					Destination: s,
+					Type:        "",
+					Source:      scratchDirPath,
+					Options: []string{
+						"rbind",
+						"nosuid",
+						"relatime",
+						"nodev",
+					},
 				},
-			},
-		)
+			)
+		}
+	} else {
+		for _, s := range l.cfg.ScratchDirs {
+			*mounts = append(*mounts,
+				specs.Mount{
+					Destination: s,
+					Type:        "tmpfs",
+					Source:      "tmpfs",
+					Options: []string{
+						"nosuid",
+						"relatime",
+						"nodev",
+						fmt.Sprintf("size=%dm", l.apptainerConf.SessiondirMaxSize),
+					},
+				},
+			)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1689
 which fixed
- sylabs/singularity# 1483

The original PR description was:
> Provides support for `--workdir` in OCI-mode.
> 
> Specifying `--workdir <dir>` means that `/tmp` and `/var/tmp` will be mapped, respectively, to `<workdir>/tmp` and `<workdir>/var_tmp` on the host, rather than to tmpfs storage. If `--scratch <scratchdir>` is used in conjunction with `--workdir`, scratch directories will be mapped to subdirectories nested under `<workdir>/scratch` on the host, rather than to tmpfs storage. (This is line with the behavior of `--scratch` in conjunction with `--workdir` in native mode.)
> 
> Also changed the usage string for the `--workdir` option to make it clear that $HOME is unaffected by this option. (The latter can be manipulated separately, using the `--home` option.) This is so both in native mode and OCI mode.
> ### This fixes or addresses the following GitHub issues: