### PR TITLE
fix: oci: correct $HOME -> default cwd / passwd handling, from sylabs 1792

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2949,5 +2949,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociOverlayExtfsPerms": (c.actionOciOverlayExtfsPerms), // permissions in writable extfs overlays mounted with FUSE in OCI mode
 		"ociOverlayTeardown":   np(c.actionOciOverlayTeardown), // proper overlay unmounting in OCI mode
 		"ociNo-mount":          c.actionOciNoMount,             // --no-mount in OCI mode
+		"ociHomeCwdPasswd":     c.actionOciHomeCwdPasswd,       // $HOME is correct in /etc/passwd, and is default cwd
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1739,3 +1739,47 @@ func (c actionTests) actionOciNoMount(t *testing.T) {
 		)
 	}
 }
+
+// Check that by default, the container is entered at the correct $HOME for the
+// user, and $HOME in their passwd entry is correct.
+// https://github.com/sylabs/singularity/issues/1791
+func (c actionTests) actionOciHomeCwdPasswd(t *testing.T) {
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+	for _, p := range e2e.OCIProfiles {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(p.String()+"/cwd"),
+			e2e.WithProfile(p),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(imageRef, "pwd"),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.ExactMatch, p.ContainerUser(t).Dir),
+			),
+		)
+
+		cu := p.ContainerUser(t)
+		// Ignore shell field as we use preserve container value. Tested previously.
+		passwdLine := fmt.Sprintf("^%s:x:%d:%d:%s:%s:",
+			cu.Name,
+			cu.UID,
+			cu.GID,
+			cu.Gecos,
+			cu.Dir,
+		)
+
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(p.String()+"/passwd"),
+			e2e.WithProfile(p),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(imageRef, "grep", "^"+cu.Name, "/etc/passwd"),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.RegexMatch, passwdLine),
+			),
+		)
+
+	}
+}

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1747,18 +1747,6 @@ func (c actionTests) actionOciHomeCwdPasswd(t *testing.T) {
 	e2e.EnsureOCIArchive(t, c.env)
 	imageRef := "oci-archive:" + c.env.OCIArchivePath
 	for _, p := range e2e.OCIProfiles {
-		c.env.RunApptainer(
-			t,
-			e2e.AsSubtest(p.String()+"/cwd"),
-			e2e.WithProfile(p),
-			e2e.WithCommand("exec"),
-			e2e.WithArgs(imageRef, "pwd"),
-			e2e.ExpectExit(
-				0,
-				e2e.ExpectOutput(e2e.ExactMatch, p.ContainerUser(t).Dir),
-			),
-		)
-
 		cu := p.ContainerUser(t)
 		// Ignore shell field as we use preserve container value. Tested previously.
 		passwdLine := fmt.Sprintf("^%s:x:%d:%d:%s:%s:",
@@ -1767,6 +1755,18 @@ func (c actionTests) actionOciHomeCwdPasswd(t *testing.T) {
 			cu.GID,
 			cu.Gecos,
 			cu.Dir,
+		)
+
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(p.String()+"/cwd"),
+			e2e.WithProfile(p),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(imageRef, "pwd"),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.ExactMatch, cu.Dir),
+			),
 		)
 
 		c.env.RunApptainer(

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -399,7 +399,7 @@ func (l *Launcher) updatePasswdGroup(rootfs string, uid, gid uint32) error {
 
 	if l.apptainerConf.ConfigPasswd {
 		sylog.Debugf("Updating passwd file: %s", containerPasswd)
-		content, err := files.Passwd(containerPasswd, l.cfg.HomeDir, int(uid), nil)
+		content, err := files.Passwd(containerPasswd, l.homeDest, int(uid), nil)
 		if err != nil {
 			sylog.Warningf("%s", err)
 		} else if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -108,7 +108,7 @@ func (l *Launcher) getProcessCwd() (dir string, err error) {
 		return l.cfg.CwdPath, nil
 	}
 
-	return l.cfg.HomeDir, nil
+	return l.homeDest, nil
 }
 
 // getReverseUserMaps returns uid and gid mappings that re-map container uid to target


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1792
 which fixed
- sylabs/singularity# 17891

The original PR description was:
> In the refactoring performed in [a10b379](https://github.com/sylabs/singularity/commit/a10b379bf8859ee35abca55f31a3576f202df792), the setting of the default CWD, and creation of `/etc/passwd`, was not correctly adapted.
> 
> We need to use our parsed / processed `l.homeDest` value for the container homeDir in all cases. With a nested root-mapped user namespace re-exec, the CLI passed value is not correct unless it is a custom value.
> 
> The first commit adds e2e coverage for this issue. The second commit is the fix.