### PR TITLE
Revamp passwd utility function, from sylabs 1597

### DIFF
--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -347,12 +347,6 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/prometheus/procfs/blob/master/LICENSE>
 
-## github.com/revel/log15
-
-**License:** Apache-2.0
-
-**License URL:** <https://github.com/revel/log15/blob/master/LICENSE>
-
 ## github.com/rootless-containers/proto/go-proto
 
 **License:** Apache-2.0
@@ -460,12 +454,6 @@ The dependencies and their licenses are as follows:
 **License:** Apache-2.0
 
 **Project URL:** <https://gopkg.in/square/go-jose.v2>
-
-## gopkg.in/stack.v0
-
-**License:** Apache-2.0
-
-**Project URL:** <https://gopkg.in/stack.v0>
 
 ## gopkg.in/yaml.v2
 
@@ -695,12 +683,6 @@ The dependencies and their licenses are as follows:
 
 **Project URL:** <https://golang.org/x/text>
 
-## golang.org/x/tools
-
-**License:** BSD-3-Clause
-
-**Project URL:** <https://golang.org/x/tools>
-
 ## google.golang.org/protobuf
 
 **License:** BSD-3-Clause
@@ -851,12 +833,6 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/go-log/log/blob/master/LICENSE>
 
-## github.com/inconshreveable/log15/term
-
-**License:** MIT
-
-**License URL:** <https://github.com/inconshreveable/log15/blob/master/term/LICENSE>
-
 ## github.com/josharian/intern
 
 **License:** MIT
@@ -923,12 +899,6 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/pelletier/go-toml/blob/master/v2/LICENSE>
 
-## github.com/revel/cmd
-
-**License:** MIT
-
-**License URL:** <https://github.com/revel/cmd/blob/master/LICENSE>
-
 ## github.com/rivo/uniseg
 
 **License:** MIT
@@ -959,12 +929,6 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/sirupsen/logrus/blob/master/LICENSE>
 
-## github.com/stat0s2p/etcpwdparse
-
-**License:** MIT
-
-**License URL:** <https://github.com/stat0s2p/etcpwdparse/blob/master/LICENSE.md>
-
 ## github.com/titanous/rocacheck
 
 **License:** MIT
@@ -988,12 +952,6 @@ The dependencies and their licenses are as follows:
 **License:** MIT
 
 **Project URL:** <https://go.mozilla.org/pkcs7>
-
-## gopkg.in/natefinch/lumberjack.v2
-
-**License:** MIT
-
-**Project URL:** <https://gopkg.in/natefinch/lumberjack.v2>
 
 ## gopkg.in/yaml.v3
 
@@ -1042,12 +1000,6 @@ The dependencies and their licenses are as follows:
 **License:** Unknown
 
 **Project URL:** <https://github.com/garyburd/redigo/redis>
-
-## github.com/revel/config
-
-**License:** Unknown
-
-**Project URL:** <https://github.com/revel/config>
 
 ## github.com/vbauerster/mpb
 

--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -347,6 +347,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/prometheus/procfs/blob/master/LICENSE>
 
+## github.com/revel/log15
+
+**License:** Apache-2.0
+
+**License URL:** <https://github.com/revel/log15/blob/master/LICENSE>
+
 ## github.com/rootless-containers/proto/go-proto
 
 **License:** Apache-2.0
@@ -454,6 +460,12 @@ The dependencies and their licenses are as follows:
 **License:** Apache-2.0
 
 **Project URL:** <https://gopkg.in/square/go-jose.v2>
+
+## gopkg.in/stack.v0
+
+**License:** Apache-2.0
+
+**Project URL:** <https://gopkg.in/stack.v0>
 
 ## gopkg.in/yaml.v2
 
@@ -683,6 +695,12 @@ The dependencies and their licenses are as follows:
 
 **Project URL:** <https://golang.org/x/text>
 
+## golang.org/x/tools
+
+**License:** BSD-3-Clause
+
+**Project URL:** <https://golang.org/x/tools>
+
 ## google.golang.org/protobuf
 
 **License:** BSD-3-Clause
@@ -833,6 +851,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/go-log/log/blob/master/LICENSE>
 
+## github.com/inconshreveable/log15/term
+
+**License:** MIT
+
+**License URL:** <https://github.com/inconshreveable/log15/blob/master/term/LICENSE>
+
 ## github.com/josharian/intern
 
 **License:** MIT
@@ -899,6 +923,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/pelletier/go-toml/blob/master/v2/LICENSE>
 
+## github.com/revel/cmd
+
+**License:** MIT
+
+**License URL:** <https://github.com/revel/cmd/blob/master/LICENSE>
+
 ## github.com/rivo/uniseg
 
 **License:** MIT
@@ -929,6 +959,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/sirupsen/logrus/blob/master/LICENSE>
 
+## github.com/stat0s2p/etcpwdparse
+
+**License:** MIT
+
+**License URL:** <https://github.com/stat0s2p/etcpwdparse/blob/master/LICENSE.md>
+
 ## github.com/titanous/rocacheck
 
 **License:** MIT
@@ -952,6 +988,12 @@ The dependencies and their licenses are as follows:
 **License:** MIT
 
 **Project URL:** <https://go.mozilla.org/pkcs7>
+
+## gopkg.in/natefinch/lumberjack.v2
+
+**License:** MIT
+
+**Project URL:** <https://gopkg.in/natefinch/lumberjack.v2>
 
 ## gopkg.in/yaml.v3
 
@@ -1000,6 +1042,12 @@ The dependencies and their licenses are as follows:
 **License:** Unknown
 
 **Project URL:** <https://github.com/garyburd/redigo/redis>
