### PR TITLE
fix rel. path --workdir with --scratch, add oci e2e tests, from sylabs 1694

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2893,45 +2893,46 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	np := testhelper.NoParallel
 
 	return testhelper.Tests{
-		"action URI":                c.RunFromURI,              // action_URI
-		"singularity link":          c.singularityLink,         // singularity symlink
-		"exec":                      c.actionExec,              // apptainer exec
-		"persistent overlay":        c.PersistentOverlay,       // Persistent Overlay
-		"persistent overlay unpriv": c.PersistentOverlayUnpriv, // Persistent Overlay Unprivileged
-		"run":                       c.actionRun,               // apptainer run
-		"shell":                     c.actionShell,             // shell interaction
-		"STDPIPE":                   c.STDPipe,                 // stdin/stdout pipe
-		"action basic profiles":     c.actionBasicProfiles,     // run basic action under different profiles
-		"issue 4488":                c.issue4488,               // https://github.com/apptainer/singularity/issues/4488
-		"issue 4587":                c.issue4587,               // https://github.com/apptainer/singularity/issues/4587
-		"issue 4755":                c.issue4755,               // https://github.com/apptainer/singularity/issues/4755
-		"issue 4768":                c.issue4768,               // https://github.com/apptainer/singularity/issues/4768
-		"issue 4797":                c.issue4797,               // https://github.com/apptainer/singularity/issues/4797
-		"issue 4823":                c.issue4823,               // https://github.com/apptainer/singularity/issues/4823
-		"issue 4836":                c.issue4836,               // https://github.com/apptainer/singularity/issues/4836
-		"issue 5211":                c.issue5211,               // https://github.com/apptainer/singularity/issues/5211
-		"issue 5228":                c.issue5228,               // https://github.com/apptainer/singularity/issues/5228
-		"issue 5271":                c.issue5271,               // https://github.com/apptainer/singularity/issues/5271
-		"issue 5399":                c.issue5399,               // https://github.com/apptainer/singularity/issues/5399
-		"issue 5455":                c.issue5455,               // https://github.com/apptainer/singularity/issues/5455
-		"issue 5465":                c.issue5465,               // https://github.com/apptainer/singularity/issues/5465
-		"issue 5599":                c.issue5599,               // https://github.com/apptainer/singularity/issues/5599
-		"issue 5631":                c.issue5631,               // https://github.com/apptainer/singularity/issues/5631
-		"issue 5690":                c.issue5690,               // https://github.com/apptainer/singularity/issues/5690
-		"issue 6165":                c.issue6165,               // https://github.com/apptainer/singularity/issues/6165
-		"issue 619":                 c.issue619,                // https://github.com/apptainer/apptainer/issues/619
-		"network":                   c.actionNetwork,           // test basic networking
-		"binds":                     c.actionBinds,             // test various binds with --bind and --mount
-		"exit and signals":          c.exitSignals,             // test exit and signals propagation
-		"fuse mount":                c.fuseMount,               // test fusemount option
-		"bind image":                c.bindImage,               // test bind image with --bind and --mount
-		"unsquash":                  c.actionUnsquash,          // test --unsquash
-		"no-mount":                  c.actionNoMount,           // test --no-mount
-		"compat":                    np(c.actionCompat),        // test --compat
-		"umask":                     np(c.actionUmask),         // test umask propagation
-		"invalidRemote":             np(c.invalidRemote),       // GHSA-5mv9-q7fq-9394
-		"fakeroot home":             c.actionFakerootHome,      // test home dir in fakeroot
-		"relWorkdirScratch":         np(c.relWorkdirScratch),   // test relative --workdir with --scratch
+		"action URI":                c.RunFromURI,               // action_URI
+		"singularity link":          c.singularityLink,          // singularity symlink
+		"exec":                      c.actionExec,               // apptainer exec
+		"persistent overlay":        c.PersistentOverlay,        // Persistent Overlay
+		"persistent overlay unpriv": c.PersistentOverlayUnpriv,  // Persistent Overlay Unprivileged
+		"run":                       c.actionRun,                // apptainer run
+		"shell":                     c.actionShell,              // shell interaction
+		"STDPIPE":                   c.STDPipe,                  // stdin/stdout pipe
+		"action basic profiles":     c.actionBasicProfiles,      // run basic action under different profiles
+		"issue 4488":                c.issue4488,                // https://github.com/apptainer/singularity/issues/4488
+		"issue 4587":                c.issue4587,                // https://github.com/apptainer/singularity/issues/4587
+		"issue 4755":                c.issue4755,                // https://github.com/apptainer/singularity/issues/4755
+		"issue 4768":                c.issue4768,                // https://github.com/apptainer/singularity/issues/4768
+		"issue 4797":                c.issue4797,                // https://github.com/apptainer/singularity/issues/4797
+		"issue 4823":                c.issue4823,                // https://github.com/apptainer/singularity/issues/4823
+		"issue 4836":                c.issue4836,                // https://github.com/apptainer/singularity/issues/4836
+		"issue 5211":                c.issue5211,                // https://github.com/apptainer/singularity/issues/5211
+		"issue 5228":                c.issue5228,                // https://github.com/apptainer/singularity/issues/5228
+		"issue 5271":                c.issue5271,                // https://github.com/apptainer/singularity/issues/5271
+		"issue 5399":                c.issue5399,                // https://github.com/apptainer/singularity/issues/5399
+		"issue 5455":                c.issue5455,                // https://github.com/apptainer/singularity/issues/5455
+		"issue 5465":                c.issue5465,                // https://github.com/apptainer/singularity/issues/5465
+		"issue 5599":                c.issue5599,                // https://github.com/apptainer/singularity/issues/5599
+		"issue 5631":                c.issue5631,                // https://github.com/apptainer/singularity/issues/5631
+		"issue 5690":                c.issue5690,                // https://github.com/apptainer/singularity/issues/5690
+		"issue 6165":                c.issue6165,                // https://github.com/apptainer/singularity/issues/6165
+		"issue 619":                 c.issue619,                 // https://github.com/apptainer/apptainer/issues/619
+		"network":                   c.actionNetwork,            // test basic networking
+		"binds":                     c.actionBinds,              // test various binds with --bind and --mount
+		"exit and signals":          c.exitSignals,              // test exit and signals propagation
+		"fuse mount":                c.fuseMount,                // test fusemount option
+		"bind image":                c.bindImage,                // test bind image with --bind and --mount
+		"unsquash":                  c.actionUnsquash,           // test --unsquash
+		"no-mount":                  c.actionNoMount,            // test --no-mount
+		"compat":                    np(c.actionCompat),         // test --compat
+		"umask":                     np(c.actionUmask),          // test umask propagation
+		"invalidRemote":             np(c.invalidRemote),        // GHSA-5mv9-q7fq-9394
+		"fakeroot home":             c.actionFakerootHome,       // test home dir in fakeroot
+		"relWorkdirScratch":         np(c.relWorkdirScratch),    // test relative --workdir with --scratch
+		"ociRelWorkdirScratch":      np(c.ociRelWorkdirScratch), // test relative --workdir with --scratch in OCI mode
 		//
 		// OCI Runtime Mode
 		//

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1324,6 +1324,49 @@ func haveAllCommands(t *testing.T, cmds []string) bool {
 	return true
 }
 
+// Make sure --workdir and --scratch work together nicely even when workdir is a
+// relative path. Test needs to be run in non-parallel mode, because it changes
+// the current working directory of the host.
+func (c actionTests) ociRelWorkdirScratch(t *testing.T) {
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	testdir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "persistent-overlay-", "")
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
+
+	const subdirName string = "mysubdir"
+	if err := os.Mkdir(filepath.Join(testdir, subdirName), 0o777); err != nil {
+		t.Fatalf("could not create subdirectory %q in %q: %s", subdirName, testdir, err)
+	}
+
+	// Change current working directory, with deferred undoing of change.
+	prevCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("could not get current working directory: %s", err)
+	}
+	defer os.Chdir(prevCwd)
+	if err = os.Chdir(testdir); err != nil {
+		t.Fatalf("could not change cwd to %q: %s", testdir, err)
+	}
+
+	profiles := e2e.OCIProfiles
+
+	for _, p := range profiles {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(p.String()),
+			e2e.WithProfile(p),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs("--workdir", "./"+subdirName, "--scratch", "/myscratch", imageRef, "true"),
+			e2e.ExpectExit(0),
+		)
+	}
+}
+
 // ociSTDPipe tests pipe stdin/stdout to apptainer actions cmd
 func (c actionTests) ociSTDPipe(t *testing.T) {
 	e2e.EnsureOCIArchive(t, c.env)

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1334,7 +1334,7 @@ func (c actionTests) ociRelWorkdirScratch(t *testing.T) {
 	testdir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "persistent-overlay-", "")
 	t.Cleanup(func() {
 		if !t.Failed() {
-			cleanup(t)
+			e2e.Privileged(cleanup)
 		}
 	})
 

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -84,7 +84,7 @@ func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) error {
 
 		workdir, err := filepath.Abs(filepath.Clean(l.cfg.WorkDir))
 		if err != nil {
-			sylog.Warningf("Can't determine absolute path of workdir %s", l.cfg.WorkDir)
+			return fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 		}
 
 		tmpSrc := filepath.Join(workdir, tmpSrcSubdir)
@@ -336,7 +336,7 @@ func (l *Launcher) addScratchMounts(mounts *[]specs.Mount) error {
 	if len(l.cfg.WorkDir) > 0 {
 		workdir, err := filepath.Abs(filepath.Clean(l.cfg.WorkDir))
 		if err != nil {
-			sylog.Warningf("Can't determine absolute path of workdir %s", l.cfg.WorkDir)
+			return fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 		}
 		scratchContainerDirPath := filepath.Join(workdir, scratchContainerDirName)
 		if err := fs.Mkdir(scratchContainerDirPath, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1694
 which fixed
- sylabs/singularity# 1693

The original PR description was:
> Fixes a bug where `--scratch` failed when used in conjunction with `--workdir` if the latter was given a relative (rather than absolute) path.
> 
> Also changes the behavior of `--workdir` code so that an error (rather than a warning) is generated if specified workdir cannot be converted to an absolute path.
> 
> Lastly, adds e2e tests for this behavior (`--scratch` in conjunction with relative `--workdir`), in both native and OCI modes.