### PR TITLE
ci: fix buildcfg check, and usage in bin.FindBin, from sylabs 1879

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,10 +376,10 @@ jobs:
 
       - name: Check pkg/... doesn't depend on buildcfg
         run: |
-          if go list -f '{{.Deps}}' ./pkg/... | grep -q buildcfg
+          if $(/usr/local/go/bin/go list -f '{{.Deps}}' ./pkg/... | grep -q buildcfg)
           then
             echo "Prohibited buildcfg dependency found in pkg/:"
             echo
-            go list -f '{{.ImportPath}} - {{.Deps}}' ./pkg/... | grep buildcfg
+            /usr/local/go/bin/go list -f '{{.ImportPath}} - {{.Deps}}' ./pkg/... | grep buildcfg
             exit 1
           fi

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -12,14 +12,6 @@ package bin
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"strings"
-
-	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
-	"github.com/apptainer/apptainer/pkg/sylog"
-	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
-	"github.com/pkg/errors"
 )
 
 // FindBin returns the path to the named binary, or an error if it is not found.
@@ -73,45 +65,4 @@ func FindBin(name string) (path string, err error) {
 		return findOnPath(name, false)
 	}
 	return "", fmt.Errorf("unknown executable name %q", name)
-}
-
-// findOnPath performs a search on the configurated binary path for the
-// named executable, returning its full path.
-func findOnPath(name string, useSuidPath bool) (path string, err error) {
-	cfg := apptainerconf.GetCurrentConfig()
-	if cfg == nil {
-		if strings.HasSuffix(os.Args[0], ".test") {
-			// read config if doing unit tests
-			cfg, err = apptainerconf.Parse(buildcfg.APPTAINER_CONF_FILE)
-			if err != nil {
-				return "", errors.Wrap(err, "unable to parse apptainer configuration file")
-			}
-			apptainerconf.SetCurrentConfig(cfg)
-		} else {
-			sylog.Fatalf("configuration not pre-loaded in findOnPath")
-		}
-	}
-	if cfg.SuidBinaryPath == "" {
-		if strings.HasSuffix(os.Args[0], ".test") {
-			apptainerconf.SetBinaryPath(buildcfg.LIBEXECDIR, true)
-		} else {
-			sylog.Fatalf("SetBinaryPath has not been run before findOnPath")
-		}
-	}
-	var newPath string
-	if useSuidPath {
-		sylog.Debugf("Searching for %q in SuidBinaryPath", name)
-		newPath = cfg.SuidBinaryPath
-	} else {
-		newPath = cfg.BinaryPath
-	}
-	oldPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", oldPath)
-	os.Setenv("PATH", newPath)
-
-	path, err = exec.LookPath(name)
-	if err == nil {
-		sylog.Debugf("Found %q at %q", name, path)
-	}
-	return path, err
 }

--- a/internal/pkg/util/bin/bin_apptainer.go
+++ b/internal/pkg/util/bin/bin_apptainer.go
@@ -1,0 +1,64 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+//go:build apptainer_engine
+
+package bin
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
+	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
+	"github.com/pkg/errors"
+)
+
+// findOnPath performs a search on the configurated binary path for the
+// named executable, returning its full path.
+func findOnPath(name string, useSuidPath bool) (path string, err error) {
+	cfg := apptainerconf.GetCurrentConfig()
+	if cfg == nil {
+		if strings.HasSuffix(os.Args[0], ".test") {
+			// read config if doing unit tests
+			cfg, err = apptainerconf.Parse(buildcfg.APPTAINER_CONF_FILE)
+			if err != nil {
+				return "", errors.Wrap(err, "unable to parse apptainer configuration file")
+			}
+			apptainerconf.SetCurrentConfig(cfg)
+		} else {
+			sylog.Fatalf("configuration not pre-loaded in findOnPath")
+		}
+	}
+	if cfg.SuidBinaryPath == "" {
+		if strings.HasSuffix(os.Args[0], ".test") {
+			apptainerconf.SetBinaryPath(buildcfg.LIBEXECDIR, true)
+		} else {
+			sylog.Fatalf("SetBinaryPath has not been run before findOnPath")
+		}
+	}
+	var newPath string
+	if useSuidPath {
+		sylog.Debugf("Searching for %q in SuidBinaryPath", name)
+		newPath = cfg.SuidBinaryPath
+	} else {
+		newPath = cfg.BinaryPath
+	}
+	oldPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oldPath)
+	os.Setenv("PATH", newPath)
+
+	path, err = exec.LookPath(name)
+	if err == nil {
+		sylog.Debugf("Found %q at %q", name, path)
+	}
+	return path, err
+}

--- a/internal/pkg/util/bin/bin_no_apptainer.go
+++ b/internal/pkg/util/bin/bin_no_apptainer.go
@@ -1,0 +1,21 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+//go:build !apptainer_engine
+
+package bin
+
+import (
+	"os/exec"
+)
+
+// findOnPath falls back to exec.LookPath when not built as part of Apptainer.
+func findOnPath(name string, useSuidPath bool) (path string, err error) {
+	return exec.LookPath(name)
+}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1879
 which fixed
- sylabs/singularity# 1823

The original PR description was:
> If code in `pkg/` uses `bin.FindBin` then prior to this PR it would attempt to import `buildcfg`.
> 
> `buildcfg` is only available as part of a full build of SingularityCE, not when other code imports `pkg/`.
> 
> Add build tag gated variants of the private functions called by `bin.FindBin` that do not require `buildcfg`, to avoid this issue.