+
+## github.com/revel/config
+
+**License:** Unknown
+
+**Project URL:** <https://github.com/revel/config>
 
 ## github.com/vbauerster/mpb
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -216,6 +216,14 @@ func (c actionTests) actionExec(t *testing.T) {
 				e2e.ExpectOutput(e2e.RegexMatch, `^(\s*)Server:(\s+)(1\.1\.1\.1)(\s*)\n`),
 			},
 		},
+		{
+			name: "CustomHomePreservesRootShell",
+			argv: []string{"--home", "/tmp", c.env.ImagePath, "cat", "/etc/passwd"},
+			exit: 0,
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `^root:x:0:0:root:[^:]*:/bin/ash\n`),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -272,7 +272,7 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			argv: []string{"--home", "/tmp", imageRef, "cat", "/etc/passwd"},
 			exit: 0,
 			wantOutputs: []e2e.ApptainerCmdResultOp{
-				e2e.ExpectOutput(e2e.RegexMatch, `^root:x:0:0:root:[^:]*:/bin/sh\n`),
+				e2e.ExpectOutput(e2e.RegexMatch, `^root:x:0:0:root:[^:]*:/bin/ash\n`),
 			},
 		},
 		{

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -268,6 +268,14 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			},
 		},
 		{
+			name: "CustomHomePreservesRootShell",
+			argv: []string{"--home", "/tmp", imageRef, "cat", "/etc/passwd"},
+			exit: 0,
+			wantOutputs: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `^root:x:0:0:root:[^:]*:/bin/sh\n`),
+			},
+		},
+		{
 			name: "Containlibs",
 			argv: []string{"--containlibs", "/etc/hosts", imageRef, "ls", "/.singularity.d/libs"},
 			exit: 0,

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -967,6 +967,28 @@ func (c ctx) testDockerUSER(t *testing.T) {
 			},
 			expectExit: 0,
 		},
+		// `--oci` modes: check that we correctly error on conflict with `--home`
+		{
+			name:       "WithHomeOCIUser",
+			cmd:        "run",
+			profile:    e2e.OCIUserProfile,
+			args:       []string{"--home", "/tmp", dockerURI},
+			expectExit: 255,
+		},
+		{
+			name:       "WithHomeOCIFakeroot",
+			cmd:        "run",
+			profile:    e2e.OCIFakerootProfile,
+			args:       []string{"--home", "/tmp", dockerURI},
+			expectExit: 255,
+		},
+		{
+			name:       "WithHomeOCIRoot",
+			cmd:        "run",
+			profile:    e2e.OCIRootProfile,
+			args:       []string{"--home", "/tmp", dockerURI},
+			expectExit: 255,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -360,12 +360,15 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 		return err
 	}
 
-	// If we are entering as root, or a USER defined in the container, then passwd/group
-	// information should be present already.
-	if targetUID == 0 || containerUser {
+	// If the container specifies a USER, we do not proceed to invoke l.updatePasswdGroup(). All we do is test for a conflicting --home option (in which case, we issue an error) and return
+	if containerUser {
+		if l.cfg.CustomHome {
+			return fmt.Errorf("a custom --home is not currently supported when running containers that declare a USER")
+		}
+
 		return nil
 	}
-	// Otherwise, add to the passwd and group files in the container.
+
 	if err := l.updatePasswdGroup(tools.RootFs(b.Path()).Path(), targetUID, targetGID); err != nil {
 		return err
 	}
@@ -374,10 +377,6 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 }
 
 func (l *Launcher) updatePasswdGroup(rootfs string, uid, gid uint32) error {
-	if os.Getuid() == 0 || l.cfg.Fakeroot {
-		return nil
-	}
-
 	containerPasswd := filepath.Join(rootfs, "etc", "passwd")
 	containerGroup := filepath.Join(rootfs, "etc", "group")
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1597

The original PR description was:
> _NOTE: This PR is a continuation of sylabs/singularity# 1531. See additional discussion there._
> 
> The way the Passwd() utility-function (internal/pkg/util/fs/files/passwd.go:22) worked until now, it was only able to append a new line to what it got as input (from the base layer).
> 
> This meant that, for example, to override the homedir of a regular user, we would simply add a modified line (with the custom homedir) to the in-container /etc/passwd; but to override the homedir of root (when running singularity itself as root, or when running with `--fakeroot`), we couldn't do that – since there was already a "root" line in the base layer's /etc/passwd – and we resorted to an entirely different method, namely, overriding the `$HOME` environment variable upon container initialization.
> 
> In addition to being non-uniform, the approach involving environment variables can also give rise to an internally inconsistent state, where, when we're root inside the container, our $HOME is set to one thing (a custom homedir) but the /etc/passwd file still has `/root` as the homedir for the root user.
> 
> A more uniform approach, which also avoids this inconsistent state described above, is possible: change the Passwd() utility-function so that when "adding" a line to /etc/passwd it first checks if a line with the corresponding uid already exists, and if it does, replaces that specific line instead of appending a new line to the file.
> ### Performance considerations
> 
> The implementation in this PR involves calling `ParsePasswdLine()` from the [github.com/stat0s2p/etcpwdparse](https://pkg.go.dev/github.com/stat0s2p/etcpwdparse) package on every line in the /etc/passwd file (internal/pkg/util/fs/files/passwd.go:52).
> 
> If this turns out to be problematic from a performance perspective, we can replace it with strings.split or something similar to just pull out the first field of each /etc/passwd line (=the username), and using only that to judge sameness-of-users for the purposes of deciding whether to replace a line or append a new one.
> ### Related PRs
> 
> Bug sylabs/singularity# 1529 was a failure to override root's homedir when running in OCI mode as root/fakeroot. It was fixed in PR sylabs/singularity# 1530 using the environment-variables method described above, in order to maintain uniformity with the native-runtime mode, and in order to not have the fix depend on the redoing of Passwd() described here.