### PR TITLE
oci: Support --no-mount, to extent possible, from sylabs 1785

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `<workdir>/scratch` on the host, rather than to tmpfs storage.
 - OCI-mode now supports the `--no-home` flag, to prevent the container home
   directory from being mounted.
+- OCI-mode now supports the `--no-mount` flag to disable the `proc`, `sys`,
+  `devpts`, `tmp`, and `home` mounts in the container. `dev` cannot be disabled
+  in OCI-mode, and `bind-path` mounts are not supported.
 
 ### New Features & Functionality
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2947,5 +2947,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociCompat":          np(c.actionOciCompat),          // --oci equivalence to native mode --compat
 		"ociOverlay":         (c.actionOciOverlay),           // --overlay in OCI mode
 		"ociOverlayTeardown": np(c.actionOciOverlayTeardown), // proper overlay unmounting in OCI mode
+		"ociNo-mount":        c.actionOciNoMount,             // --no-mount in OCI mode
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1462,3 +1462,114 @@ func (c actionTests) ociSTDPipe(t *testing.T) {
 		)
 	}
 }
+
+func (c actionTests) actionOciNoMount(t *testing.T) {
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	tests := []struct {
+		name      string
+		noMount   string
+		noMatch   string
+		warnMatch string
+		exit      int
+	}{
+		{
+			name:    "proc",
+			noMount: "proc",
+			noMatch: "on /proc",
+			exit:    1, // mount fails with exit code 1 when there is no `/proc`
+		},
+		{
+			name:    "sys",
+			noMount: "sys",
+			noMatch: "on /sys",
+			exit:    0,
+		},
+		{
+			name:      "dev",
+			noMount:   "dev",
+			warnMatch: "--no-mount dev is not supported in OCI mode, ignoring.",
+			exit:      0,
+		},
+		{
+			name:    "devpts",
+			noMount: "devpts",
+			noMatch: "on /dev/pts",
+			exit:    0,
+		},
+		{
+			name:    "tmp",
+			noMount: "tmp",
+			noMatch: "on /tmp",
+			exit:    0,
+		},
+		{
+			name:    "home",
+			noMount: "home",
+			noMatch: "on /home",
+			exit:    0,
+		},
+		{
+			name:      "cwd",
+			noMount:   "cwd",
+			warnMatch: "--no-mount cwd is not supported in OCI mode, ignoring.",
+			exit:      0,
+		},
+		//
+		// TODO - apptainer.conf bind path handling is not implemented yet in OCI mode.
+		//        If/when it is, consider how to handle below.
+		//
+		// /etc/hosts & /etc/localtime are default 'bind path' entries we should
+		// be able to disable by abs path. Although other 'bind path' entries
+		// are ignored under '--contain' these two are handled specially in
+		// addBindsMount(), so make sure that `--no-mount` applies properly
+		// under contain also.
+		{
+			name:    "/etc/hosts",
+			noMount: "/etc/hosts",
+			// noMatch: "on /etc/hosts",
+			warnMatch: "--no-mount /etc/hosts is not supported in OCI mode, ignoring.",
+			exit:      0,
+		},
+		{
+			name:    "/etc/localtime",
+			noMount: "/etc/localtime",
+			// noMatch: "on /etc/localtime",
+			warnMatch: "--no-mount /etc/localtime is not supported in OCI mode, ignoring.",
+			exit:      0,
+		},
+		// bind-paths should disable all of the bind path mounts - including both defaults
+		{
+			name:    "binds-paths-hosts",
+			noMount: "bind-paths",
+			// noMatch: "on /etc/hosts",
+			warnMatch: "--no-mount bind-paths is not supported in OCI mode, ignoring.",
+			exit:      0,
+		},
+		{
+			name:    "bind-paths-localtime",
+			noMount: "bind-paths",
+			// noMatch: "on /etc/localtime",
+			warnMatch: "--no-mount bind-paths is not supported in OCI mode, ignoring.",
+			exit:      0,
+		},
+	}
+
+	for _, tt := range tests {
+
+		expectOp := e2e.ExpectOutput(e2e.UnwantedContainMatch, tt.noMatch)
+		if tt.warnMatch != "" {
+			expectOp = e2e.ExpectError(e2e.ContainMatch, tt.warnMatch)
+		}
+
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.OCIUserProfile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs("--no-mount", tt.noMount, imageRef, "mount"),
+			e2e.ExpectExit(tt.exit, expectOp),
+		)
+	}
+}

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/user"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/bind"
+	"github.com/apptainer/apptainer/pkg/util/slice"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -75,6 +76,10 @@ func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) error {
 
 	if !l.apptainerConf.MountTmp {
 		sylog.Debugf("Skipping mount of /tmp due to apptainer.conf")
+		return nil
+	}
+	if slice.ContainsString(l.cfg.NoMount, "tmp") {
+		sylog.Debugf("Skipping mount of /tmp due to --no-mount")
 		return nil
 	}
 
@@ -193,7 +198,6 @@ func (l *Launcher) addDevMounts(mounts *[]specs.Mount) error {
 				fmt.Sprintf("size=%dm", l.apptainerConf.SessiondirMaxSize),
 			},
 		},
