### PR TITLE
don't bind-mount /etc passwd & group when persistent writes possible, from sylabs 1822

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -2272,5 +2272,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"test sif header and execute image":      c.testSIFHeaderAndExecute,              // https://github.com/apptainer/apptainer/issues/211
 		"build sif image using gocryptfs":        c.testGocryptfsSIFBuild,                // https://github.com/apptainer/apptainer/issues/484
 		"definition build with template support": c.buildDefinitionWithBuildArgs,         // builds from definition with build args (build arg file) support
+		"issue 1812":                             c.issue1812,                            // https://github.com/sylabs/singularity/issues/1812
 	}
 }

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2371,7 +2371,8 @@ func (c *container) addIdentityMount(system *mount.System) error {
 
 	if (uid == 0) &&
 		(c.engine.EngineConfig.GetWritableImage() ||
-			c.engine.EngineConfig.GetWritableTmpfs()) {
+			c.engine.EngineConfig.GetWritableTmpfs()) ||
+		c.engine.EngineConfig.GetWritableOverlay() {
 		sylog.Verbosef("skipping bind-mount of /etc/passwd and /etc/group (rootfs is writable and not a tmpfs, and container is running as root)")
 		return nil
 	}

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2369,6 +2369,13 @@ func (c *container) addIdentityMount(system *mount.System) error {
 		uid = c.engine.EngineConfig.GetTargetUID()
 	}
 
+	if (uid == 0) &&
+		(c.engine.EngineConfig.GetWritableImage() ||
+			c.engine.EngineConfig.GetWritableTmpfs()) {
+		sylog.Verbosef("skipping bind-mount of /etc/passwd and /etc/group (rootfs is writable and not a tmpfs, and container is running as root)")
+		return nil
+	}
+
 	if c.engine.EngineConfig.File.ConfigPasswd {
 		passwd := filepath.Join(rootfs, "/etc/passwd")
 		_, home, err := c.getHomePaths()

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -1312,27 +1312,27 @@ func (e *EngineOperations) loadOverlayImages(starterConfig *starter.Config, writ
 	images := make([]image.Image, 0)
 
 	for _, overlayImg := range e.EngineConfig.GetOverlayImage() {
-		writableOverlay := true
+		e.EngineConfig.SetWritableOverlay(true)
 
 		splitted := strings.SplitN(overlayImg, ":", 2)
 		if len(splitted) == 2 {
 			if splitted[1] == "ro" {
-				writableOverlay = false
+				e.EngineConfig.SetWritableOverlay(false)
 			}
 		}
 
-		img, err := e.loadImage(splitted[0], writableOverlay, userNS)
+		img, err := e.loadImage(splitted[0], e.EngineConfig.GetWritableOverlay(), userNS)
 		if err != nil {
 			if !image.IsReadOnlyFilesytem(err) {
 				return nil, fmt.Errorf("failed to open overlay image %s: %s", splitted[0], err)
 			}
 			// let's proceed with readonly filesystem and set
 			// writableOverlay to appropriate value
-			writableOverlay = false
+			e.EngineConfig.SetWritableOverlay(false)
 		}
 		img.Usage = image.OverlayUsage
 
-		if writableOverlay && img.Writable {
+		if e.EngineConfig.GetWritableOverlay() && img.Writable {
 			if writableOverlayPath != "" {
 				return nil, fmt.Errorf(
 					"you can't specify more than one writable overlay, "+

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -151,6 +151,7 @@ type JSONConfig struct {
 	NoEval                bool              `json:"noEval,omitempty"`
 	Underlay              bool              `json:"underlay,omitempty"`
 	UserInfo              UserInfo          `json:"userInfo,omitempty"`
+	WritableOverlay       bool              `json:"writableOverlay,omitempty"`
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.
@@ -903,4 +904,14 @@ func (e *EngineConfig) SetUnderlay(underlay bool) {
 // GetUnderlay gets the value of whether to use underlay instead of overlay
 func (e *EngineConfig) GetUnderlay() bool {
 	return e.JSON.Underlay
+}
+
+// SetWritableOverlay sets whether the overlay is writable or not
+func (e *EngineConfig) SetWritableOverlay(writableOverlay bool) {
+	e.JSON.WritableOverlay = writableOverlay
+}
+
+// GetWritableOverlay gets the value of whether the overlay is writable or not
+func (e *EngineConfig) GetWritableOverlay() bool {
+	return e.JSON.WritableOverlay
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1822
 which fixed
- sylabs/singularity# 1812

The original PR description was:
> If all of the following conditions hold —
> 
> * The user inside the container is root
> * The root filesystem is writable
> * The root filesystem is not a tmpfs
> 
> — then writes to `/etc/passwd` or `/etc/group` are possible, and would be expected to persist from build to action stage (run/exec/shell) or across distinct actions (e.g. from one run to the next).
> 
> Under this exact combination of conditions, then, we inhibit bind-mounting modified versions of `/etc/passwd` and `/etc/group` from tmpfs storage into the container.


