### PR TITLE
e2e: In actionOCiOverlayTeardown, show mount table differences, from sylabs 1873

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -10,7 +10,6 @@
 package actions
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -1385,7 +1384,7 @@ func (c actionTests) actionOciOverlayTeardown(t *testing.T) {
 	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
 	const mountInfoPath string = "/proc/self/mountinfo"
-	numMountLinesPre, err := countLines(mountInfoPath)
+	mountsPre, err := os.ReadFile(mountInfoPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1408,30 +1407,14 @@ func (c actionTests) actionOciOverlayTeardown(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 
-	numMountLinesPost, err := countLines(mountInfoPath)
+	mountsPost, err := os.ReadFile(mountInfoPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	assert.Equal(
-		t, numMountLinesPost, numMountLinesPre,
-		"Number of mounts after running in OCI-mode with overlays (%d) does not match the number before the run (%d)", numMountLinesPost, numMountLinesPre)
-}
-
-func countLines(path string) (int, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return -1, err
-	}
-	defer file.Close()
-	scanner := bufio.NewScanner(file)
-	scanner.Split(bufio.ScanLines)
-	lines := 0
-	for scanner.Scan() {
-		lines++
-	}
-
-	return lines, nil
+		t, string(mountsPre), string(mountsPost),
+		"/proc/self/mountinfo table differs after running OCI container")
 }
 
 // Check that write permissions are indeed available for writable FUSE-mounted


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1873

The original PR description was:
> Instead of counting the mounts, compare the full mount table before and after execution. The assert.Equal will produce a nice diff if they don't match, easing troubleshooting.
> 
> Cherry-picked from the WIP sylabs/singularity# 1838 to simplify that ongoing PR.


