### PR TITLE
oci: Support --add-caps and --drop-caps, from sylabs 1804

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   container process, and enable the NoNewPrivileges flag.
 - OCI-mode now supports the `--keep-privs` flag to keep effective capabilities
   for the container process (bounding set only for non-root container users).
+- OCI-mode now supports the `--add-caps` and `--drop-caps` flags to modify
+  capabilities of the container process.
 
 ### Developer / API
 

--- a/e2e/security/oci.go
+++ b/e2e/security/oci.go
@@ -20,6 +20,11 @@ import (
 const (
 	// Default OCI capabilities as visible in /proc/status
 	ociDefaultCapString = "00000020a80425fb"
+	// DefaultOCI capabilities with CAP_CHOWN dropped
+	ociDropChownString = "00000020a80425fa"
+	// DefaultOCI capabilities with CAP_SYS_ADMIN added
+	ociAddSysAdminString = "00000020a82425fb"
+	capSysAdminString    = "0000000000200000"
 	// No capabilities, as visible in /proc/status
 	nullCapString = "0000000000000000"
 )
@@ -95,6 +100,46 @@ func (c ctx) ociCapabilities(t *testing.T) {
 			expectPrm: fullCapString,
 			expectEff: fullCapString,
 			expectBnd: fullCapString,
+			expectAmb: nullCapString,
+		},
+		{
+			name:      "DropChownUser",
+			options:   []string{"--drop-caps", "CAP_CHOWN"},
+			profiles:  []e2e.Profile{e2e.OCIUserProfile},
+			expectInh: nullCapString,
+			expectPrm: nullCapString,
+			expectEff: nullCapString,
+			expectBnd: ociDropChownString,
+			expectAmb: nullCapString,
+		},
+		{
+			name:      "DropChownRoot",
+			options:   []string{"--drop-caps", "CAP_CHOWN"},
+			profiles:  []e2e.Profile{e2e.OCIRootProfile, e2e.OCIFakerootProfile},
+			expectInh: nullCapString,
+			expectPrm: ociDropChownString,
+			expectEff: ociDropChownString,
+			expectBnd: ociDropChownString,
+			expectAmb: nullCapString,
+		},
+		{
+			name:      "AddSysAdminUser",
+			options:   []string{"--add-caps", "CAP_SYS_ADMIN"},
+			profiles:  []e2e.Profile{e2e.OCIUserProfile},
+			expectInh: capSysAdminString,
+			expectPrm: capSysAdminString,
+			expectEff: capSysAdminString,
+			expectBnd: ociAddSysAdminString,
+			expectAmb: capSysAdminString,
+		},
+		{
+			name:      "AddSysAdminRoot",
+			options:   []string{"--add-caps", "CAP_SYS_ADMIN"},
+			profiles:  []e2e.Profile{e2e.OCIRootProfile, e2e.OCIFakerootProfile},
+			expectInh: nullCapString,
+			expectPrm: ociAddSysAdminString,
+			expectEff: ociAddSysAdminString,
+			expectBnd: ociAddSysAdminString,
 			expectAmb: nullCapString,
 		},
 	}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -137,12 +137,6 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "NetworkArgs")
 	}
 
-	if lo.AddCaps != "" {
-		badOpt = append(badOpt, "AddCaps")
-	}
-	if lo.DropCaps != "" {
-		badOpt = append(badOpt, "DropCaps")
-	}
 	if lo.AllowSUID {
 		badOpt = append(badOpt, "AllowSUID")
 	}

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -21,9 +21,11 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/shell/interpreter"
+	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/capabilities"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/samber/lo"
 	"golang.org/x/term"
 )
 
@@ -350,12 +352,11 @@ func envFileMap(ctx context.Context, f string) (map[string]string, error) {
 	return envMap, nil
 }
 
