### PR TITLE
oci: support --containlibs / SINGULARITY_CONTAINLIBS, from sylabs 1786

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   in OCI-mode, and `bind-path` mounts are not supported.
 - If kernel does not support unprivileged overlays, OCI-mode will attempt to use
   `fuse-overlayfs` and `fusermount` for overlay mounting and unmounting.
+- OCI-mode now suppports the `APPTAINER_CONTAINLIBS` env var, to specify
+  libraries to bind into `/.singularity.d/libs/` in the container.
 
 ### Developer / API
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -268,6 +268,14 @@ func (c actionTests) actionOciExec(t *testing.T) {
 				e2e.ExpectOutput(e2e.RegexMatch, `^(\s*)Server:(\s+)(1\.1\.1\.1)(\s*)\n`),
 			},
 		},
+		{
+			name: "Containlibs",
+			argv: []string{"--containlibs", "/etc/hosts", imageRef, "ls", "/.singularity.d/libs"},
+			exit: 0,
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.ExactMatch, `hosts`),
+			},
+		},
 	}
 	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -120,10 +120,6 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "NvCCLI")
 	}
 
-	if len(lo.ContainLibs) > 0 {
-		badOpt = append(badOpt, "ContainLibs")
-	}
-
 	if lo.CleanEnv {
 		badOpt = append(badOpt, "CleanEnv")
 	}

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -61,6 +61,11 @@ func (l *Launcher) getMounts() ([]specs.Mount, error) {
 	if (l.cfg.Nvidia || l.apptainerConf.AlwaysUseNv) && !l.cfg.NoNvidia {
 		if err := l.addNvidiaMounts(mounts); err != nil {
 			return nil, fmt.Errorf("while configuring Nvidia mount(s): %w", err)
+		}
+	}
+	if len(l.cfg.ContainLibs) > 0 {
+		if err := l.addLibrariesMounts(mounts); err != nil {
+			return nil, fmt.Errorf("while configuring containlibs mount(s): %w", err)
 		}
 	}
 
@@ -615,6 +620,27 @@ func (l *Launcher) addNvidiaMounts(mounts *[]specs.Mount) error {
 			Destination: dev,
 		}
 		if err := addDevBindMount(mounts, bind); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (l *Launcher) addLibrariesMounts(mounts *[]specs.Mount) error {
+	if !l.apptainerConf.UserBindControl {
+		sylog.Warningf("Ignoring containlibs mount request: user bind control disabled by system administrator")
+		return nil
+	}
+
+	for _, lib := range l.cfg.ContainLibs {
+		containerLib := filepath.Join(containerLibDir, filepath.Base(lib))
+		bind := bind.Path{
+			Source:      lib,
+			Destination: containerLib,
+			Options:     map[string]*bind.Option{"ro": {}},
+		}
+		if err := addBindMount(mounts, bind); err != nil {
 			return err
 		}
 	}

--- a/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -13,6 +13,8 @@
 package oci
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -280,6 +282,111 @@ func TestLauncher_addBindMounts(t *testing.T) {
 			}
 			if !reflect.DeepEqual(mounts, tt.wantMounts) {
 				t.Errorf("addBindMount() want %v, got %v", tt.wantMounts, mounts)
+			}
+		})
+	}
+}
+
+func TestLauncher_addLibrariesMounts(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "add-libraries-mounts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.RemoveAll(tmpDir)
+		}
+	})
+
+	lib1 := filepath.Join(tmpDir, "lib1.so")
+	lib2 := filepath.Join(tmpDir, "lib2.so")
+	libInvalid := filepath.Join(tmpDir, "invalid")
+	if err := os.WriteFile(lib1, []byte("lib1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lib2, []byte("lib2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		cfg        launcher.Options
+		userbind   bool
+		wantMounts *[]specs.Mount
+		wantErr    bool
+	}{
+		{
+			name: "Disabled",
+			cfg: launcher.Options{
+				ContainLibs: []string{lib1},
+			},
+			wantMounts: &[]specs.Mount{},
+			wantErr:    false,
+		},
+		{
+			name: "Invalid",
+			cfg: launcher.Options{
+				ContainLibs: []string{libInvalid},
+			},
+			userbind:   true,
+			wantMounts: &[]specs.Mount{},
+			wantErr:    true,
+		},
+		{
+			name: "Single",
+			cfg: launcher.Options{
+				ContainLibs: []string{lib1},
+			},
+			userbind: true,
+			wantMounts: &[]specs.Mount{
+				{
+					Source:      lib1,
+					Destination: "/.singularity.d/libs/lib1.so",
+					Type:        "none",
+					Options:     []string{"rbind", "nosuid", "nodev", "ro"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Multiple",
+			cfg: launcher.Options{
+				ContainLibs: []string{lib1, lib2},
+			},
+			userbind: true,
+			wantMounts: &[]specs.Mount{
+				{
+					Source:      lib1,
+					Destination: "/.singularity.d/libs/lib1.so",
+					Type:        "none",
+					Options:     []string{"rbind", "nosuid", "nodev", "ro"},
+				},
+				{
+					Source:      lib2,
+					Destination: "/.singularity.d/libs/lib2.so",
+					Type:        "none",
+					Options:     []string{"rbind", "nosuid", "nodev", "ro"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &Launcher{
+				cfg:           tt.cfg,
+				apptainerConf: &apptainerconf.File{},
+			}
+			if tt.userbind {
+				l.apptainerConf.UserBindControl = true
+			}
+			mounts := &[]specs.Mount{}
+			err := l.addLibrariesMounts(mounts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("addLibrariesMounts() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(mounts, tt.wantMounts) {
+				t.Errorf("addLibrariesMounts() want %v, got %v", tt.wantMounts, mounts)
 			}
 		})
 	}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1786
 which fixed
- sylabs/singularity# 1782

The original PR description was:
> Support the hidden `--containlibs` flag, and its env var `SINGULARITY_CONTAINLIBS` in `--oci` mode.
> 
> Specified paths are bound into `/.singularity.d/libs` in the container, which is on the container `LD_LIBRARY_PATH`.