### PR TITLE
oci: wire up default capabilities, from sylabs 1798

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `--timeout` have been removed.
 - `sessiondir maxsize` in `apptainer.conf` now defaults to 64 MiB for new
   installations. This is an increase from 16 MiB in prior versions.
+- Default OCI config generated with `apptainer mount` no longer sets any
+  inheritable / ambient capabilites, matching other OCI runtimes.
 
 ### New Features & Functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   installations. This is an increase from 16 MiB in prior versions.
 - Default OCI config generated with `apptainer mount` no longer sets any
   inheritable / ambient capabilites, matching other OCI runtimes.
+- In OCI-mode, a container run as root, or with `--fakeroot` has OCI default
+  effective/permitted capabilities.
 
 ### New Features & Functionality
 

--- a/e2e/security/oci.go
+++ b/e2e/security/oci.go
@@ -1,0 +1,87 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package security
+
+import (
+	"testing"
+
+	"github.com/apptainer/apptainer/e2e/internal/e2e"
+)
+
+const (
+	// Default OCI capabilities as visible in /proc/status
+	ociDefaultCapString = "00000020a80425fb"
+	// No capabilities, as visible in /proc/status
+	nullCapString = "0000000000000000"
+)
+
+func (c ctx) ociCapabilities(t *testing.T) {
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	tests := []struct {
+		name       string
+		profile    e2e.Profile
+		expectInh  string
+		expectPrm  string
+		expectEff  string
+		expectBnd  string
+		expectAmb  string
+		expectExit int
+	}{
+		{
+			name:      "DefaultUser",
+			profile:   e2e.OCIUserProfile,
+			expectInh: nullCapString,
+			expectPrm: nullCapString,
+			expectEff: nullCapString,
+			expectBnd: ociDefaultCapString,
+			expectAmb: nullCapString,
+		},
+		{
+			name:      "DefaultRoot",
+			profile:   e2e.OCIRootProfile,
+			expectInh: nullCapString,
+			expectPrm: ociDefaultCapString,
+			expectEff: ociDefaultCapString,
+			expectBnd: ociDefaultCapString,
+			expectAmb: nullCapString,
+		},
+		{
+			name:      "DefaultFakeroot",
+			profile:   e2e.OCIRootProfile,
+			expectInh: nullCapString,
+			expectPrm: ociDefaultCapString,
+			expectEff: ociDefaultCapString,
+			expectBnd: ociDefaultCapString,
+			expectAmb: nullCapString,
+		},
+	}
+
+	e2e.EnsureImage(t, c.env)
+
+	for _, tt := range tests {
+		args := []string{imageRef, "grep", "^Cap...:", "/proc/self/status"}
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(tt.profile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(args...),
+			e2e.ExpectExit(tt.expectExit,
+				e2e.ExpectOutput(e2e.ContainMatch, "CapInh:\t"+tt.expectInh),
+				e2e.ExpectOutput(e2e.ContainMatch, "CapPrm:\t"+tt.expectPrm),
+				e2e.ExpectOutput(e2e.ContainMatch, "CapEff:\t"+tt.expectEff),
+				e2e.ExpectOutput(e2e.ContainMatch, "CapBnd:\t"+tt.expectBnd),
+				e2e.ExpectOutput(e2e.ContainMatch, "CapAmb:\t"+tt.expectAmb),
+			),
+		)
+	}
+}

--- a/e2e/security/security.go
+++ b/e2e/security/security.go
@@ -267,5 +267,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"apptainerSecurityUnpriv":   c.testSecurityUnpriv,
 		"apptainerSecurityPriv":     c.testSecurityPriv,
 		"testSecurityConfOwnership": np(c.testSecurityConfOwnership),
+		// OCI-Mode
+		"ociCapabilities": c.ociCapabilities,
 	}
 }

--- a/internal/pkg/confgen/testdata/test_1.out.correct
+++ b/internal/pkg/confgen/testdata/test_1.out.correct
@@ -200,7 +200,8 @@ always use nv = no
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the apptainer runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/apptainer/capability.json

--- a/internal/pkg/confgen/testdata/test_2.in
+++ b/internal/pkg/confgen/testdata/test_2.in
@@ -200,7 +200,8 @@ always use nv = no
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the apptainer runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/apptainer/capability.json

--- a/internal/pkg/confgen/testdata/test_2.out.correct
+++ b/internal/pkg/confgen/testdata/test_2.out.correct
@@ -200,7 +200,8 @@ always use nv = no
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the apptainer runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/apptainer/capability.json

--- a/internal/pkg/confgen/testdata/test_3.in
+++ b/internal/pkg/confgen/testdata/test_3.in
@@ -191,7 +191,8 @@ always use nv = no
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the apptainer runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/apptainer/capability.json

--- a/internal/pkg/confgen/testdata/test_3.out.correct
+++ b/internal/pkg/confgen/testdata/test_3.out.correct
@@ -200,7 +200,8 @@ always use nv = no
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the apptainer runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/apptainer/capability.json

--- a/internal/pkg/confgen/testdata/test_default.tmpl
+++ b/internal/pkg/confgen/testdata/test_default.tmpl
@@ -211,7 +211,8 @@ always use nv = {{ if eq .AlwaysUseNv true }}yes{{ else }}no{{ end }}
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the apptainer runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/apptainer/capability.json

--- a/internal/pkg/runtime/engine/config/oci/config.go
+++ b/internal/pkg/runtime/engine/config/oci/config.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -19,6 +19,26 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	cseccomp "github.com/seccomp/containers-golang"
 )
