### PR TITLE
oci: support --keep-privs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   libraries to bind into `/.singularity.d/libs/` in the container.
 - OCI-mode now supports the `--no-privs` flag to drop all capabilities from the
   container process, and enable the NoNewPrivileges flag.
+- OCI-mode now supports the `--keep-privs` flag to keep effective capabilities
+  for the container process (bounding set only for non-root container users).
 
 ### Developer / API
 

--- a/e2e/security/oci.go
+++ b/e2e/security/oci.go
@@ -10,9 +10,11 @@
 package security
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
+	"github.com/apptainer/apptainer/pkg/util/capabilities"
 )
 
 const (
@@ -25,6 +27,16 @@ const (
 func (c ctx) ociCapabilities(t *testing.T) {
 	e2e.EnsureOCIArchive(t, c.env)
 	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	var rootCaps uint64
+	var err error
+	e2e.Privileged(func(t *testing.T) {
+		rootCaps, err = capabilities.GetProcessEffective()
+		if err != nil {
+			t.Fatalf("Could not get CapEff: %v", err)
+		}
+	})(t)
+	fullCapString := fmt.Sprintf("%0.16x", rootCaps)
 
 	tests := []struct {
 		name       string
@@ -63,6 +75,26 @@ func (c ctx) ociCapabilities(t *testing.T) {
 			expectPrm: nullCapString,
 			expectEff: nullCapString,
 			expectBnd: nullCapString,
+			expectAmb: nullCapString,
+		},
+		{
+			name:      "KeepPrivsUser",
+			options:   []string{"--keep-privs"},
+			profiles:  []e2e.Profile{e2e.OCIUserProfile},
+			expectInh: nullCapString,
+			expectPrm: nullCapString,
+			expectEff: nullCapString,
+			expectBnd: fullCapString,
+			expectAmb: nullCapString,
+		},
+		{
+			name:      "KeepPrivsRoot",
+			options:   []string{"--keep-privs"},
+			profiles:  []e2e.Profile{e2e.OCIRootProfile, e2e.OCIFakerootProfile},
+			expectInh: nullCapString,
+			expectPrm: fullCapString,
+			expectEff: fullCapString,
+			expectBnd: fullCapString,
 			expectAmb: nullCapString,
 		},
 	}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -146,9 +146,6 @@ func checkOpts(lo launcher.Options) error {
 	if lo.AllowSUID {
 		badOpt = append(badOpt, "AllowSUID")
 	}
-	if lo.KeepPrivs {
-		badOpt = append(badOpt, "KeepPrivs")
-	}
 	if len(lo.SecurityOpts) > 0 {
 		badOpt = append(badOpt, "SecurityOpts")
 	}

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -21,6 +21,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/shell/interpreter"
+	"github.com/apptainer/apptainer/pkg/util/capabilities"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/term"
@@ -69,9 +70,14 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, imag
 		noNewPrivs = true
 	}
 
+	caps, err := l.getProcessCapabilities(u.UID)
+	if err != nil {
+		return nil, err
+	}
+
 	p := specs.Process{
 		Args:            getProcessArgs(imgSpec, process, args),
-		Capabilities:    l.getProcessCapabilities(u.UID),
+		Capabilities:    caps,
 		Cwd:             cwd,
 		Env:             getProcessEnv(imgSpec, rtEnv),
 		NoNewPrivileges: noNewPrivs,
@@ -347,9 +353,23 @@ func envFileMap(ctx context.Context, f string) (map[string]string, error) {
 // getProcessCapabilities returns the capabilities that are enabled for the
 // container. These follow OCI specified defaults. A non-root container user has
 // no effective/permitted capabilities.
-func (l *Launcher) getProcessCapabilities(targetUID uint32) *specs.LinuxCapabilities {
+func (l *Launcher) getProcessCapabilities(targetUID uint32) (*specs.LinuxCapabilities, error) {
 	if l.cfg.NoPrivs {
-		return &specs.LinuxCapabilities{}
+		return &specs.LinuxCapabilities{}, nil
+	}
+
+	if l.cfg.KeepPrivs {
+		c, err := capabilities.GetProcessEffective()
+		if err != nil {
+			return nil, err
+		}
+
+		cStr := capabilities.ToStrings(c)
+		return &specs.LinuxCapabilities{
+			Bounding:  cStr,
+			Permitted: cStr,
+			Effective: cStr,
+		}, nil
 	}
 
 	if targetUID == 0 {
@@ -357,10 +377,10 @@ func (l *Launcher) getProcessCapabilities(targetUID uint32) *specs.LinuxCapabili
 			Bounding:  oci.DefaultCaps,
 			Permitted: oci.DefaultCaps,
 			Effective: oci.DefaultCaps,
-		}
+		}, nil
 	}
 
 	return &specs.LinuxCapabilities{
 		Bounding: oci.DefaultCaps,
-	}
+	}, nil
 }

--- a/pkg/util/capabilities/capabilities.go
+++ b/pkg/util/capabilities/capabilities.go
@@ -9,7 +9,10 @@
 
 package capabilities
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 const (
 	// Permitted capability string constant.
@@ -526,4 +529,17 @@ func normalize(capabilities []string) []string {
 		capabilities[i] = capb
 	}
 	return capabilities
+}
+
+// ToStrings returns a list of string CAP_ values from a uint64 capability set.
+// If a capability bit is set that is not in Map, it is ignored.
+func ToStrings(c uint64) []string {
+	s := []string{}
+	for _, cap := range Map {
+		if c&uint64(1<<cap.Value) != 0 {
+			s = append(s, cap.Name)
+		}
+	}
+	sort.Strings(s)
+	return s
 }

--- a/pkg/util/capabilities/capabilities_test.go
+++ b/pkg/util/capabilities/capabilities_test.go
@@ -10,6 +10,7 @@
 package capabilities
 
 import (
+	"reflect"
 	"sort"
 	"testing"
 )
@@ -167,6 +168,37 @@ func TestRemoveDuplicated(t *testing.T) {
 				if tc.expect[i] != actual[i] {
 					t.Fatalf("expected %s at position %d, but got %s", tc.expect[i], i, actual[i])
 				}
+			}
+		})
+	}
+}
+
+func TestToStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		c    uint64
+		want []string
+	}{
+		{
+			name: "Empty",
+			c:    0,
+			want: []string{},
+		},
+		{
+			name: "Single",
+			c:    0x8000000,
+			want: []string{"CAP_MKNOD"},
+		},
+		{
+			name: "Multi",
+			c:    0x8001001,
+			want: []string{"CAP_CHOWN", "CAP_MKNOD", "CAP_NET_ADMIN"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToStrings(tt.c); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ToStrings() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/util/capabilities/process_linux.go
+++ b/pkg/util/capabilities/process_linux.go
@@ -60,6 +60,16 @@ func GetProcessInheritable() (uint64, error) {
 	return uint64(data[0].Inheritable) | uint64(data[1].Inheritable)<<32, nil
 }
 
+// GetProcessBounding returns bounding capabilities for
+// the current process.
+func GetProcessBounding() (uint64, error) {
+	data, err := getProcessCapabilities()
+	if err != nil {
+		return 0, err
+	}
+	return uint64(data[0].Inheritable) | uint64(data[1].Inheritable)<<32, nil
+}
+
 // SetProcessEffective set effective capabilities for the
 // the current process and returns previous effective set.
 func SetProcessEffective(caps uint64) (uint64, error) {


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1803
 which fixed
- sylabs/singularity# 1475

The original PR description was:
> When `--keep-privs` is specified in `--oci` mode, keep effective capabilities on the container process, rather than set the default OCI capabilities.
> 
> Non-root users in the container receive the capabilities in the bounding set only.