-// getProcessCapabilities returns the capabilities that are enabled for the
-// container. These follow OCI specified defaults. A non-root container user has
-// no effective/permitted capabilities.
-func (l *Launcher) getProcessCapabilities(targetUID uint32) (*specs.LinuxCapabilities, error) {
+// getBaseCapabilities returns the capabilities that are enabled for the user
+// prior to processing AddCaps / DropCaps.
+func (l *Launcher) getBaseCapabilities() ([]string, error) {
 	if l.cfg.NoPrivs {
-		return &specs.LinuxCapabilities{}, nil
+		return []string{}, nil
 	}
 
 	if l.cfg.KeepPrivs {
@@ -364,23 +365,53 @@ func (l *Launcher) getProcessCapabilities(targetUID uint32) (*specs.LinuxCapabil
 			return nil, err
 		}
 
-		cStr := capabilities.ToStrings(c)
-		return &specs.LinuxCapabilities{
-			Bounding:  cStr,
-			Permitted: cStr,
-			Effective: cStr,
-		}, nil
+		return capabilities.ToStrings(c), nil
 	}
 
+	return oci.DefaultCaps, nil
+}
+
+// getProcessCapabilities returns the capabilities that are enabled for the
+// user, after applying all capabilities related options.
+func (l *Launcher) getProcessCapabilities(targetUID uint32) (*specs.LinuxCapabilities, error) {
+	caps, err := l.getBaseCapabilities()
+	if err != nil {
+		return nil, err
+	}
+
+	addCaps, ignoredCaps := capabilities.Split(l.cfg.AddCaps)
+	if len(ignoredCaps) > 0 {
+		sylog.Warningf("Ignoring unknown --add-caps: %s", strings.Join(ignoredCaps, ","))
+	}
+
+	dropCaps, ignoredCaps := capabilities.Split(l.cfg.DropCaps)
+	if len(ignoredCaps) > 0 {
+		sylog.Warningf("Ignoring unknown --drop-caps: %s", strings.Join(ignoredCaps, ","))
+	}
+
+	caps = append(caps, addCaps...)
+	caps = capabilities.RemoveDuplicated(caps)
+	caps = lo.Without(caps, dropCaps...)
+
+	// If root inside the container, Permitted==Effective==Bounding.
 	if targetUID == 0 {
 		return &specs.LinuxCapabilities{
-			Bounding:  oci.DefaultCaps,
-			Permitted: oci.DefaultCaps,
-			Effective: oci.DefaultCaps,
+			Permitted:   caps,
+			Effective:   caps,
+			Bounding:    caps,
+			Inheritable: []string{},
+			Ambient:     []string{},
 		}, nil
 	}
 
+	// If non-root inside the container, Permitted/Effective/Inheritable/Ambient
+	// are only the explicitly requested capabilities.
+	explicitCaps := lo.Without(addCaps, dropCaps...)
 	return &specs.LinuxCapabilities{
-		Bounding: oci.DefaultCaps,
+		Permitted:   explicitCaps,
+		Effective:   explicitCaps,
+		Bounding:    caps,
+		Inheritable: explicitCaps,
+		Ambient:     explicitCaps,
 	}, nil
 }

--- a/internal/pkg/runtime/launcher/oci/process_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux_test.go
@@ -16,8 +16,12 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci"
+	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
+	"github.com/apptainer/apptainer/pkg/util/capabilities"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/samber/lo"
 )
 
 func TestApptainerEnvMap(t *testing.T) {
@@ -436,6 +440,211 @@ func TestLauncher_reverseMapByRange(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotGIDMap, tt.wantGIDMap) {
 				t.Errorf("Launcher.getReverseUserMaps() gotGidMap = %v, want %v", gotGIDMap, tt.wantGIDMap)
+			}
+		})
+	}
+}
+
+func TestLauncher_getBaseCapabilities(t *testing.T) {
+	currCaps, err := capabilities.GetProcessEffective()
+	if err != nil {
+		t.Fatal(err)
+	}
+	currCapStrings := capabilities.ToStrings(currCaps)
+
+	tests := []struct {
+		name      string
+		keepPrivs bool
+		noPrivs   bool
+		want      []string
+		wantErr   bool
+	}{
+		{
+			name:      "Default",
+			keepPrivs: false,
+			noPrivs:   false,
+			want:      oci.DefaultCaps,
+			wantErr:   false,
+		},
+		{
+			name:      "NoPrivs",
+			keepPrivs: false,
+			noPrivs:   true,
+			want:      []string{},
+			wantErr:   false,
+		},
+		{
+			name:      "NoPrivsPrecendence",
+			keepPrivs: true,
+			noPrivs:   true,
+			want:      []string{},
+			wantErr:   false,
+		},
+		{
+			name:      "KeepPrivs",
+			keepPrivs: true,
+			noPrivs:   false,
+			want:      currCapStrings,
+			wantErr:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &Launcher{
+				cfg: launcher.Options{
+					KeepPrivs: tt.keepPrivs,
+					NoPrivs:   tt.noPrivs,
+				},
+			}
+			got, err := l.getBaseCapabilities()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Launcher.getBaseCapabilities() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Launcher.getBaseCapabilities() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLauncher_getProcessCapabilities(t *testing.T) {
+	tests := []struct {
+		name     string
+		addCaps  string
+		dropCaps string
+		uid      uint32
+		want     *specs.LinuxCapabilities
+		wantErr  bool
+	}{
+		{
+			name:     "DefaultRoot",
+			addCaps:  "",
+			dropCaps: "",
+			uid:      0,
+			want: &specs.LinuxCapabilities{
+				Permitted:   oci.DefaultCaps,
+				Effective:   oci.DefaultCaps,
+				Bounding:    oci.DefaultCaps,
+				Inheritable: []string{},
+				Ambient:     []string{},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "DefaultUser",
+			addCaps:  "",
+			dropCaps: "",
+			uid:      1000,
+			want: &specs.LinuxCapabilities{
+				Permitted:   []string{},
+				Effective:   []string{},
+				Bounding:    oci.DefaultCaps,
+				Inheritable: []string{},
+				Ambient:     []string{},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "AddRoot",
+			addCaps:  "CAP_SYSLOG,CAP_WAKE_ALARM",
+			dropCaps: "",
+			uid:      0,
+			want: &specs.LinuxCapabilities{
+				Permitted:   append(oci.DefaultCaps, "CAP_SYSLOG", "CAP_WAKE_ALARM"),
+				Effective:   append(oci.DefaultCaps, "CAP_SYSLOG", "CAP_WAKE_ALARM"),
+				Bounding:    append(oci.DefaultCaps, "CAP_SYSLOG", "CAP_WAKE_ALARM"),
+				Inheritable: []string{},
+				Ambient:     []string{},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "DropRoot",
+			addCaps:  "",
+			dropCaps: "CAP_SETUID,CAP_SETGID",
+			uid:      0,
+			want: &specs.LinuxCapabilities{
+				Permitted:   lo.Without(oci.DefaultCaps, "CAP_SETUID", "CAP_SETGID"),
+				Effective:   lo.Without(oci.DefaultCaps, "CAP_SETUID", "CAP_SETGID"),
+				Bounding:    lo.Without(oci.DefaultCaps, "CAP_SETUID", "CAP_SETGID"),
+				Inheritable: []string{},
+				Ambient:     []string{},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "AddUser",
+			addCaps:  "CAP_SYSLOG,CAP_WAKE_ALARM",
+			dropCaps: "",
+			uid:      1000,
+			want: &specs.LinuxCapabilities{
+				Permitted:   []string{"CAP_SYSLOG", "CAP_WAKE_ALARM"},
+				Effective:   []string{"CAP_SYSLOG", "CAP_WAKE_ALARM"},
+				Bounding:    append(oci.DefaultCaps, "CAP_SYSLOG", "CAP_WAKE_ALARM"),
+				Inheritable: []string{"CAP_SYSLOG", "CAP_WAKE_ALARM"},
+				Ambient:     []string{"CAP_SYSLOG", "CAP_WAKE_ALARM"},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "DropUser",
+			addCaps:  "",
+			dropCaps: "CAP_SETUID,CAP_SETGID",
+			uid:      1000,
+			want: &specs.LinuxCapabilities{
+				Permitted:   []string{},
+				Effective:   []string{},
+				Bounding:    lo.Without(oci.DefaultCaps, "CAP_SETUID", "CAP_SETGID"),
+				Inheritable: []string{},
+				Ambient:     []string{},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "AddDropRoot",
+			addCaps:  "CAP_SYSLOG,CAP_WAKE_ALARM",
+			dropCaps: "CAP_SETUID,CAP_SETGID",
+			uid:      0,
+			want: &specs.LinuxCapabilities{
+				Permitted:   lo.Without(append(oci.DefaultCaps, "CAP_SYSLOG", "CAP_WAKE_ALARM"), "CAP_SETUID", "CAP_SETGID"),
+				Effective:   lo.Without(append(oci.DefaultCaps, "CAP_SYSLOG", "CAP_WAKE_ALARM"), "CAP_SETUID", "CAP_SETGID"),
+				Bounding:    lo.Without(append(oci.DefaultCaps, "CAP_SYSLOG", "CAP_WAKE_ALARM"), "CAP_SETUID", "CAP_SETGID"),
+				Inheritable: []string{},
+				Ambient:     []string{},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "AddDropUser",
+			addCaps:  "CAP_SYSLOG,CAP_WAKE_ALARM",
+			dropCaps: "CAP_SETUID,CAP_SETGID",
+			uid:      1000,
+			want: &specs.LinuxCapabilities{
+				Permitted:   []string{"CAP_SYSLOG", "CAP_WAKE_ALARM"},
+				Effective:   []string{"CAP_SYSLOG", "CAP_WAKE_ALARM"},
+				Bounding:    lo.Without(append(oci.DefaultCaps, "CAP_SYSLOG", "CAP_WAKE_ALARM"), "CAP_SETUID", "CAP_SETGID"),
+				Inheritable: []string{"CAP_SYSLOG", "CAP_WAKE_ALARM"},
+				Ambient:     []string{"CAP_SYSLOG", "CAP_WAKE_ALARM"},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &Launcher{
+				cfg: launcher.Options{
+					AddCaps:  tt.addCaps,
+					DropCaps: tt.dropCaps,
+				},
+			}
+			got, err := l.getProcessCapabilities(tt.uid)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Launcher.getProcessCapabilities() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Launcher.getProcessCapabilities() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1804
 which fixed
- sylabs/singularity# 1468

The original PR description was:
> Add support for --add-caps and --drop-caps to modify the capabilities of the container process.
> 
> When the container user is root, these modify the permitted/effective/bounding sets.
> 
> When the container user is non-root, the bounding set is modified, and any explicit add-caps are added to the permitted/effective/inheritable/ambient sets.