-		ptsMount,
 		specs.Mount{
 			Destination: "/dev/shm",
 			Type:        "tmpfs",
@@ -214,6 +218,12 @@ func (l *Launcher) addDevMounts(mounts *[]specs.Mount) error {
 		},
 	)
 
+	if slice.ContainsString(l.cfg.NoMount, "devpts") {
+		sylog.Debugf("Skipping mount of /dev/pts due to --no-mount")
+		return nil
+	}
+
+	*mounts = append(*mounts, ptsMount)
 	return nil
 }
 
@@ -221,6 +231,10 @@ func (l *Launcher) addDevMounts(mounts *[]specs.Mount) error {
 func (l *Launcher) addProcMount(mounts *[]specs.Mount) {
 	if !l.apptainerConf.MountProc {
 		sylog.Debugf("Skipping mount of /proc due to apptainer.conf")
+		return
+	}
+	if slice.ContainsString(l.cfg.NoMount, "proc") {
+		sylog.Debugf("Skipping mount of /proc due to --no-mount")
 		return
 	}
 
@@ -236,6 +250,10 @@ func (l *Launcher) addProcMount(mounts *[]specs.Mount) {
 func (l *Launcher) addSysMount(mounts *[]specs.Mount) error {
 	if !l.apptainerConf.MountSys {
 		sylog.Debugf("Skipping mount of /sys due to apptainer.conf")
+		return nil
+	}
+	if slice.ContainsString(l.cfg.NoMount, "sys") {
+		sylog.Debugf("Skipping mount of /sys due to --no-mount")
 		return nil
 	}
 
@@ -274,6 +292,10 @@ func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
 	}
 	if l.cfg.NoHome {
 		sylog.Debugf("Skipping mount of $HOME due to --no-home")
+		return nil
+	}
+	if slice.ContainsString(l.cfg.NoMount, "home") {
+		sylog.Debugf("Skipping mount of /home due to --no-mount")
 		return nil
 	}
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1785
 which fixed
- sylabs/singularity# 1781

The original PR description was:
> Allow the `--no-mount` flag to be specified in `--oci` mode. This allows disabling the following mounts:
> 
>  * proc
>  * sys
>  * devpts
>  * tmp
>  * home
> 
> Note that `dev` cannot be supported in `--oci` mode, as an OCI runtime _requires_ that certain devices are present, and will include them in a `/dev` tmpfs.
> 
> We currently run similar to native mode `--compat`, so we don't mount the current working directory. Therefore, `--no-mount cwd` is not supported.
> 
> Similarly, `--compat` infers that `bind path` entries from `singularity.conf` are ignored. We may handle them in some way, in future.





