### PR TITLE
oci: create runtime bundle within buildcfg.SESSIONDIR tmpfs, from sylabs 1872

### DIFF
--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
@@ -351,70 +352,141 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 		return err
 	}
 
+	// Handle container /etc/[group|passwd|resolv.conf]
+	if err := l.prepareEtc(b, spec, containerUser); err != nil {
+		return err
+	}
+
 	if err := b.Update(ctx, spec); err != nil {
 		return err
 	}
 
-	// Prepare DNS settings for the container.
-	if err := l.prepareResolvConf(tools.RootFs(b.Path()).Path()); err != nil {
+	return nil
+}
+
+// prepareEtc creates modified container-specific /etc files and adds them to
+// the spec mount list, to be bound into the assembled container. containerUser
+// should be set to true if the runtime user information will be derived from
+// the container's existing passwd/group files. spec.Process.User.[UG]ID must be
+// set correctly before calling.
+func (l *Launcher) prepareEtc(b ocibundle.Bundle, spec *specs.Spec, containerUser bool) error {
+	if err := os.Mkdir(filepath.Join(b.Path(), "etc"), 0o755); err != nil && !os.IsExist(err) {
 		return err
 	}
 
-	// If the container specifies a USER, we do not proceed to invoke l.updatePasswdGroup(). All we do is test for a conflicting --home option (in which case, we issue an error) and return
+	resolvMount, err := l.prepareResolvConf(b.Path())
+	if err != nil {
+		return err
+	}
+	if resolvMount != nil {
+		spec.Mounts = append(spec.Mounts, *resolvMount)
+	}
+
+	// If the container specifies a USER, we do not create a customized
+	// /etc/passwd|group. All we do is test for a conflicting --home option (in
+	// which case, we issue an error) and return
 	if containerUser {
 		if l.cfg.CustomHome {
 			return fmt.Errorf("a custom --home is not currently supported when running containers that declare a USER")
 		}
-
 		return nil
 	}
 
-	if err := l.updatePasswdGroup(tools.RootFs(b.Path()).Path(), targetUID, targetGID); err != nil {
+	passwdMount, err := l.preparePasswd(b.Path(), spec.Process.User.UID)
+	if err != nil {
 		return err
 	}
-
-	return nil
-}
-
-func (l *Launcher) updatePasswdGroup(rootfs string, uid, gid uint32) error {
-	containerPasswd := filepath.Join(rootfs, "etc", "passwd")
-	containerGroup := filepath.Join(rootfs, "etc", "group")
-
-	if l.apptainerConf.ConfigPasswd {
-		sylog.Debugf("Updating passwd file: %s", containerPasswd)
-		content, err := files.Passwd(containerPasswd, l.homeDest, int(uid), nil)
-		if err != nil {
-			sylog.Warningf("%s", err)
-		} else if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {
-			return fmt.Errorf("while writing passwd file: %w", err)
-		}
-	} else {
-		sylog.Debugf("Skipping update of %s due to apptainer.conf", containerPasswd)
+	if passwdMount != nil {
+		spec.Mounts = append(spec.Mounts, *passwdMount)
 	}
 
-	if l.apptainerConf.ConfigGroup {
-		sylog.Debugf("Updating group file: %s", containerGroup)
-		content, err := files.Group(containerGroup, int(uid), []int{int(gid)}, nil)
-		if err != nil {
-			sylog.Warningf("%s", err)
-		} else if err := os.WriteFile(containerGroup, content, 0o755); err != nil {
-			return fmt.Errorf("while writing passwd file: %w", err)
-		}
-	} else {
-		sylog.Debugf("Skipping update of %s due to apptainer.conf", containerGroup)
+	groupMount, err := l.prepareGroup(b.Path(), spec.Process.User.UID, spec.Process.User.GID)
+	if err != nil {
+		return err
+	}
+	if groupMount != nil {
+		spec.Mounts = append(spec.Mounts, *groupMount)
 	}
 
 	return nil
 }
 
-func (l *Launcher) prepareResolvConf(rootfs string) error {
+// preparePasswd creates an `/etc/passwd` file in the bundle. This is based on
+// the passwd file from the pristine rootfs, modified to reflect the container
+// user configuration. An appropriate bind mount to use the create file is
+// returned on success.
+func (l *Launcher) preparePasswd(bundlePath string, uid uint32) (*specs.Mount, error) {
+	rootfs := tools.RootFs(bundlePath).Path()
+	rootfsPasswd := filepath.Join(rootfs, "etc", "passwd")
+	containerPasswd := filepath.Join(bundlePath, "etc", "passwd")
+
+	if !l.apptainerConf.ConfigPasswd {
+		sylog.Debugf("Skipping creation of %s due to apptainer.conf", containerPasswd)
+		return nil, nil
+	}
+
+	sylog.Debugf("Creating container passwd file: %s", containerPasswd)
+	content, err := files.Passwd(rootfsPasswd, l.homeDest, int(uid), nil)
+	if err != nil {
+		// E.g. container doesn't contain an /etc/passwd
+		sylog.Warningf("%s", err)
+		return nil, nil
+	}
+	if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {
+		return nil, fmt.Errorf("while writing passwd file: %w", err)
+	}
+	passwdMount := specs.Mount{
+		Source:      containerPasswd,
+		Destination: "/etc/passwd",
+		Type:        "none",
+		Options:     []string{"bind"},
+	}
+	return &passwdMount, nil
+}
+
+// prepareGroup creates an `/etc/group` file in the bundle. This is based on
+// the group file from the pristine rootfs, modified to reflect the container
+// group configuration. An appropriate bind mount to use the create file is
+// returned on success.
+func (l *Launcher) prepareGroup(bundlePath string, uid, gid uint32) (*specs.Mount, error) {
+	rootfs := tools.RootFs(bundlePath).Path()
+	rootfsGroup := filepath.Join(rootfs, "etc", "group")
+	containerGroup := filepath.Join(bundlePath, "etc", "group")
+
+	if !l.apptainerConf.ConfigGroup {
+		sylog.Debugf("Skipping creation of %s due to apptainer.conf", containerGroup)
+		return nil, nil
+	}
+
+	sylog.Debugf("Creating container group file: %s", containerGroup)
+	content, err := files.Group(rootfsGroup, int(uid), []int{int(gid)}, nil)
+	if err != nil {
+		// E.g. container doesn't contain an /etc/group
+		sylog.Warningf("%s", err)
+		return nil, nil
+	} else if err := os.WriteFile(containerGroup, content, 0o755); err != nil {
+		return nil, fmt.Errorf("while writing passwd file: %w", err)
+	}
+	groupMount := specs.Mount{
+		Source:      containerGroup,
+		Destination: "/etc/group",
+		Type:        "none",
+		Options:     []string{"bind"},
+	}
+	return &groupMount, nil
+}
+
+// prepareResolvConfcreates `/etc/resolv.conf` in the bundle. An appropriate
+// bind mount to bind over the pristing rootfs `/etc/resolv.conf` is returned on
+// success.
+func (l *Launcher) prepareResolvConf(bundlePath string) (*specs.Mount, error) {
 	hostResolvConfPath := "/etc/resolv.conf"
-	containerEtc := filepath.Join(rootfs, "etc")
-	containerResolvConfPath := filepath.Join(rootfs, "etc", "resolv.conf")
+	containerEtc := filepath.Join(bundlePath, "etc")
+	containerResolvConfPath := filepath.Join(containerEtc, "resolv.conf")
 
 	if !l.apptainerConf.ConfigResolvConf {
-		sylog.Debugf("Skipping update of %s due to apptainer.conf", containerResolvConfPath)
-		return nil
+		sylog.Debugf("Skipping creation of %s due to apptainer.conf", containerResolvConfPath)
+		return nil, nil
 	}
 
 	var resolvConfData []byte
@@ -424,7 +496,7 @@ func (l *Launcher) prepareResolvConf(rootfs string) error {
 		ips := strings.Split(dns, ",")
 		for _, ip := range ips {
 			if net.ParseIP(ip) == nil {
-				return fmt.Errorf("DNS nameserver %v is not a valid IP address", ip)
+				return nil, fmt.Errorf("DNS nameserver %v is not a valid IP address", ip)
 			}
 			line := fmt.Sprintf("nameserver %s\n", ip)
 			resolvConfData = append(resolvConfData, line...)
@@ -432,21 +504,22 @@ func (l *Launcher) prepareResolvConf(rootfs string) error {
 	} else {
 		resolvConfData, err = os.ReadFile(hostResolvConfPath)
 		if err != nil {
-			return fmt.Errorf("could not read host's resolv.conf file: %w", err)
+			return nil, fmt.Errorf("could not read host's resolv.conf file: %w", err)
 		}
 	}
 
-	stat, err := os.Stat(containerEtc)
-	if os.IsNotExist(err) || !stat.IsDir() {
-		sylog.Warningf("container does not contain an /etc directory; skipping resolv.conf configuration")
-		return nil
-	}
-
 	if err := os.WriteFile(containerResolvConfPath, resolvConfData, 0o755); err != nil {
-		return fmt.Errorf("while writing container's resolv.conf file: %v", err)
+		return nil, fmt.Errorf("while writing container's resolv.conf file: %v", err)
 	}
 
-	return nil
+	resolvMount := specs.Mount{
+		Source:      containerResolvConfPath,
+		Destination: "/etc/resolv.conf",
+		Type:        "none",
+		Options:     []string{"bind"},
+	}
+
+	return &resolvMount, nil
 }
 
 // Exec will interactively execute a container via the runc low-level runtime.
@@ -460,14 +533,18 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		return fmt.Errorf("launcher SysContext must be set for OCI image handling")
 	}
 
-	bundleDir, err := os.MkdirTemp("", "oci-bundle")
+	if err := l.mountSessionTmpfs(); err != nil {
+		return err
+	}
+
+	bundleDir, err := os.MkdirTemp(buildcfg.SESSIONDIR, "oci-bundle")
 	if err != nil {
 		return nil
 	}
 	defer func() {
 		sylog.Debugf("Removing OCI bundle at: %s", bundleDir)
-		if err := fs.ForceRemoveAll(bundleDir); err != nil {
-			sylog.Errorf("Couldn't remove OCI bundle %s: %v", bundleDir, err)
+		if cleanupErr := fs.ForceRemoveAll(bundleDir); cleanupErr != nil {
+			sylog.Errorf("Couldn't remove OCI bundle %s: %v", bundleDir, cleanupErr)
 		}
 	}()
 
@@ -513,8 +590,17 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		return fmt.Errorf("while generating container id: %w", err)
 	}
 
-	// Execution of runc/crun run, wrapped with prep / cleanup.
+	// Execution of runc/crun run, wrapped with overlay prep / cleanup.
 	err = RunWrapped(ctx, id.String(), b.Path(), "", l.cfg.OverlayPaths, l.apptainerConf.SystemdCgroups)
+
+	// Unmounts pristine rootfs from bundle, and removes the bundle.
+	if cleanupErr := b.Delete(); cleanupErr != nil {
+		sylog.Errorf("Couldn't cleanup bundle: %v", err)
+	}
+
+	if err := l.unmountSessionTmpfs(); err != nil {
+		sylog.Errorf("Couldn't unmount session directory: %v", err)
+	}
 
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
@@ -534,6 +620,25 @@ func (l *Launcher) getCgroup() (path string, resources *specs.LinuxResources, er
 		return "", nil, err
 	}
 	return path, resources, nil
+}
+
+// mountSessionTmpfs mounts a tmpfs onto buildcfg.SESSIONDIR
+func (l *Launcher) mountSessionTmpfs() error {
+	sylog.Debugf("Mounting %d MiB tmpfs to %s", l.apptainerConf.SessiondirMaxSize, buildcfg.SESSIONDIR)
+	options := fmt.Sprintf("mode=1777,size=%dm", l.apptainerConf.SessiondirMaxSize)
+	if err := syscall.Mount("tmpfs", buildcfg.SESSIONDIR, "tmpfs", syscall.MS_NODEV, options); err != nil {
+		return fmt.Errorf("failed to mount session tmpfs %s: %w", buildcfg.SESSIONDIR, err)
+	}
+	return nil
+}
+
+// unmountSessionTmpfs mounts a tmpfs onto buildcfg.SESSIONDIR
+func (l *Launcher) unmountSessionTmpfs() error {
+	sylog.Debugf("Umounting tmpfs from %s", buildcfg.SESSIONDIR)
+	if err := syscall.Unmount(buildcfg.SESSIONDIR, syscall.MNT_DETACH); err != nil {
+		return fmt.Errorf("failed to unmount session tmpfs %s: %w", buildcfg.SESSIONDIR, err)
+	}
+	return nil
 }
 
 // crunNestCgroup will check whether we are using crun, and enter a cgroup if

--- a/pkg/ocibundle/native/bundle_linux.go
+++ b/pkg/ocibundle/native/bundle_linux.go
@@ -15,10 +15,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/apptainer/apptainer/internal/pkg/build/oci"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/ocibundle"
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -42,8 +44,14 @@ type Bundle struct {
 	// Note that we only use the 'blob' cache section. The 'oci-tmp' cache section holds
 	// OCI->SIF conversions, which are not used here.
 	imgCache *cache.Handle
-	// process is the command to execute, which may override the image's ENTRYPOINT / CMD.
-	// Generic bundle properties
+	// tmpDir is the location for any temporary files that will be created outside of the
+	// assembled runtime bundle directory.
+	tmpDir string
+	// rootfsParentDir is the parent directory of the pristine rootfs, that will be mounted into the bundle.
+	// It is created and mounted to the bundlePath/rootfs during Create() and umounted and removed during Delete().
+	rootfsParentDir string
+	// rootfsMounted is set to true when the pristine rootfs has been bind mounted into the bundle.
+	rootfsMounted bool
 	ocibundle.Bundle
 }
 
@@ -85,6 +93,15 @@ func OptImgCache(ic *cache.Handle) Option {
 	}
 }
 
+// OptTempDir sets the parent temporary directory for temporary files generated
+// outside of the assembled bundle.
+func OptTmpDir(tmpDir string) Option {
+	return func(b *Bundle) error {
+		b.tmpDir = tmpDir
+		return nil
+	}
+}
+
 // New returns a bundle interface to create/delete an OCI bundle from an OCI image ref.
 func New(opts ...Option) (ocibundle.Bundle, error) {
 	b := Bundle{
@@ -104,6 +121,20 @@ func New(opts ...Option) (ocibundle.Bundle, error) {
 
 // Delete erases OCI bundle created an OCI image ref
 func (b *Bundle) Delete() error {
+	if b.rootfsMounted {
+		sylog.Debugf("Unmounting bundle rootfs %q", tools.RootFs(b.bundlePath).Path())
+		if err := syscall.Unmount(tools.RootFs(b.bundlePath).Path(), syscall.MNT_DETACH); err != nil {
+			return fmt.Errorf("while unmounting bundle rootfs bind mount: %w", err)
+		}
+	}
+
+	if b.rootfsParentDir != "" {
+		sylog.Debugf("Removing pristine rootfs %q", b.rootfsParentDir)
+		if err := fs.ForceRemoveAll(b.rootfsParentDir); err != nil {
+			return fmt.Errorf("while removing pristine rootfs %q: %w", b.rootfsParentDir, err)
+		}
+	}
+
 	return tools.DeleteBundle(b.bundlePath)
 }
 
@@ -117,13 +148,13 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 
 	// Get a reference to an OCI layout source for the image, fetching the image
 	// through the cache if it is enabled.
-	tmpDir, err := os.MkdirTemp("", "oci-tmp")
+	tmpLayout, err := os.MkdirTemp(b.tmpDir, "oci-tmp-layout")
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpDir)
+	defer os.RemoveAll(tmpLayout)
 
-	layoutRef, err := oci.FetchLayout(ctx, b.sysCtx, b.imgCache, b.imageRef, tmpDir)
+	layoutRef, err := oci.FetchLayout(ctx, b.sysCtx, b.imgCache, b.imageRef, tmpLayout)
 	if err != nil {
 		return err
 	}
@@ -154,10 +185,43 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 		return err
 	}
 
-	// Extract from temp oci layout into bundle rootfs
-	if err := oci.UnpackRootfs(ctx, tmpDir, manifest, tools.RootFs(b.bundlePath).Path()); err != nil {
+	// Extract from temp oci layout into a temporary pristine rootfs dir, outside of the bundle.
+	// The rootfs must be nested inside a parent directory, so extracting it does not
+	// open the tmpdir permissions.
+	b.rootfsParentDir, err = os.MkdirTemp(b.tmpDir, "oci-tmp-rootfs")
+	if err != nil {
 		return err
 	}
+	pristineRootfs := filepath.Join(b.rootfsParentDir, "rootfs")
+
+	if err := oci.UnpackRootfs(ctx, tmpLayout, manifest, pristineRootfs); err != nil {
+		return err
+	}
+
+	bundleRootfs := tools.RootFs(b.bundlePath).Path()
+	if err := os.Mkdir(bundleRootfs, 0o755); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	sylog.Debugf("Performing bind mount of pristine rootfs %q to bundle %q", pristineRootfs, bundleRootfs)
+	if err = syscall.Mount(pristineRootfs, bundleRootfs, "", syscall.MS_BIND, ""); err != nil {
+		return fmt.Errorf("failed to bind pristine rootfs to %q: %w", bundleRootfs, err)
+	}
+
+	defer func() {
+		if err != nil {
+			sylog.Debugf("Encountered error with rootfs bind mount; attempting to unmount %q", bundleRootfs)
+			syscall.Unmount(bundleRootfs, syscall.MNT_DETACH)
+		}
+	}()
+
+	sylog.Debugf("Performing remount of bundle rootfs %q", bundleRootfs)
+	if err = syscall.Mount("", bundleRootfs, "", syscall.MS_REMOUNT|syscall.MS_BIND|syscall.MS_RDONLY|syscall.MS_NODEV|syscall.MS_NOSUID, ""); err != nil {
+		return fmt.Errorf("failed to remount bundle rootfs %q: %w", bundleRootfs, err)
+	}
+
+	b.rootfsMounted = true
+
 	return b.writeConfig(g)
 }
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1872
 which fixed
- sylabs/singularity# 1855

The original PR description was:
> In Singularity's native mode, we assemble the runtime representation of the container's rootfs under a tmpfs mounted on buildcfg.SESSIONDIR. The pristine rootfs, whether from a SIF file or an OCI source image extracted to a directory, is mounted into the tmpfs before other overlays, customised files, host mounts etc. are layered over it.
> 
> The location of buildcfg.SESSIONDIR is set when SingularityCE is compiled. It is documented that it needs to be on a local filesystem. Using a tmpfs mount over a local fs SESSIONDIR avoids potential issues with mounts over network file systems etc. The OCI mode is currently vulnerable to issues as it creates the runtime bundle on TMPDIR.
> 
> Also, prior to this PR, our code assumes that an OCI container rootfs sits directly in the runtime bundle, and can be modified directly by the launcher code. This does not allow e.g. mounting the rootfs out of a read only loopback image.
> 
> In preparation for enabling oci-sif mounts, this PR modifies the existing ocibundle and launcher code to adopt the same SESSIONDIR tmpfs pattern.


