### PR TITLE
Enter namespaces earlier in --oci mode, from sylabs 1774

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher/native"
 	ocilauncher "github.com/apptainer/apptainer/internal/pkg/runtime/launcher/oci"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
+	"github.com/apptainer/apptainer/internal/pkg/util/rootless"
 	"github.com/apptainer/apptainer/internal/pkg/util/uri"
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -344,6 +345,20 @@ var TestCmd = &cobra.Command{
 }
 
 func launchContainer(cmd *cobra.Command, image string, containerCmd string, containerArgs []string, instanceName string) error {
+	// The OCI runtime must always be launched where the effective uid/gid is 0 (root or fake-root).
+	if ociRuntime && !rootless.InNS() {
+		// If we need to, enter a new cgroup now, to workaround an issue with crun container cgroup creation (#1538).
+		if err := ocilauncher.CrunNestCgroup(); err != nil {
+			return fmt.Errorf("while applying crun cgroup workaround: %w", err)
+		}
+		// If we are root already, run the launcher in a new mount namespace only.
+		if os.Geteuid() == 0 {
+			return rootless.RunInMountNS(os.Args[1:])
+		}
+		// If we are not root, re-exec in a root-mapped user namespace and mount namespace.
+		return rootless.ExecWithFakeroot(os.Args[1:])
+	}
+
 	ns := launcher.Namespaces{
 		User: userNamespace,
 		UTS:  utsNamespace,

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/internal/pkg/util/interactive"
+	"github.com/apptainer/apptainer/internal/pkg/util/rootless"
 	"github.com/apptainer/apptainer/internal/pkg/util/starter"
 	"github.com/apptainer/apptainer/internal/pkg/util/user"
 	"github.com/apptainer/apptainer/pkg/build/types"
@@ -84,11 +85,12 @@ func fakerootExec(isDeffile, unprivEncrypt bool) {
 	var err error
 	uid := uint32(os.Getuid())
 
-	// Append the user's real UID to the environment as _CONTAINERS_ROOTLESS_UID.
+	// Append the user's real UID/GID to the environment as _CONTAINERS_ROOTLESS_UID/GID.
 	// This is required in fakeroot builds that may use containers/image 5.7 and above.
 	// https://github.com/containers/image/issues/1066
 	// https://github.com/containers/image/blob/master/internal/rootless/rootless.go
-	os.Setenv("_CONTAINERS_ROOTLESS_UID", strconv.FormatUint(uint64(uid), 10))
+	os.Setenv(rootless.UIDEnv, strconv.Itoa(os.Getuid()))
+	os.Setenv(rootless.GIDEnv, strconv.Itoa(os.Getgid()))
 
 	if uid != 0 && (!fakeroot.IsUIDMapped(uid) || buildArgs.ignoreSubuid) {
 		sylog.Infof("User not listed in %v, trying root-mapped namespace", fakeroot.SubUIDFile)

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs/files"
+	"github.com/apptainer/apptainer/internal/pkg/util/rootless"
 	"github.com/apptainer/apptainer/pkg/ocibundle"
 	"github.com/apptainer/apptainer/pkg/ocibundle/native"
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
@@ -189,10 +190,14 @@ func checkOpts(lo launcher.Options) error {
 // container. This spec excludes the Process config, as this has to be computed
 // where the image config is available, to account for the image's CMD /
 // ENTRYPOINT / ENV / USER. See finalizeSpec() function.
-func (l *Launcher) createSpec() (*specs.Spec, error) {
-	spec := minimalSpec()
+func (l *Launcher) createSpec() (spec *specs.Spec, err error) {
+	ms := minimalSpec()
+	spec = &ms
 
-	spec = addNamespaces(spec, l.cfg.Namespaces)
+	err = addNamespaces(spec, l.cfg.Namespaces)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(l.cfg.Hostname) > 0 {
 		// This is a sanity-check; actionPreRun in actions.go should have prevented this scenario from arising.
@@ -218,7 +223,7 @@ func (l *Launcher) createSpec() (*specs.Spec, error) {
 		spec.Linux.Resources = resources
 	}
 
-	return &spec, nil
+	return spec, nil
 }
 
 // finalizeSpec updates the bundle config, filling in Process config that depends on the image spec.
@@ -229,9 +234,18 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 	}
 
 	// In the absence of a USER in the OCI image config, we will run the
-	// container process as our current user / group.
-	currentUID := uint32(os.Getuid())
-	currentGID := uint32(os.Getgid())
+	// container process as our own user / group, i.e. the uid / gid outside of
+	// any initial id-mapped user namespace.
+	rootlessUID, err := rootless.Getuid()
+	if err != nil {
+		return fmt.Errorf("while fetching uid: %w", err)
+	}
+	rootlessGID, err := rootless.Getgid()
+	if err != nil {
+		return fmt.Errorf("while fetching gid: %w", err)
+	}
+	currentUID := uint32(rootlessUID)
+	currentGID := uint32(rootlessGID)
 	targetUID := currentUID
 	targetGID := currentGID
 	containerUser := false
@@ -408,11 +422,6 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		return fmt.Errorf("launcher SysContext must be set for OCI image handling")
 	}
 
-	// If we need to, enter a new cgroup to workaround an issue with crun container cgroup creation (#1538).
-	if err := l.crunNestCgroup(); err != nil {
-		return fmt.Errorf("while applying crun cgroup workaround: %w", err)
-	}
-
 	bundleDir, err := os.MkdirTemp("", "oci-bundle")
 	if err != nil {
 		return nil
@@ -466,14 +475,9 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		return fmt.Errorf("while generating container id: %w", err)
 	}
 
-	if os.Getuid() == 0 {
-		// Execution of runc/crun run, wrapped with prep / cleanup.
-		err = RunWrapped(ctx, id.String(), b.Path(), "", l.cfg.OverlayPaths, l.apptainerConf.SystemdCgroups)
-	} else {
-		// Reexec apptainer oci run in a userns with mappings.
-		// Note - the oci run command will pull out the SystemdCgroups setting from config.
-		err = RunWrappedNS(ctx, id.String(), b.Path(), l.cfg.OverlayPaths)
-	}
+	// Execution of runc/crun run, wrapped with prep / cleanup.
+	err = RunWrapped(ctx, id.String(), b.Path(), "", l.cfg.OverlayPaths, l.apptainerConf.SystemdCgroups)
+
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		os.Exit(exitErr.ExitCode())
@@ -498,7 +502,12 @@ func (l *Launcher) getCgroup() (path string, resources *specs.LinuxResources, er
 // running as a non-root user under cgroups v2, with systemd. This is required
 // to satisfy a common user-owned ancestor cgroup requirement on e.g. bare ssh
 // logins. See: https://github.com/sylabs/singularity/issues/1538
-func (l *Launcher) crunNestCgroup() error {
+func CrunNestCgroup() error {
+	c := apptainerconf.GetCurrentConfig()
+	if c == nil {
+		return fmt.Errorf("apptainer configuration is not initialized")
+	}
+
 	r, err := runtime()
 	if err != nil {
 		return err
@@ -516,14 +525,14 @@ func (l *Launcher) crunNestCgroup() error {
 
 	// We can only create a new cgroup under cgroups v2 with systemd as manager.
 	// Generally we won't hit the issue that needs a workaround under cgroups v1, so no-op instead of a warning here.
-	if !(lccgroups.IsCgroup2UnifiedMode() && l.apptainerConf.SystemdCgroups) {
+	if !(lccgroups.IsCgroup2UnifiedMode() && c.SystemdCgroups) {
 		return nil
 	}
 
 	// We are running crun as a user. Enter a cgroup now.
 	pid := os.Getpid()
 	sylog.Debugf("crun workaround - adding process %d to sibling cgroup", pid)
-	manager, err := cgroups.NewManagerWithSpec(&specs.LinuxResources{}, pid, "", l.apptainerConf.SystemdCgroups)
+	manager, err := cgroups.NewManagerWithSpec(&specs.LinuxResources{}, pid, "", c.SystemdCgroups)
 	if err != nil {
 		return fmt.Errorf("couldn't create cgroup manager: %w", err)
 	}

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -21,6 +21,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/internal/pkg/util/gpu"
+	"github.com/apptainer/apptainer/internal/pkg/util/rootless"
 	"github.com/apptainer/apptainer/internal/pkg/util/user"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/bind"
@@ -33,7 +34,9 @@ const containerLibDir = "/.singularity.d/libs"
 func (l *Launcher) getMounts() ([]specs.Mount, error) {
 	mounts := &[]specs.Mount{}
 	l.addProcMount(mounts)
-	l.addSysMount(mounts)
+	if err := l.addSysMount(mounts); err != nil {
+		return nil, fmt.Errorf("while configuring sys mount: %w", err)
+	}
 	if err := l.addDevMounts(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring devpts mount: %w", err)
 	}
@@ -165,7 +168,12 @@ func (l *Launcher) addDevMounts(mounts *[]specs.Mount) error {
 		Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620"},
 	}
 
-	if os.Getuid() == 0 {
+	rootlessUID, err := rootless.Getuid()
+	if err != nil {
+		return fmt.Errorf("while fetching uid: %w", err)
+	}
+
+	if rootlessUID == 0 {
 		group, err := user.GetGrNam("tty")
 		if err != nil {
 			return fmt.Errorf("while identifying tty gid: %w", err)
@@ -225,13 +233,18 @@ func (l *Launcher) addProcMount(mounts *[]specs.Mount) {
 }
 
 // addSysMount adds the /sys tree in the container.
-func (l *Launcher) addSysMount(mounts *[]specs.Mount) {
+func (l *Launcher) addSysMount(mounts *[]specs.Mount) error {
 	if !l.apptainerConf.MountSys {
 		sylog.Debugf("Skipping mount of /sys due to apptainer.conf")
-		return
+		return nil
 	}
 
-	if os.Getuid() == 0 {
+	rootlessUID, err := rootless.Getuid()
+	if err != nil {
+		return fmt.Errorf("while fetching uid: %w", err)
+	}
+
+	if rootlessUID == 0 {
 		*mounts = append(*mounts,
 			specs.Mount{
 				Source:      "sysfs",
@@ -248,6 +261,8 @@ func (l *Launcher) addSysMount(mounts *[]specs.Mount) {
 				Options:     []string{"rbind", "nosuid", "noexec", "nodev", "ro"},
 			})
 	}
+
+	return nil
 }
 
 // addHomeMount adds a user home directory as a tmpfs mount. We are currently

--- a/internal/pkg/runtime/launcher/oci/oci_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_linux.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/apptainer/apptainer/internal/pkg/util/bin"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
-	"github.com/apptainer/apptainer/internal/pkg/util/user"
+	"github.com/apptainer/apptainer/internal/pkg/util/rootless"
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/fs/lock"
@@ -58,14 +58,14 @@ func runtime() (path string, err error) {
 // runtimeStateDir returns path to use for crun/runc's state handling.
 func runtimeStateDir() (path string, err error) {
 	// Ensure we get correct uid for host if we were re-exec'd in id mapped userns
-	pw, err := user.CurrentOriginal()
+	u, err := rootless.GetUser()
 	if err != nil {
 		return "", err
 	}
-	if pw.UID == 0 {
+	if u.Uid == "0" {
 		return "/run/apptainer-oci", nil
 	}
-	return fmt.Sprintf("/run/user/%d/apptainer-oci", pw.UID), nil
+	return fmt.Sprintf("/run/user/%s/apptainer-oci", u.Uid), nil
 }
 
 // stateDir returns the path to container state handled by conmon/apptainer
@@ -76,7 +76,7 @@ func stateDir(containerID string) (string, error) {
 		return "", err
 	}
 
-	u, err := user.CurrentOriginal()
+	u, err := rootless.GetUser()
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/runtime/launcher/oci/oci_overlay.go
+++ b/internal/pkg/runtime/launcher/oci/oci_overlay.go
@@ -11,8 +11,6 @@ package oci
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	"github.com/apptainer/apptainer/internal/pkg/util/fs/overlay"
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
@@ -97,20 +95,4 @@ func prepareWritableTmpfs(bundleDir string) (string, error) {
 func cleanupWritableTmpfs(bundleDir, overlayDir string) error {
 	sylog.Debugf("Cleaning up writable tmpfs overlay for %s", bundleDir)
 	return tools.DeleteOverlayTmpfs(bundleDir, overlayDir)
-}
-
-// absOverlay takes an overlay description string (a path, optionally followed by a colon with an option string, like ":ro" or ":rw"), and replaces any relative path in the description string with an absolute one.
-func absOverlay(desc string) (string, error) {
-	splitted := strings.SplitN(desc, ":", 2)
-	barePath := splitted[0]
-	absBarePath, err := filepath.Abs(barePath)
-	if err != nil {
-		return "", err
-	}
-	absDesc := absBarePath
-	if len(splitted) > 1 {
-		absDesc += ":" + splitted[1]
-	}
-
-	return absDesc, nil
 }

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -10,9 +10,8 @@
 package oci
 
 import (
-	"os"
-
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
+	"github.com/apptainer/apptainer/internal/pkg/util/rootless"
 	"github.com/apptainer/apptainer/pkg/sylog"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -82,7 +81,7 @@ func minimalSpec() specs.Spec {
 
 // addNamespaces adds requested namespace, if appropriate, to an existing spec.
 // It is assumed that spec contains at least the defaultNamespaces.
-func addNamespaces(spec specs.Spec, ns launcher.Namespaces) specs.Spec {
+func addNamespaces(spec *specs.Spec, ns launcher.Namespaces) error {
 	if ns.IPC {
 		sylog.Infof("--oci runtime always uses an IPC namespace, ipc flag is redundant.")
 	}
@@ -101,13 +100,18 @@ func addNamespaces(spec specs.Spec, ns launcher.Namespaces) specs.Spec {
 	}
 
 	if ns.User {
-		if os.Getuid() == 0 {
+		uid, err := rootless.Getuid()
+		if err != nil {
+			return err
+		}
+
+		if uid == 0 {
 			spec.Linux.Namespaces = append(
 				spec.Linux.Namespaces,
 				specs.LinuxNamespace{Type: specs.UserNamespace},
 			)
 		} else {
-			sylog.Infof("--oci runtime always uses a user namespace when run as a non-root userns, user flag is redundant.")
+			sylog.Infof("The --oci runtime always creates a user namespace when run as non-root, --userns / -u flag is redundant.")
 		}
 	}
 
@@ -118,5 +122,5 @@ func addNamespaces(spec specs.Spec, ns launcher.Namespaces) specs.Spec {
 		)
 	}
 
-	return spec
+	return nil
 }

--- a/internal/pkg/runtime/launcher/oci/spec_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux_test.go
@@ -61,9 +61,13 @@ func Test_addNamespaces(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := minimalSpec()
-			newSpec := addNamespaces(spec, tt.ns)
-			newNS := newSpec.Linux.Namespaces
+			ms := minimalSpec()
+			spec := &ms
+			err := addNamespaces(spec, tt.ns)
+			if err != nil {
+				t.Errorf("addNamespaces() returned an unexpected error: %v", err)
+			}
+			newNS := spec.Linux.Namespaces
 			if !reflect.DeepEqual(newNS, tt.wantNS) {
 				t.Errorf("addNamespaces() got %v, want %v", newNS, tt.wantNS)
 			}

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -10,6 +10,9 @@
 package launcher
 
 import (
+	"fmt"
+
+	"github.com/apptainer/apptainer/internal/pkg/util/fs/overlay"
 	"github.com/apptainer/apptainer/pkg/util/cryptkey"
 	"github.com/containers/image/v5/types"
 )
@@ -180,8 +183,16 @@ func OptWritableTmpfs(b bool) Option {
 }
 
 // OptOverlayPaths sets overlay images and directories to apply to the container.
+// Relative paths are resolved to absolute paths at this point.
 func OptOverlayPaths(op []string) Option {
 	return func(lo *Options) error {
+		var err error
+		for i, p := range op {
+			op[i], err = overlay.AbsOverlay(p)
+			if err != nil {
+				return fmt.Errorf("could not convert %q to absolute path: %w", p, err)
+			}
+		}
 		lo.OverlayPaths = op
 		return nil
 	}

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/apptainer/apptainer/internal/pkg/util/bin"
@@ -243,4 +245,20 @@ func DetachMount(dir string) error {
 	}
 
 	return nil
+}
+
+// AbsOverlay takes an overlay description string (a path, optionally followed by a colon with an option string, like ":ro" or ":rw"), and replaces any relative path in the description string with an absolute one.
+func AbsOverlay(desc string) (string, error) {
+	splitted := strings.SplitN(desc, ":", 2)
+	barePath := splitted[0]
+	absBarePath, err := filepath.Abs(barePath)
+	if err != nil {
+		return "", err
+	}
+	absDesc := absBarePath
+	if len(splitted) > 1 {
+		absDesc += ":" + splitted[1]
+	}
+
+	return absDesc, nil
 }

--- a/internal/pkg/util/fs/overlay/overlay_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux_test.go
@@ -10,6 +10,8 @@
 package overlay
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -213,5 +215,85 @@ func TestCheckLowerUpper(t *testing.T) {
 			}
 			t.Errorf("unexpected error for %q: %q instead of %q", tt.name, err, expectedError)
 		}
+	}
+}
+
+func TestAbsOverlay(t *testing.T) {
+	tmpDir := mkTempDirOrFatal(t)
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Chdir(oldDir)
+	})
+
+	innerDir := filepath.Join(tmpDir, "inner")
+	if err := os.Mkdir(innerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		desc    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "abs",
+			desc: innerDir,
+			want: innerDir,
+		},
+		{
+			name: "rel",
+			desc: "inner",
+			want: innerDir,
+		},
+		{
+			name: "abs_dots",
+			desc: innerDir + "/../inner",
+			want: innerDir,
+		},
+		{
+			name: "rel_dots",
+			desc: "inner/../inner",
+			want: innerDir,
+		},
+		{
+			name: "absDest",
+			desc: innerDir + ":/dest",
+			want: innerDir + ":/dest",
+		},
+		{
+			name: "relDest",
+			desc: "inner" + ":/dest",
+			want: innerDir + ":/dest",
+		},
+		{
+			name: "absDestOpt",
+			desc: innerDir + ":/dest:ro",
+			want: innerDir + ":/dest:ro",
+		},
+		{
+			name: "relDestOpt",
+			desc: "inner" + ":/dest:ro",
+			want: innerDir + ":/dest:ro",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := AbsOverlay(tt.desc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AbsOverlay() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("AbsOverlay() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/pkg/util/rootless/rootless.go
+++ b/internal/pkg/util/rootless/rootless.go
@@ -1,0 +1,127 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package rootless
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
+	fakerootConfig "github.com/apptainer/apptainer/internal/pkg/runtime/engine/fakeroot/config"
+	"github.com/apptainer/apptainer/internal/pkg/util/starter"
+	"github.com/apptainer/apptainer/pkg/runtime/engine/config"
+	"github.com/apptainer/apptainer/pkg/sylog"
+)
+
+const (
+	NSEnv  = "_APPTAINER_NAMESPACE"
+	UIDEnv = "_CONTAINERS_ROOTLESS_UID"
+	GIDEnv = "_CONTAINERS_ROOTLESS_GID"
+)
+
+// Getuid retrieves the uid stored in the env var _CONTAINERS_ROOTLESS_UID, or
+// the current euid if the env var is not set.
+func Getuid() (uid int, err error) {
+	u := os.Getenv(UIDEnv)
+	if u != "" {
+		return strconv.Atoi(u)
+	}
+	return os.Geteuid(), nil
+}
+
+// Getgid retrieves the uid stored in the env var _CONTAINERS_ROOTLESS_GID, or
+// the current egid if the env var is not set.
+func Getgid() (uid int, err error) {
+	g := os.Getenv(GIDEnv)
+	if g != "" {
+		return strconv.Atoi(g)
+	}
+	return os.Getegid(), nil
+}
+
+// GetUser retrieves the User struct for the uid stored in the env var
+// _CONTAINERS_ROOTLESS_UID, or the current euid if the env var is not set.
+func GetUser() (*user.User, error) {
+	u := os.Getenv(UIDEnv)
+	if u != "" {
+		return user.LookupId(u)
+	}
+	return user.Current()
+}
+
+// InNS returns true if we are in a namespace created using this package.
+func InNS() bool {
+	_, envSet := os.LookupEnv(NSEnv)
+	return envSet
+}
+
+// ExecWithFakeroot will exec apptainer with provided args, in a
+// subuid/gid-mapped fakeroot user namespace. This uses the fakeroot engine.
+func ExecWithFakeroot(args []string) error {
+	apptainerBin := []string{
+		filepath.Join(buildcfg.BINDIR, "apptainer"),
+	}
+	args = append(apptainerBin, args...)
+
+	env := os.Environ()
+	env = append(env, NSEnv+"=TRUE")
+	// Use _CONTAINERS_ROOTLESS_xID naming for these vars as they are required
+	// by our use of containers/image for OCI image handling.
+	env = append(env, UIDEnv+"="+strconv.Itoa(os.Geteuid()))
+	env = append(env, GIDEnv+"="+strconv.Itoa(os.Getegid()))
+
+	sylog.Debugf("Calling fakeroot engine to execute %q", strings.Join(args, " "))
+
+	cfg := &config.Common{
+		EngineName:  fakerootConfig.Name,
+		ContainerID: "fakeroot",
+		EngineConfig: &fakerootConfig.EngineConfig{
+			Envs:    env,
+			Args:    args,
+			NoPIDNS: true,
+		},
+	}
+
+	return starter.Exec(
+		"Apptainer oci fakeroot",
+		cfg,
+	)
+}
+
+// RunInMountNS will run apptainer with provided args, in a mount
+// namespace only.
+func RunInMountNS(args []string) error {
+	apptainerBin := filepath.Join(buildcfg.BINDIR, "apptainer")
+
+	env := os.Environ()
+	env = append(env, NSEnv+"=TRUE")
+
+	cmd := exec.Command(apptainerBin, args...)
+	cmd.Env = env
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	// Unshare mount namespace
+	cmd.SysProcAttr.Unshareflags = syscall.CLONE_NEWNS
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		os.Exit(exitErr.ExitCode())
+	}
+	return err
+}

--- a/internal/pkg/util/rootless/rootless_test.go
+++ b/internal/pkg/util/rootless/rootless_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package rootless
+
+import (
+	"os"
+	"os/user"
+	"reflect"
+	"testing"
+)
+
+//nolint:dupl
+func TestGetuid(t *testing.T) {
+	tests := []struct {
+		name    string
+		setEnv  bool
+		envVal  string
+		wantUID int
+		wantErr bool
+	}{
+		{
+			name:    "unset",
+			setEnv:  false,
+			envVal:  "",
+			wantUID: os.Geteuid(),
+			wantErr: false,
+		},
+		{
+			name:    "empty",
+			setEnv:  true,
+			envVal:  "",
+			wantUID: os.Geteuid(),
+			wantErr: false,
+		},
+		{
+			name:    "valid",
+			setEnv:  true,
+			envVal:  "123",
+			wantUID: 123,
+			wantErr: false,
+		},
+		{
+			name:    "invalid",
+			setEnv:  true,
+			envVal:  "abc",
+			wantUID: 0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				os.Setenv(UIDEnv, tt.envVal)
+				defer os.Unsetenv(UIDEnv)
+			}
+			gotUID, err := Getuid()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Getuid() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotUID != tt.wantUID {
+				t.Errorf("Getuid() = %v, want %v", gotUID, tt.wantUID)
+			}
+		})
+	}
+}
+
+//nolint:dupl
+func TestGetgid(t *testing.T) {
+	tests := []struct {
+		name    string
+		setEnv  bool
+		envVal  string
+		wantGID int
+		wantErr bool
+	}{
+		{
+			name:    "unset",
+			setEnv:  false,
+			envVal:  "",
+			wantGID: os.Getegid(),
+			wantErr: false,
+		},
+		{
+			name:    "empty",
+			setEnv:  true,
+			envVal:  "",
+			wantGID: os.Getegid(),
+			wantErr: false,
+		},
+		{
+			name:    "valid",
+			setEnv:  true,
+			envVal:  "456",
+			wantGID: 456,
+			wantErr: false,
+		},
+		{
+			name:    "invalid",
+			setEnv:  true,
+			envVal:  "abc",
+			wantGID: 0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				os.Setenv(GIDEnv, tt.envVal)
+				defer os.Unsetenv(GIDEnv)
+			}
+			gotGID, err := Getgid()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Getgid() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotGID != tt.wantGID {
+				t.Errorf("Getgid() = %v, want %v", gotGID, tt.wantGID)
+			}
+		})
+	}
+}
+
+func TestGetUser(t *testing.T) {
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootUser, err := user.LookupId("0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		setEnv  bool
+		envVal  string
+		want    *user.User
+		wantErr bool
+	}{
+		{
+			name:    "unset",
+			setEnv:  false,
+			envVal:  "",
+			want:    currentUser,
+			wantErr: false,
+		},
+		{
+			name:    "empty",
+			setEnv:  true,
+			envVal:  "",
+			want:    currentUser,
+			wantErr: false,
+		},
+		{
+			name:    "valid",
+			setEnv:  true,
+			envVal:  "0",
+			want:    rootUser,
+			wantErr: false,
+		},
+		{
+			name:    "invalid",
+			setEnv:  true,
+			envVal:  "abc",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				os.Setenv(UIDEnv, tt.envVal)
+				defer os.Unsetenv(UIDEnv)
+			}
+			got, err := GetUser()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetUser() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetUser() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -18,11 +18,11 @@ package syfs
 
 import (
 	"os"
-	"os/user"
 	"path/filepath"
 	"sync"
 
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
+	"github.com/apptainer/apptainer/internal/pkg/util/user"
 	"github.com/apptainer/apptainer/pkg/sylog"
 )
 
@@ -62,7 +62,7 @@ func configDir(dir string) string {
 
 	homedir := os.Getenv("HOME")
 	if homedir == "" {
-		user, err := user.Current()
+		user, err := user.CurrentOriginal()
 		if err != nil {
 			sylog.Warningf("Could not lookup the current user's information: %s", err)
 
@@ -73,7 +73,7 @@ func configDir(dir string) string {
 			}
 			homedir = cwd
 		} else {
-			homedir = user.HomeDir
+			homedir = user.Dir
 		}
 	}
 
@@ -95,16 +95,16 @@ func DockerConf() string {
 // ConfigDirForUsername returns the directory where the apptainer
 // configuration and data for the specified username is located.
 func ConfigDirForUsername(username string) (string, error) {
-	u, err := user.Lookup(username)
+	u, err := user.GetPwNam(username)
 	if err != nil {
 		return "", err
 	}
 
-	if cu, err := user.Current(); err == nil && u.Username == cu.Username {
+	if cu, err := user.CurrentOriginal(); err == nil && u.Name == cu.Name {
 		return ConfigDir(), nil
 	}
 
-	return filepath.Join(u.HomeDir, apptainerDir), nil
+	return filepath.Join(u.Dir, apptainerDir), nil
 }
 
 // LegacyConfigDir returns where singularity stores user configuration.


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1774
 which fixed
- sylabs/singularity# 1773

The original PR description was:
> Before this PR, if we are a non-root user we enter a root-mapped user namespace before calling `singularity oci run` at the end of the `--oci` launcher flow. If we are the root user, we do not enter any namespace. This means that bundle preparation, performed by the launcher, takes place outside of any namespaces.
> 
> As a non-root user, we want to perform bundle preparation inside a root-mapped user namespace. This is in order to benefit from fully-unprivileged FUSE operations when we start handling image mounts, plus advantages around cleanup on namespace exit. As a root user, we want to be inside a mount namespace to avoid polluting the host mount namespace with our container-specific mounts.
> 
> In this PR:
> 
>  * As a non-root user, a root-mapped namespace is entered early, before   the oci launcher code executes.
>  * As a root user, a mount namespace is entered early, before the oci launcher code executes.
> 
> 
> We use the `_CONTAINERS_ROOTLESS_xID` environment variables for tracking our UID/GID outside of the root-mapped namespace, since they must be set anyway for `containers/image` to operate properly inside the namespace. We are using `containers/image` for our OCI image handling.

