### PR TITLE
fix: correct Stdin wire-up in runc/crun execs, from sylabs 1714

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2895,6 +2895,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociRun":             c.actionOciRun,                 // apptainer run --oci
 		"ociExec":            c.actionOciExec,                // apptainer exec --oci
 		"ociShell":           c.actionOciShell,               // apptainer shell --oci
+		"ociSTDPIPE":         c.ociSTDPipe,                   // stdin/stdout pipe --oci
 		"ociNetwork":         c.actionOciNetwork,             // apptainer exec --oci --net
 		"ociBinds":           c.actionOciBinds,               // apptainer exec --oci --bind / --mount
 		"ociCdi":             c.actionOciCdi,                 // apptainer exec --oci --cdi

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -11,6 +11,7 @@ package actions
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -1166,4 +1167,95 @@ func countLines(path string) (int, error) {
 	}
 
 	return lines, nil
+}
+
+// ociSTDPipe tests pipe stdin/stdout to apptainer actions cmd
+func (c actionTests) ociSTDPipe(t *testing.T) {
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	stdinTests := []struct {
+		name    string
+		command string
+		argv    []string
+		input   string
+		exit    int
+	}{
+		{
+			name:    "TrueSTDIN",
+			command: "exec",
+			argv:    []string{imageRef, "grep", "hi"},
+			input:   "hi",
+			exit:    0,
+		},
+		{
+			name:    "FalseSTDIN",
+			command: "exec",
+			argv:    []string{imageRef, "grep", "hi"},
+			input:   "bye",
+			exit:    1,
+		},
+	}
+
+	var input bytes.Buffer
+
+	for _, tt := range stdinTests {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.OCIUserProfile),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.argv...),
+			e2e.WithStdin(&input),
+			e2e.PreRun(func(t *testing.T) {
+				input.WriteString(tt.input)
+			}),
+			e2e.ExpectExit(tt.exit),
+		)
+		input.Reset()
+	}
+
+	user := e2e.CurrentUser(t)
+	stdoutTests := []struct {
+		name    string
+		command string
+		argv    []string
+		output  string
+		exit    int
+	}{
+		{
+			name:    "CwdPath",
+			command: "exec",
+			argv:    []string{"--cwd", "/etc", imageRef, "pwd"},
+			output:  "/etc",
+			exit:    0,
+		},
+		{
+			name:    "PwdPath",
+			command: "exec",
+			argv:    []string{"--pwd", "/etc", imageRef, "pwd"},
+			output:  "/etc",
+			exit:    0,
+		},
+		{
+			name:    "id",
+			command: "exec",
+			argv:    []string{imageRef, "id", "-un"},
+			output:  user.Name,
+			exit:    0,
+		},
+	}
+	for _, tt := range stdoutTests {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.OCIUserProfile),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.argv...),
+			e2e.ExpectExit(
+				tt.exit,
+				e2e.ExpectOutput(e2e.ExactMatch, tt.output),
+			),
+		)
+	}
 }

--- a/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
@@ -98,7 +98,7 @@ func Exec(containerID string, cmdArgs []string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
+	cmd.Stdin = os.Stdin
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
@@ -124,7 +124,6 @@ func Kill(containerID string, killSignal string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
@@ -151,12 +150,11 @@ func Pause(containerID string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
-// Resume pauses processes in a container
+// Resume un-pauses processes in a container
 func Resume(containerID string, systemdCgroups bool) error {
 	runtimeBin, err := runtime()
 	if err != nil {
@@ -178,7 +176,6 @@ func Resume(containerID string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
@@ -218,7 +215,7 @@ func Run(ctx context.Context, containerID, bundlePath, pidFile string, systemdCg
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
+	cmd.Stdin = os.Stdin
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
@@ -306,7 +303,6 @@ func Start(containerID string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
@@ -333,7 +329,6 @@ func State(containerID string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
@@ -360,7 +355,6 @@ func Update(containerID, cgFile string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1714
 which fixed
- sylabs/singularity# 1712

The original PR description was:
> When runc/crun is called from oci_runc_linux.go, Stdin was incorrectly connected for the various runc/crun operations.
> 
> * Non-interactive operations such as resume / kill don't need Stdin.
> * Interactive operations (run/exec) had cmd.Stdin incorrectly set to os.Stdout. This prevented OCI containers from receiving input from pipes, redirection, etc.
> 
> 
> This PR fixes these issues and ports action STDPIPE tests to --oci mode. These were previously missed, resulting in sylabs/singularity# 1712 not being caught by the e2e suite.