### PR TITLE
chore: refactor OCI fetch/extraction code, from sylabs 1871

### DIFF
--- a/internal/pkg/build/oci/fetch.go
+++ b/internal/pkg/build/oci/fetch.go
@@ -1,0 +1,194 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/apptainer/apptainer/internal/pkg/cache"
+	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/docker"
+	dockerarchive "github.com/containers/image/v5/docker/archive"
+	dockerdaemon "github.com/containers/image/v5/docker/daemon"
+	ociarchive "github.com/containers/image/v5/oci/archive"
+	ocilayout "github.com/containers/image/v5/oci/layout"
+	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/types"
+)
+
+// FetchLayout will fetch the OCI image specified by imageRef to a containers/image OCI layout in layoutDir.
+// An ImageReference to the image that was fetched into layoutDir is returned on success.
+// If imgCache is non-nil, and enabled, the image will be pulled through the cache.
+func FetchLayout(ctx context.Context, sysCtx *types.SystemContext, imgCache *cache.Handle, imageRef, layoutDir string) (layoutRef types.ImageReference, err error) {
+	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+	policyCtx, err := signature.NewPolicyContext(policy)
+	if err != nil {
+		return nil, err
+	}
+
+	parts := strings.SplitN(imageRef, ":", 2)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("could not parse image ref: %s", imageRef)
+	}
+	var srcRef types.ImageReference
+
+	switch parts[0] {
+	case "docker":
+		srcRef, err = docker.ParseReference(parts[1])
+	case "docker-archive":
+		srcRef, err = dockerarchive.ParseReference(parts[1])
+	case "docker-daemon":
+		srcRef, err = dockerdaemon.ParseReference(parts[1])
+	case "oci":
+		srcRef, err = ocilayout.ParseReference(parts[1])
+	case "oci-archive":
+		if os.Geteuid() == 0 {
+			// As root, the direct oci-archive handling will work
+			srcRef, err = ociarchive.ParseReference(parts[1])
+		} else {
+			// As non-root we need to do a dumb tar extraction first
+			var tmpDir string
+			tmpDir, err = os.MkdirTemp(sysCtx.BigFilesTemporaryDir, "temp-oci-")
+			if err != nil {
+				return nil, fmt.Errorf("could not create temporary oci directory: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			archiveParts := strings.SplitN(parts[1], ":", 2)
+			sylog.Debugf("Extracting oci-archive %q to %q", archiveParts[0], tmpDir)
+			err = extractArchive(archiveParts[0], tmpDir)
+			if err != nil {
+				return nil, fmt.Errorf("error extracting the OCI archive file: %v", err)
+			}
+			// We may or may not have had a ':tag' in the source to handle
+			if len(archiveParts) == 2 {
+				srcRef, err = ocilayout.ParseReference(tmpDir + ":" + archiveParts[1])
+			} else {
+				srcRef, err = ocilayout.ParseReference(tmpDir)
+			}
+		}
+	default:
+		return nil, fmt.Errorf("cannot create an OCI container from %s source", parts[0])
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("invalid image source: %v", err)
+	}
+
+	if imgCache != nil {
+		// Grab the modified source ref from the cache
+		srcRef, err = ConvertReference(ctx, imgCache, srcRef, sysCtx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	lr, err := ocilayout.ParseReference(layoutDir + ":apptainer")
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = copy.Image(ctx, policyCtx, lr, srcRef, &copy.Options{
+		ReportWriter: io.Discard,
+		SourceCtx:    sysCtx,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return lr, nil
+}
+
+// Perform a dumb tar(gz) extraction with no chown, id remapping etc.
+// This is needed for non-root handling of `oci-archive` as the extraction
+// by containers/archive is failing when uid/gid don't match local machine
+// and we're not root
+func extractArchive(src string, dst string) error {
+	f, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	r := bufio.NewReader(f)
+	header, err := r.Peek(10) // read a few bytes without consuming
+	if err != nil {
+		return err
+	}
+	gzipped := strings.Contains(http.DetectContentType(header), "x-gzip")
+
+	if gzipped {
+		r, err := gzip.NewReader(f)
+		if err != nil {
+			return err
+		}
+		defer r.Close()
+	}
+
+	tr := tar.NewReader(r)
+
+	for {
+		header, err := tr.Next()
+
+		switch {
+
+		// if no more files are found return
+		case err == io.EOF:
+			return nil
+
+		// return any other error
+		case err != nil:
+			return err
+
+		// if the header is nil, just skip it (not sure how this happens)
+		case header == nil:
+			continue
+		}
+
+		// ZipSlip protection - don't escape from dst
+		target := filepath.Join(dst, header.Name)
+		if !strings.HasPrefix(target, filepath.Clean(dst)+string(os.PathSeparator)) {
+			return fmt.Errorf("%s: illegal extraction path", target)
+		}
+
+		// check the file type
+		switch header.Typeflag {
+		// if its a dir and it doesn't exist create it
+		case tar.TypeDir:
+			if _, err := os.Stat(target); err != nil {
+				if err := os.MkdirAll(target, 0o755); err != nil {
+					return err
+				}
+			}
+		// if it's a file create it
+		case tar.TypeReg:
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			// copy over contents
+			if _, err := io.Copy(f, tr); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/build/oci/unpack.go
+++ b/internal/pkg/build/oci/unpack.go
@@ -2,38 +2,32 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-// TODO(ian): The build package should be refactored to make each conveyorpacker
-// its own separate package. With that change, this file should be grouped with the
-// OCIConveyorPacker code
-
-package sources
+package oci
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 
 	apexlog "github.com/apex/log"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
-	sytypes "github.com/apptainer/apptainer/pkg/build/types"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/namespaces"
-	"github.com/containers/image/v5/types"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/umoci"
 	umocilayer "github.com/opencontainers/umoci/oci/layer"
 	"github.com/opencontainers/umoci/pkg/idtools"
 )
 
-// unpackRootfs extracts all of the layers of the given image reference into the rootfs of the provided bundle
-func unpackRootfs(ctx context.Context, b *sytypes.Bundle, tmpfsRef types.ImageReference, sysCtx *types.SystemContext) (err error) {
+// UnpackRootfs extracts all of the layers of the given image manifest from an
+// OCI layout into rootfsDir.
+func UnpackRootfs(ctx context.Context, layoutDir string, manifest imgspecv1.Manifest, destDir string) (err error) {
 	var mapOptions umocilayer.MapOptions
 
 	loggerLevel := sylog.GetLevel()
@@ -71,60 +65,29 @@ func unpackRootfs(ctx context.Context, b *sytypes.Bundle, tmpfsRef types.ImageRe
 		mapOptions.GIDMappings = append(mapOptions.GIDMappings, gidMap)
 	}
 
-	engineExt, err := umoci.OpenLayout(b.TmpDir)
+	engineExt, err := umoci.OpenLayout(layoutDir)
 	if err != nil {
 		return fmt.Errorf("error opening layout: %s", err)
 	}
 
-	// Obtain the manifest
-	imageSource, err := tmpfsRef.NewImageSource(ctx, sysCtx)
-	if err != nil {
-		return fmt.Errorf("error creating image source: %s", err)
-	}
-	manifestData, mediaType, err := imageSource.GetManifest(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("error obtaining manifest source: %s", err)
-	}
-	if mediaType != imgspecv1.MediaTypeImageManifest {
-		return fmt.Errorf("error verifying manifest media type: %s", mediaType)
-	}
-	var manifest imgspecv1.Manifest
-	json.Unmarshal(manifestData, &manifest)
-
 	// UnpackRootfs from umoci v0.4.2 expects a path to a non-existing directory
-	os.RemoveAll(b.RootfsPath)
+	os.RemoveAll(destDir)
 
 	// Unpack root filesystem
 	unpackOptions := umocilayer.UnpackOptions{MapOptions: mapOptions}
-	err = umocilayer.UnpackRootfs(ctx, engineExt, b.RootfsPath, manifest, &unpackOptions)
+	err = umocilayer.UnpackRootfs(ctx, engineExt, destDir, manifest, &unpackOptions)
 	if err != nil {
 		return fmt.Errorf("error unpacking rootfs: %s", err)
-	}
-
-	// If the `--fix-perms` flag was used, then modify the permissions so that
-	// content has owner rwX and we're done
-	if b.Opts.FixPerms {
-		sylog.Warningf("The --fix-perms option modifies the filesystem permissions on the resulting container.")
-		sylog.Debugf("Modifying permissions for file/directory owners")
-		return sytypes.FixPerms(b.RootfsPath)
-	}
-
-	// If `--fix-perms` was not used and this is a sandbox, scan for restrictive
-	// perms that would stop the user doing an `rm` without a chmod first,
-	// and warn if they exist
-	if b.Opts.SandboxTarget {
-		sylog.Debugf("Scanning for restrictive permissions")
-		return checkPerms(b.RootfsPath)
 	}
 
 	// No `--fix-perms` and no sandbox... we are fine
 	return err
 }
 
-// checkPerms will work through the rootfs of this bundle, and find if any
+// CheckPerms will work through the rootfs of this bundle, and find if any
 // directory does not have owner rwX - which may cause unexpected issues for a
 // user trying to look through, or delete a sandbox
-func checkPerms(rootfs string) (err error) {
+func CheckPerms(rootfs string) (err error) {
 	// This is a locally defined error we can bubble up to cancel our recursive
 	// structure.
 	errRestrictivePerm := errors.New("restrictive file permission found")

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -11,15 +11,10 @@
 package sources
 
 import (
-	"archive/tar"
-	"bufio"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -27,19 +22,13 @@ import (
 	"text/template"
 
 	"github.com/apptainer/apptainer/internal/pkg/build/oci"
+	"github.com/apptainer/apptainer/internal/pkg/cache"
 	"github.com/apptainer/apptainer/internal/pkg/util/shell"
 	sytypes "github.com/apptainer/apptainer/pkg/build/types"
 	"github.com/apptainer/apptainer/pkg/image"
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
-	"github.com/containers/image/v5/copy"
-	"github.com/containers/image/v5/docker"
-	dockerarchive "github.com/containers/image/v5/docker/archive"
-	dockerdaemon "github.com/containers/image/v5/docker/daemon"
-	ociarchive "github.com/containers/image/v5/oci/archive"
-	ocilayout "github.com/containers/image/v5/oci/layout"
-	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -132,8 +121,6 @@ exec "$@"
 type OCIConveyorPacker struct {
 	srcRef    types.ImageReference
 	b         *sytypes.Bundle
-	tmpfsRef  types.ImageReference
-	policyCtx *signature.PolicyContext
 	imgConfig imgspecv1.ImageConfig
 	sysCtx    *types.SystemContext
 }
@@ -141,12 +128,6 @@ type OCIConveyorPacker struct {
 // Get downloads container information from the specified source
 func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err error) {
 	cp.b = b
-
-	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
-	cp.policyCtx, err = signature.NewPolicyContext(policy)
-	if err != nil {
-		return err
-	}
 
 	// DockerInsecureSkipTLSVerify is set only if --no-https is specified to honor
 	// configuration from /etc/containers/registries.conf because DockerInsecureSkipTLSVerify
@@ -177,7 +158,7 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		cp.sysCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(true)
 	}
 
-	// add registry and namespace to reference if specified
+	// Add registry and namespace to image reference if specified
 	ref := b.Recipe.Header["from"]
 	if b.Recipe.Header["namespace"] != "" {
 		ref = b.Recipe.Header["namespace"] + "/" + ref
@@ -185,71 +166,20 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 	if b.Recipe.Header["registry"] != "" {
 		ref = b.Recipe.Header["registry"] + "/" + ref
 	}
-	sylog.Debugf("Reference: %v", ref)
-
-	switch b.Recipe.Header["bootstrap"] {
-	case "docker":
+	// Docker sources are docker://<from>, not docker:<from>
+	if b.Recipe.Header["bootstrap"] == "docker" {
 		ref = "//" + ref
-		cp.srcRef, err = docker.ParseReference(ref)
-	case "docker-archive":
-		cp.srcRef, err = dockerarchive.ParseReference(ref)
-	case "docker-daemon":
-		cp.srcRef, err = dockerdaemon.ParseReference(ref)
-	case "oci":
-		cp.srcRef, err = ocilayout.ParseReference(ref)
-	case "oci-archive":
-		if os.Geteuid() == 0 {
-			// As root, the direct oci-archive handling will work
-			cp.srcRef, err = ociarchive.ParseReference(ref)
-		} else {
-			// As non-root we need to do a dumb tar extraction first
-			tmpDir, err := os.MkdirTemp(b.TmpDir, "temp-oci-")
-			if err != nil {
-				return fmt.Errorf("could not create temporary oci directory: %v", err)
-			}
-			defer os.RemoveAll(tmpDir)
-
-			refParts := strings.SplitN(b.Recipe.Header["from"], ":", 2)
-			err = cp.extractArchive(refParts[0], tmpDir)
-			if err != nil {
-				return fmt.Errorf("error extracting the OCI archive file: %v", err)
-			}
-			// We may or may not have had a ':tag' in the source to handle
-			if len(refParts) == 2 {
-				cp.srcRef, err = ocilayout.ParseReference(tmpDir + ":" + refParts[1])
-			} else {
-				cp.srcRef, err = ocilayout.ParseReference(tmpDir)
-			}
-
-			if err != nil {
-				return fmt.Errorf("error parsing reference: %v", err)
-			}
-		}
-
-	default:
-		return fmt.Errorf("oci conveyorPacker does not support %s", b.Recipe.Header["bootstrap"])
 	}
+	// Prefix bootstrap type to image reference
+	ref = b.Recipe.Header["bootstrap"] + ":" + ref
 
-	if err != nil {
-		return fmt.Errorf("invalid image source: %v", err)
-	}
-
+	var imgCache *cache.Handle
 	if !cp.b.Opts.NoCache {
-		// Grab the modified source ref from the cache
-		cp.srcRef, err = oci.ConvertReference(ctx, b.Opts.ImgCache, cp.srcRef, cp.sysCtx)
-		if err != nil {
-			return fmt.Errorf("while converting reference: %w", err)
-		}
+		imgCache = cp.b.Opts.ImgCache
 	}
 
-	// To to do the RootFS extraction we also have to have a location that
-	// contains *only* this image
-	cp.tmpfsRef, err = ocilayout.ParseReference(cp.b.TmpDir + ":" + "tmp")
-	if err != nil {
-		return fmt.Errorf("while parsing reference: %w", err)
-	}
-
-	err = cp.fetch(ctx)
+	// Fetch the image into a temporary containers/image oci layout dir.
+	cp.srcRef, err = oci.FetchLayout(ctx, cp.sysCtx, imgCache, ref, b.TmpDir)
 	if err != nil {
 		return fmt.Errorf("while fetching image: %w", err)
 	}
@@ -297,15 +227,6 @@ func (cp *OCIConveyorPacker) Pack(ctx context.Context) (*sytypes.Bundle, error) 
 	return cp.b, nil
 }
 
-func (cp *OCIConveyorPacker) fetch(ctx context.Context) error {
-	// cp.srcRef contains the cache source reference
-	_, err := copy.Image(ctx, cp.policyCtx, cp.tmpfsRef, cp.srcRef, &copy.Options{
-		ReportWriter: io.Discard,
-		SourceCtx:    cp.sysCtx,
-	})
-	return err
-}
-
 func (cp *OCIConveyorPacker) getConfig(ctx context.Context) (imgspecv1.ImageConfig, error) {
 	img, err := cp.srcRef.NewImage(ctx, cp.sysCtx)
 	if err != nil {
@@ -330,85 +251,42 @@ func (cp *OCIConveyorPacker) insertOCIConfig() error {
 	return nil
 }
 
-// Perform a dumb tar(gz) extraction with no chown, id remapping etc.
-// This is needed for non-root handling of `oci-archive` as the extraction
-// by containers/archive is failing when uid/gid don't match local machine
-// and we're not root
-func (cp *OCIConveyorPacker) extractArchive(src string, dst string) error {
-	f, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	r := bufio.NewReader(f)
-	header, err := r.Peek(10) // read a few bytes without consuming
-	if err != nil {
-		return err
-	}
-	gzipped := strings.Contains(http.DetectContentType(header), "x-gzip")
-
-	if gzipped {
-		r, err := gzip.NewReader(f)
-		if err != nil {
-			return err
-		}
-		defer r.Close()
-	}
-
-	tr := tar.NewReader(r)
-
-	for {
-		header, err := tr.Next()
-
-		switch {
-
-		// if no more files are found return
-		case err == io.EOF:
-			return nil
-
-		// return any other error
-		case err != nil:
-			return err
-
-		// if the header is nil, just skip it (not sure how this happens)
-		case header == nil:
-			continue
-		}
-
-		// ZipSlip protection - don't escape from dst
-		target := filepath.Join(dst, header.Name)
-		if !strings.HasPrefix(target, filepath.Clean(dst)+string(os.PathSeparator)) {
-			return fmt.Errorf("%s: illegal extraction path", target)
-		}
-
-		// check the file type
-		switch header.Typeflag {
-		// if its a dir and it doesn't exist create it
-		case tar.TypeDir:
-			if _, err := os.Stat(target); err != nil {
-				if err := os.MkdirAll(target, 0o755); err != nil {
-					return err
-				}
-			}
-		// if it's a file create it
-		case tar.TypeReg:
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-
-			// copy over contents
-			if _, err := io.Copy(f, tr); err != nil {
-				return err
-			}
-		}
-	}
-}
-
 func (cp *OCIConveyorPacker) unpackTmpfs(ctx context.Context) error {
-	return unpackRootfs(ctx, cp.b, cp.tmpfsRef, cp.sysCtx)
+	imageSource, err := cp.srcRef.NewImageSource(ctx, cp.sysCtx)
+	if err != nil {
+		return fmt.Errorf("error creating image source: %s", err)
+	}
+	manifestData, mediaType, err := imageSource.GetManifest(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("error obtaining manifest source: %s", err)
+	}
+	if mediaType != imgspecv1.MediaTypeImageManifest {
+		return fmt.Errorf("error verifying manifest media type: %s", mediaType)
+	}
+	var manifest imgspecv1.Manifest
+	json.Unmarshal(manifestData, &manifest)
+
+	if err := oci.UnpackRootfs(ctx, cp.b.TmpDir, manifest, cp.b.RootfsPath); err != nil {
+		return err
+	}
+
+	// If the `--fix-perms` flag was used, then modify the permissions so that
+	// content has owner rwX and we're done
+	if cp.b.Opts.FixPerms {
+		sylog.Warningf("The --fix-perms option modifies the filesystem permissions on the resulting container.")
+		sylog.Debugf("Modifying permissions for file/directory owners")
+		return sytypes.FixPerms(cp.b.RootfsPath)
+	}
+
+	// If `--fix-perms` was not used and this is a sandbox, scan for restrictive
+	// perms that would stop the user doing an `rm` without a chmod first,
+	// and warn if they exist
+	if cp.b.Opts.SandboxTarget {
+		sylog.Debugf("Scanning for restrictive permissions")
+		return oci.CheckPerms(cp.b.RootfsPath)
+	}
+
+	return nil
 }
 
 func (cp *OCIConveyorPacker) insertBaseEnv() (err error) {

--- a/pkg/ocibundle/native/bundle_linux.go
+++ b/pkg/ocibundle/native/bundle_linux.go
@@ -15,29 +15,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
-	apexlog "github.com/apex/log"
 	"github.com/apptainer/apptainer/internal/pkg/build/oci"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/apptainer/apptainer/pkg/ocibundle"
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
 	"github.com/apptainer/apptainer/pkg/sylog"
-	"github.com/containers/image/v5/copy"
-	"github.com/containers/image/v5/docker"
-	dockerarchive "github.com/containers/image/v5/docker/archive"
-	dockerdaemon "github.com/containers/image/v5/docker/daemon"
-	ociarchive "github.com/containers/image/v5/oci/archive"
-	ocilayout "github.com/containers/image/v5/oci/layout"
-	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/opencontainers/umoci"
-	umocilayer "github.com/opencontainers/umoci/oci/layer"
-	"github.com/opencontainers/umoci/pkg/idtools"
 )
 
 // Bundle is a native OCI bundle, created from imageRef.
@@ -127,16 +115,19 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 		return fmt.Errorf("failed to generate OCI bundle/config: %s", err)
 	}
 
-	// Get a reference to an OCI layout source for the image. If the cache is
-	// enabled, we pull through the blob cache layout, otherwise there will be a
-	// temp dir and image Copy to it.
-	layoutRef, layoutDir, cleanup, err := b.fetchLayout(ctx)
+	// Get a reference to an OCI layout source for the image, fetching the image
+	// through the cache if it is enabled.
+	tmpDir, err := os.MkdirTemp("", "oci-tmp")
 	if err != nil {
 		return err
 	}
-	if cleanup != nil {
-		defer cleanup()
+	defer os.RemoveAll(tmpDir)
+
+	layoutRef, err := oci.FetchLayout(ctx, b.sysCtx, b.imgCache, b.imageRef, tmpDir)
+	if err != nil {
+		return err
 	}
+
 	sylog.Debugf("Original imgref: %s, OCI layout: %s", b.imageRef, transports.ImageName(layoutRef))
 
 	// Get the Image Manifest and ImageSpec
@@ -164,7 +155,7 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 	}
 
 	// Extract from temp oci layout into bundle rootfs
-	if err := b.extractImage(ctx, layoutDir, manifest); err != nil {
+	if err := oci.UnpackRootfs(ctx, tmpDir, manifest, tools.RootFs(b.bundlePath).Path()); err != nil {
 		return err
 	}
 	return b.writeConfig(g)
@@ -192,137 +183,4 @@ func (b *Bundle) Path() string {
 
 func (b *Bundle) writeConfig(g *generate.Generator) error {
 	return tools.SaveBundleConfig(b.bundlePath, g)
-}
-
-func (b *Bundle) fetchLayout(ctx context.Context) (layoutRef types.ImageReference, layoutDir string, cleanup func(), err error) {
-	if b.sysCtx == nil {
-		return nil, "", nil, fmt.Errorf("sysctx must be provided")
-	}
-
-	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
-	policyCtx, err := signature.NewPolicyContext(policy)
-	if err != nil {
-		return nil, "", nil, err
-	}
-
-	parts := strings.SplitN(b.imageRef, ":", 2)
-	if len(parts) < 2 {
-		return nil, "", nil, fmt.Errorf("could not parse image ref: %s", b.imageRef)
-	}
-	var srcRef types.ImageReference
-
-	switch parts[0] {
-	case "docker":
-		srcRef, err = docker.ParseReference(parts[1])
-	case "docker-archive":
-		srcRef, err = dockerarchive.ParseReference(parts[1])
-	case "docker-daemon":
-		srcRef, err = dockerdaemon.ParseReference(parts[1])
-	case "oci":
-		srcRef, err = ocilayout.ParseReference(parts[1])
-	case "oci-archive":
-		srcRef, err = ociarchive.ParseReference(parts[1])
-	default:
-		return nil, "", nil, fmt.Errorf("cannot create an OCI container from %s source", parts[0])
-	}
-
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("invalid image source: %w", err)
-	}
-
-	// If the cache is enabled, then we transparently pull through an oci-layout in the cache.
-	if b.imgCache != nil && !b.imgCache.IsDisabled() {
-		// Grab the modified source ref from the cache
-		srcRef, err = oci.ConvertReference(ctx, b.imgCache, srcRef, b.sysCtx)
-		if err != nil {
-			return nil, "", nil, err
-		}
-		layoutDir, err := b.imgCache.GetOciCacheDir(cache.OciBlobCacheType)
-		if err != nil {
-			return nil, "", nil, err
-		}
-		return srcRef, layoutDir, nil, nil
-	}
-
-	// Otherwise we have to stage things in a temporary oci layout.
-	tmpDir, err := os.MkdirTemp("", "oci-tmp")
-	if err != nil {
-		return nil, "", nil, err
-	}
-	cleanup = func() {
-		os.RemoveAll(tmpDir)
-	}
-
-	tmpfsRef, err := ocilayout.ParseReference(tmpDir + ":" + "tmp")
-	if err != nil {
-		cleanup()
-		return nil, "", nil, err
-	}
-
-	_, err = copy.Image(ctx, policyCtx, tmpfsRef, srcRef, &copy.Options{
-		ReportWriter: sylog.Writer(),
-		SourceCtx:    b.sysCtx,
-	})
-	if err != nil {
-		cleanup()
-		return nil, "", nil, err
-	}
-
-	return tmpfsRef, tmpDir, cleanup, nil
-}
-
-func (b *Bundle) extractImage(ctx context.Context, layoutDir string, manifest imgspecv1.Manifest) error {
-	var mapOptions umocilayer.MapOptions
-
-	loggerLevel := sylog.GetLevel()
-	// set the apex log level, for umoci
-	if loggerLevel <= int(sylog.ErrorLevel) {
-		// silent option
-		apexlog.SetLevel(apexlog.ErrorLevel)
-	} else if loggerLevel <= int(sylog.LogLevel) {
-		// quiet option
-		apexlog.SetLevel(apexlog.WarnLevel)
-	} else if loggerLevel < int(sylog.DebugLevel) {
-		// verbose option(s) or default
-		apexlog.SetLevel(apexlog.InfoLevel)
-	} else {
-		// debug option
-		apexlog.SetLevel(apexlog.DebugLevel)
-	}
-
-	// Allow unpacking as non-root
-	if os.Geteuid() != 0 {
-		mapOptions.Rootless = true
-
-		uidMap, err := idtools.ParseMapping(fmt.Sprintf("0:%d:1", os.Geteuid()))
-		if err != nil {
-			return fmt.Errorf("error parsing uidmap: %s", err)
-		}
-		mapOptions.UIDMappings = append(mapOptions.UIDMappings, uidMap)
-
-		gidMap, err := idtools.ParseMapping(fmt.Sprintf("0:%d:1", os.Getegid()))
-		if err != nil {
-			return fmt.Errorf("error parsing gidmap: %s", err)
-		}
-		mapOptions.GIDMappings = append(mapOptions.GIDMappings, gidMap)
-	}
-
-	sylog.Debugf("Extracting manifest %s, from layout %s, to %s", manifest.Config.Digest, layoutDir, b.bundlePath)
-
-	engineExt, err := umoci.OpenLayout(layoutDir)
-	if err != nil {
-		return fmt.Errorf("error opening layout: %s", err)
-	}
-
-	// UnpackRootfs from umoci v0.4.2 expects a path to a non-existing directory
-	os.RemoveAll(tools.RootFs(b.bundlePath).Path())
-
-	// Unpack root filesystem
-	unpackOptions := umocilayer.UnpackOptions{MapOptions: mapOptions}
-	err = umocilayer.UnpackRootfs(ctx, engineExt, tools.RootFs(b.bundlePath).Path(), manifest, &unpackOptions)
-	if err != nil {
-		return fmt.Errorf("error unpacking rootfs: %s", err)
-	}
-
-	return nil
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1871
 which fixed
- sylabs/singularity# 1854

The original PR description was:
> There was a considerable amount of code duplicated between:
> 
> * The new `pkg/ocibundle/native` package.
> * The existing `internal/pkg/build/sources` OCI portions.
> 
> This PR aims to de-duplicate by moving the common OCI fetch and extraction implementation into `internal/pkg/build/oci`.
> 
> Note that function signatures remain ugly and long. I have deliberately avoided adding config structs, or heavily rewriting into a struct/ functional options pattern, to keep the changes relatively easy to read. We may want to improve the code structure in future.
> 
> There is also a general lack of test coverage below the e2e level. The e2e coverage is pretty good, exercising the various OCI sources and execution profiles. However, we may want to add additional tests at a lower level in future.