+
+// DefaultCaps is the default set of capabilities granted to an OCI container.
+// Ref: https://github.com/opencontainers/runc/blob/main/libcontainer/SPEC.md#security
+var DefaultCaps = []string{
+	"CAP_NET_RAW",
+	"CAP_NET_BIND_SERVICE",
+	"CAP_AUDIT_READ",
+	"CAP_AUDIT_WRITE",
+	"CAP_DAC_OVERRIDE",
+	"CAP_SETFCAP",
+	"CAP_SETPCAP",
+	"CAP_SETGID",
+	"CAP_SETUID",
+	"CAP_MKNOD",
+	"CAP_CHOWN",
+	"CAP_FOWNER",
+	"CAP_FSETID",
+	"CAP_KILL",
+	"CAP_SYS_CHROOT",
+}
 
 // Config is the OCI runtime configuration.
 type Config struct {
@@ -85,86 +105,9 @@ func DefaultConfigV1() (*generate.Generator, error) {
 	}
 
 	config.Process.Capabilities = &specs.LinuxCapabilities{
-		Bounding: []string{
-			"CAP_CHOWN",
-			"CAP_DAC_OVERRIDE",
-			"CAP_FSETID",
-			"CAP_FOWNER",
-			"CAP_MKNOD",
-			"CAP_NET_RAW",
-			"CAP_SETGID",
-			"CAP_SETUID",
-			"CAP_SETFCAP",
-			"CAP_SETPCAP",
-			"CAP_NET_BIND_SERVICE",
-			"CAP_SYS_CHROOT",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Permitted: []string{
-			"CAP_CHOWN",
-			"CAP_DAC_OVERRIDE",
-			"CAP_FSETID",
-			"CAP_FOWNER",
-			"CAP_MKNOD",
-			"CAP_NET_RAW",
-			"CAP_SETGID",
-			"CAP_SETUID",
-			"CAP_SETFCAP",
-			"CAP_SETPCAP",
-			"CAP_NET_BIND_SERVICE",
-			"CAP_SYS_CHROOT",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Inheritable: []string{
-			"CAP_CHOWN",
-			"CAP_DAC_OVERRIDE",
-			"CAP_FSETID",
-			"CAP_FOWNER",
-			"CAP_MKNOD",
-			"CAP_NET_RAW",
-			"CAP_SETGID",
-			"CAP_SETUID",
-			"CAP_SETFCAP",
-			"CAP_SETPCAP",
-			"CAP_NET_BIND_SERVICE",
-			"CAP_SYS_CHROOT",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Effective: []string{
-			"CAP_CHOWN",
-			"CAP_DAC_OVERRIDE",
-			"CAP_FSETID",
-			"CAP_FOWNER",
-			"CAP_MKNOD",
-			"CAP_NET_RAW",
-			"CAP_SETGID",
-			"CAP_SETUID",
-			"CAP_SETFCAP",
-			"CAP_SETPCAP",
-			"CAP_NET_BIND_SERVICE",
-			"CAP_SYS_CHROOT",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Ambient: []string{
-			"CAP_CHOWN",
-			"CAP_DAC_OVERRIDE",
-			"CAP_FSETID",
-			"CAP_FOWNER",
-			"CAP_MKNOD",
-			"CAP_NET_RAW",
-			"CAP_SETGID",
-			"CAP_SETUID",
-			"CAP_SETFCAP",
-			"CAP_SETPCAP",
-			"CAP_NET_BIND_SERVICE",
-			"CAP_SYS_CHROOT",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
+		Bounding:  DefaultCaps,
+		Permitted: DefaultCaps,
+		Effective: DefaultCaps,
 	}
 	config.Mounts = []specs.Mount{
 		{

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -54,24 +54,6 @@ func minimalSpec() specs.Spec {
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	}
 
-	// TODO - these are appropriate minimum for rootless. We need to tie into
-	// Apptainer's cap-add / cap-drop mechanism.
-	config.Process.Capabilities = &specs.LinuxCapabilities{
-		Bounding: []string{
-			"CAP_CHOWN",
-			"CAP_DAC_OVERRIDE",
-			"CAP_FOWNER",
-			"CAP_FSETID",
-			"CAP_KILL",
-			"CAP_NET_BIND_SERVICE",
-			"CAP_SETFCAP",
-			"CAP_SETGID",
-			"CAP_SETPCAP",
-			"CAP_SETUID",
-			"CAP_SYS_CHROOT",
-		},
-	}
-
 	// All mounts are added by the launcher, as it must handle flags.
 	config.Mounts = []specs.Mount{}
 

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -435,7 +435,8 @@ always use rocm = {{ if eq .AlwaysUseRocm true }}yes{{ else }}no{{ end }}
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the apptainer runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/apptainer/capability.json


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1798
 which fixed
- sylabs/singularity# 1587

The original PR description was:
> ### Preparatory commit, for consistency:
> 
> **oci: Don't set inheritable/ambient caps in DefaultConfig**
> 
> The OCI DefaultConfig, used when creating a bundle from a SIF via `singularity oci mount`, no longer sets any inheritable or ambient capabilities. This matches other OCI container runtimes.
> 
> The capability set matches: https://github.com/opencontainers/runc/blob/main/libcontainer/SPEC.md#security
> ### Implementation commit in --oci mode:
> 
> **oci: set default capabilities in --oci mode**
> 
> When running in `--oci` mode, set default capabilities for the container.
> 
> When root inside the container, this means that effective / permitted / bounding match the oci.DefaultCaps set, per the oci runtime spec docs.
> 
> When non-root inside the container, this means that only bounding matches the oci.DefaultCaps set.
> 
> No other capabilities are set. `--oci` mode does not set any inheritable or ambient capabilities, unlike native mode.