### PR TITLE
fix `mount home=no`, support `--no-home` in `--oci` mode, from sylabs 1784

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   storage. If `--scratch <scratchdir>` is used in conjunction with `--workdir`,
   scratch directories will be mapped to subdirectories nested under
   `<workdir>/scratch` on the host, rather than to tmpfs storage.
+- OCI-mode now supports the `--no-home` flag, to prevent the container home
+  directory from being mounted.
 
 ### New Features & Functionality
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -212,6 +212,11 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "NoHome",
+			argv: []string{"--no-home", imageRef, "grep", e2e.OCIUserProfile.ContainerUser(t).Dir, "/proc/self/mountinfo"},
+			exit: 1,
+		},
+		{
 			name: "UTSNamespace",
 			argv: []string{"--uts", imageRef, "true"},
 			exit: 0,

--- a/e2e/config/oci.go
+++ b/e2e/config/oci.go
@@ -215,6 +215,17 @@ func (c configTests) ociConfigGlobal(t *testing.T) {
 			directiveValue: "no",
 			exit:           1,
 		},
+		// Verify that though mount is skipped, $HOME is still set correctly
+		// https://github.com/sylabs/singularity/issues/1783
+		{
+			name:           "MountHomeNoCorrectDir",
+			argv:           []string{archiveRef, "sh", "-c", "test $HOME == " + e2e.OCIUserProfile.ContainerUser(t).Dir},
+			profile:        e2e.OCIUserProfile,
+			cwd:            "/",
+			directive:      "mount home",
+			directiveValue: "no",
+			exit:           0,
+		},
 		{
 			name:           "MountHomeYes",
 			argv:           []string{archiveRef, "grep", e2e.OCIUserProfile.ContainerUser(t).Dir, "/proc/self/mountinfo"},

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -86,9 +86,6 @@ func checkOpts(lo launcher.Options) error {
 	if lo.WritableTmpfs {
 		sylog.Infof("--oci mode uses --writable-tmpfs by default")
 	}
-	if lo.NoHome {
-		badOpt = append(badOpt, "NoHome")
-	}
 
 	if len(lo.FuseMount) > 0 {
 		badOpt = append(badOpt, "FuseMount")

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -51,6 +51,12 @@ var (
 type Launcher struct {
 	cfg           launcher.Options
 	apptainerConf *apptainerconf.File
+	// homeSrc is the computed source (on the host) for the user's home directory.
+	// An empty value indicates there is no source on the host, and a tmpfs will be used.
+	homeSrc string
+	// homeDest is the computed destination (in the container) for the user's home directory.
+	// An empty value is not valid at mount time.
+	homeDest string
 }
 
 // NewLauncher returns a oci.Launcher with an initial configuration set by opts.
@@ -71,7 +77,17 @@ func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
 		return nil, fmt.Errorf("apptainer configuration is not initialized")
 	}
 
-	return &Launcher{cfg: lo, apptainerConf: c}, nil
+	homeSrc, homeDest, err := parseHomeDir(lo.HomeDir, lo.CustomHome, lo.Fakeroot)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Launcher{
+		cfg:           lo,
+		apptainerConf: c,
+		homeSrc:       homeSrc,
+		homeDest:      homeDest,
+	}, nil
 }
 
 // checkOpts ensures that options set are supported by the oci.Launcher.
@@ -181,6 +197,43 @@ func checkOpts(lo launcher.Options) error {
 	}
 
 	return nil
+}
+
+// parseHomeDir parses the homedir value passed from the CLI layer into a host source, and container dest.
+// This includes handling fakeroot and custom --home dst, or --home src:dst specifications.
+func parseHomeDir(homedir string, custom, fakeroot bool) (src, dest string, err error) {
+	// Get the host user's information, looking outside of a user namespace if necessary.
+	pw, err := rootless.GetUser()
+	if err != nil {
+		return "", "", err
+	}
+
+	// By default in --oci mode there is no external source for $HOME, i.e. a `tmpfs` will be used.
+	src = ""
+	// By default the destination in the container matches the users's $HOME on the host.
+	dest = pw.HomeDir
+
+	// --fakeroot means we are root in the container so $HOME=/root
+	if fakeroot {
+		dest = "/root"
+	}
+
+	// If the user set a custom --home via the CLI, then override the defaults.
+	if custom {
+		homeSlice := strings.Split(homedir, ":")
+		if len(homeSlice) < 1 || len(homeSlice) > 2 {
+			return "", "", fmt.Errorf("home argument has incorrect number of elements: %v", homeSlice)
+		}
+		// A single path was provided, so we will be mounting a tmpfs on this custom destination.
+		dest = homeSlice[0]
+
+		// Two paths provided (<src>:<dest>), so we will be bind mounting from host to container.
+		if len(homeSlice) > 1 {
+			src = homeSlice[0]
+			dest = homeSlice[1]
+		}
+	}
+	return src, dest, nil
 }
 
 // createSpec creates an initial OCI runtime specification, suitable to launch a

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -265,13 +265,17 @@ func (l *Launcher) addSysMount(mounts *[]specs.Mount) error {
 	return nil
 }
 
-// addHomeMount adds a user home directory as a tmpfs mount. We are currently
-// emulating `--compat` / `--containall`, so the user must specifically bind in
-// their home directory from the host for it to be available.
+// addHomeMount adds a user home directory as a tmpfs mount, and sets the
+// container home directory. We are currently emulating `--compat` /
+// `--containall`, so the user must specifically bind in their home directory
+// from the host for it to be available.
 func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
+	// If the $HOME mount is skipped by config need to still handle setting the
+	// correct $HOME dir, but just skip adding the mount.
+	skipMount := false
 	if !l.apptainerConf.MountHome {
 		sylog.Debugf("Skipping mount of $HOME due to apptainer.conf")
-		return nil
+		skipMount = true
 	}
 
 	// Get the host user's data
@@ -295,6 +299,10 @@ func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
 			homeDest := homeSlice[1]
 			l.cfg.HomeDir = homeDest
 
+			if skipMount {
+				return nil
+			}
+
 			// Since the home dir is a bind-mount in this case, we don't have to mount a tmpfs directory for the in-container home dir, and we can just do the bind-mount & return.
 			return addBindMount(mounts, bind.Path{
 				Source:      homeSrc,
@@ -305,6 +313,11 @@ func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
 		// If we're running in fake-root mode (and we haven't requested a custom home dir), we do need to create a tmpfs mount for the home dir, but it's a special case (because of its location & permissions), so we handle that here & return.
 		if l.cfg.Fakeroot {
 			l.cfg.HomeDir = "/root"
+
+			if skipMount {
+				return nil
+			}
+
 			*mounts = append(*mounts,
 				specs.Mount{
 					Destination: "/root",
@@ -323,6 +336,10 @@ func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
 
 		// No fakeroot and no custom home dir - so the in-container home dir will be named the same as the host user's home dir. (Though note that it'll still be a tmpfs mount! It'll get mounted by the catch-all mount append, below.)
 		l.cfg.HomeDir = pw.Dir
+	}
+
+	if skipMount {
+		return nil
 	}
 
 	// If we've not hit a special case (bind-mounted custom home dir, or fakeroot), then create a tmpfs mount as a home dir in the requested location (whether it's custom or not; by this point, l.cfg.HomeDir will reflect the right value).

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -270,11 +270,15 @@ func (l *Launcher) addSysMount(mounts *[]specs.Mount) error {
 // `--containall`, so the user must specifically bind in their home directory
 // from the host for it to be available.
 func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
-	// If the $HOME mount is skipped by config need to still handle setting the
-	// correct $HOME dir, but just skip adding the mount.
+	// If the $HOME mount is skipped by config or --no-home, we still need to
+	// handle setting the correct $HOME dir, but just skip adding the mount.
 	skipMount := false
 	if !l.apptainerConf.MountHome {
 		sylog.Debugf("Skipping mount of $HOME due to apptainer.conf")
+		skipMount = true
+	}
+	if l.cfg.NoHome {
+		sylog.Debugf("Skipping mount of $HOME due to --no-home")
 		skipMount = true
 	}
 

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -265,101 +265,61 @@ func (l *Launcher) addSysMount(mounts *[]specs.Mount) error {
 	return nil
 }
 
-// addHomeMount adds a user home directory as a tmpfs mount, and sets the
-// container home directory. We are currently emulating `--compat` /
-// `--containall`, so the user must specifically bind in their home directory
-// from the host for it to be available.
+// addHomeMount adds the user home directory to the container, according to the
+// src and dest computed by parseHomeDir from launcher.New.
 func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
-	// If the $HOME mount is skipped by config or --no-home, we still need to
-	// handle setting the correct $HOME dir, but just skip adding the mount.
-	skipMount := false
 	if !l.apptainerConf.MountHome {
 		sylog.Debugf("Skipping mount of $HOME due to apptainer.conf")
-		skipMount = true
+		return nil
 	}
 	if l.cfg.NoHome {
 		sylog.Debugf("Skipping mount of $HOME due to --no-home")
-		skipMount = true
-	}
-
-	// Get the host user's data
-	pw, err := user.CurrentOriginal()
-	if err != nil {
-		return err
-	}
-
-	if l.cfg.CustomHome {
-		// Handle any user request to override the home directory source/dest
-		homeSlice := strings.Split(l.cfg.HomeDir, ":")
-		if len(homeSlice) < 1 || len(homeSlice) > 2 {
-			return fmt.Errorf("home argument has incorrect number of elements: %v", homeSlice)
-		}
-		homeSrc := homeSlice[0]
-		l.cfg.HomeDir = homeSrc
-
-		// User requested more than just a custom home dir; they want to bind-mount a directory in the host to this custom home dir.
-		// This means the home dir, as viewed from inside the container, is actually the second member of the ":"-separated slice. The first member is actually just the source portion of the requested bind-mount.
-		if len(homeSlice) > 1 {
-			homeDest := homeSlice[1]
-			l.cfg.HomeDir = homeDest
-
-			if skipMount {
-				return nil
-			}
-
-			// Since the home dir is a bind-mount in this case, we don't have to mount a tmpfs directory for the in-container home dir, and we can just do the bind-mount & return.
-			return addBindMount(mounts, bind.Path{
-				Source:      homeSrc,
-				Destination: homeDest,
-			})
-		}
-	} else {
-		// If we're running in fake-root mode (and we haven't requested a custom home dir), we do need to create a tmpfs mount for the home dir, but it's a special case (because of its location & permissions), so we handle that here & return.
-		if l.cfg.Fakeroot {
-			l.cfg.HomeDir = "/root"
-
-			if skipMount {
-				return nil
-			}
-
-			*mounts = append(*mounts,
-				specs.Mount{
-					Destination: "/root",
-					Type:        "tmpfs",
-					Source:      "tmpfs",
-					Options: []string{
-						"nosuid",
-						"relatime",
-						"mode=755",
-						fmt.Sprintf("size=%dm", l.apptainerConf.SessiondirMaxSize),
-					},
-				})
-
-			return nil
-		}
-
-		// No fakeroot and no custom home dir - so the in-container home dir will be named the same as the host user's home dir. (Though note that it'll still be a tmpfs mount! It'll get mounted by the catch-all mount append, below.)
-		l.cfg.HomeDir = pw.Dir
-	}
-
-	if skipMount {
 		return nil
 	}
 
-	// If we've not hit a special case (bind-mounted custom home dir, or fakeroot), then create a tmpfs mount as a home dir in the requested location (whether it's custom or not; by this point, l.cfg.HomeDir will reflect the right value).
+	if l.homeDest == "" {
+		return fmt.Errorf("cannot add home mount with empty destination")
+	}
+
+	// If l.homeSrc is set, then we are simply bind mounting from the host.
+	if l.homeSrc != "" {
+		return addBindMount(mounts, bind.Path{
+			Source:      l.homeSrc,
+			Destination: l.homeDest,
+		})
+	}
+
+	// Otherwise we setup a tmpfs, mounted onto l.homeDst.
+	tmpfsOpt := []string{
+		"nosuid",
+		"relatime",
+		"mode=755",
+		fmt.Sprintf("size=%dm", l.apptainerConf.SessiondirMaxSize),
+	}
+
+	// If we aren't using fakeroot, ensure the tmpfs ownership is correct for our real uid/gid.
+	if !l.cfg.Fakeroot {
+		uid, err := rootless.Getuid()
+		if err != nil {
+			return fmt.Errorf("while fetching uid: %w", err)
+		}
+		gid, err := rootless.Getgid()
+		if err != nil {
+			return fmt.Errorf("while fetching gid: %w", err)
+		}
+
+		tmpfsOpt = append(tmpfsOpt,
+			fmt.Sprintf("uid=%d", uid),
+			fmt.Sprintf("gid=%d", gid),
+		)
+	}
+
 	*mounts = append(*mounts,
 		specs.Mount{
-			Destination: l.cfg.HomeDir,
+			Destination: l.homeDest,
 			Type:        "tmpfs",
 			Source:      "tmpfs",
-			Options: []string{
-				"nosuid",
-				"relatime",
-				"mode=755",
-				fmt.Sprintf("size=%dm", l.apptainerConf.SessiondirMaxSize),
-				fmt.Sprintf("uid=%d", pw.UID),
-				fmt.Sprintf("gid=%d", pw.GID),
-			},
+			Options:     tmpfsOpt,
 		})
 
 	return nil

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -53,7 +53,7 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, imag
 
 	// Ensure HOME points to the required home directory, even if it is a custom one, unless the container explicitly specifies its USER, in which case we don't want to touch HOME.
 	if imgSpec.Config.User == "" {
-		rtEnv["HOME"] = l.cfg.HomeDir
+		rtEnv["HOME"] = l.homeDest
 	}
 
 	cwd, err := l.getProcessCwd()


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1784
 which fixed
- sylabs/singularity# 1783
- sylabs/singularity# 1780

The original PR description was:
> **fix: set correct $HOME in --oci mode when mount home = no**
> 
> When `mount home = no` is set in `singularity.conf`, we still need to set the correct value for `$HOME` in the container... we just don't want to mount it.
> 
> **support `--no-home` in `--oci` mode**
> 
> When `--no-home` is set on the CLI in `--oci` mode, do not mount onto the container home directory.



