### PR TITLE
oci: Support pull --oci to OCI-SIF, from sylabs 1878

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   capabilities of the container process.
 - The `cache` commands now accept `--type oci-sif` to list and clean cached
   OCI-SIF image conversions of OCI sources.
+- The `pull` command now accepts a new flag `--oci` for OCI image sources. This
+  will create an OCI-SIF image rather than convert to Apptainer's native
+  container format.
 
 ### Developer / API
 

--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -17,6 +17,18 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/Netflix/go-expect/blob/master/LICENSE>
 
+## github.com/anchore/go-logger
+
+**License:** Apache-2.0
+
+**License URL:** <https://github.com/anchore/go-logger/blob/master/LICENSE>
+
+## github.com/anchore/stereoscope
+
+**License:** Apache-2.0
+
+**License URL:** <https://github.com/anchore/stereoscope/blob/master/LICENSE>
+
 ## github.com/container-orchestrated-devices/container-device-interface
 
 **License:** Apache-2.0
@@ -28,6 +40,12 @@ The dependencies and their licenses are as follows:
 **License:** Apache-2.0
 
 **License URL:** <https://github.com/containerd/containerd/blob/master/LICENSE>
+
+## github.com/containerd/stargz-snapshotter/estargz
+
+**License:** Apache-2.0
+
+**License URL:** <https://github.com/containerd/stargz-snapshotter/blob/master/estargz/LICENSE>
 
 ## github.com/containernetworking/cni
 
@@ -89,11 +107,11 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/cyberphone/json-canonicalization/blob/master/go/src/webpki.org/jsoncanonicalizer/LICENSE>
 
-## github.com/docker/cli/cli/config
+## github.com/docker/cli/cli
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/docker/cli/blob/master/cli/config/LICENSE>
+**License URL:** <https://github.com/docker/cli/blob/master/cli/LICENSE>
 
 ## github.com/docker/distribution
 
@@ -323,6 +341,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/opencontainers/umoci/blob/master/third_party/shared/COPYING>
 
+## github.com/pelletier/go-toml
+
+**License:** Apache-2.0
+
+**License URL:** <https://github.com/pelletier/go-toml/blob/master/LICENSE>
+
 ## github.com/prometheus/client_golang/prometheus
 
 **License:** Apache-2.0
@@ -359,6 +383,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/safchain/ethtool/blob/master/LICENSE>
 
+## github.com/scylladb/go-set
+
+**License:** Apache-2.0
+
+**License URL:** <https://github.com/scylladb/go-set/blob/master/LICENSE>
+
 ## github.com/seccomp/containers-golang
 
 **License:** Apache-2.0
@@ -383,6 +413,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/sigstore/sigstore/blob/master/pkg/LICENSE>
 
+## github.com/spf13/afero
+
+**License:** Apache-2.0
+
+**License URL:** <https://github.com/spf13/afero/blob/master/LICENSE.txt>
+
 ## github.com/spf13/cobra
 
 **License:** Apache-2.0
@@ -395,11 +431,11 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/stefanberger/go-pkcs11uri/blob/master/LICENSE>
 
-## github.com/sylabs/oci-tools/pkg/sif
+## github.com/sylabs/oci-tools/pkg
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/sylabs/oci-tools/blob/master/pkg/sif/LICENSE>
+**License URL:** <https://github.com/sylabs/oci-tools/blob/master/pkg/LICENSE>
 
 ## github.com/vbatts/go-mtree/pkg/govis
 
@@ -611,6 +647,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/miekg/pkcs11/blob/master/LICENSE>
 
+## github.com/pierrec/lz4/v4
+
+**License:** BSD-3-Clause
+
+**License URL:** <https://github.com/pierrec/lz4/blob/master/v4/LICENSE>
+
 ## github.com/proglottis/gpgme
 
 **License:** BSD-3-Clause
@@ -743,6 +785,12 @@ The dependencies and their licenses are as follows:
 
 **Project URL:** <https://mvdan.cc/sh/v3>
 
+## github.com/therootcompany/xz
+
+**License:** CC0-1.0
+
+**License URL:** <https://github.com/therootcompany/xz/blob/master/LICENSE>
+
 ## github.com/BurntSushi/toml
 
 **License:** MIT
@@ -785,6 +833,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/astromechza/etcpwdparse/blob/master/LICENSE.md>
 
+## github.com/becheran/wildmatch-go
+
+**License:** MIT
+
+**License URL:** <https://github.com/becheran/wildmatch-go/blob/master/LICENSE>
+
 ## github.com/beorn7/perks/quantile
 
 **License:** MIT
@@ -796,6 +850,12 @@ The dependencies and their licenses are as follows:
 **License:** MIT
 
 **License URL:** <https://github.com/blang/semver/blob/master/v4/LICENSE>
+
+## github.com/bmatcuk/doublestar/v4
+
+**License:** MIT
+
+**License URL:** <https://github.com/bmatcuk/doublestar/blob/master/v4/LICENSE>
 
 ## github.com/buger/goterm
 
@@ -857,6 +917,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/felixge/httpsnoop/blob/master/LICENSE.txt>
 
+## github.com/gabriel-vasile/mimetype
+
+**License:** MIT
+
+**License URL:** <https://github.com/gabriel-vasile/mimetype/blob/master/LICENSE>
+
 ## github.com/go-log/log
 
 **License:** MIT
@@ -911,6 +977,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/mattn/go-runewidth/blob/master/LICENSE>
 
+## github.com/mitchellh/go-homedir
+
+**License:** MIT
+
+**License URL:** <https://github.com/mitchellh/go-homedir/blob/master/LICENSE>
+
 ## github.com/mitchellh/mapstructure
 
 **License:** MIT
@@ -959,6 +1031,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/sirupsen/logrus/blob/master/LICENSE>
 
+## github.com/sylabs/squashfs
+
+**License:** MIT
+
+**License URL:** <https://github.com/sylabs/squashfs/blob/master/LICENSE>
+
 ## github.com/titanous/rocacheck
 
 **License:** MIT
@@ -970,6 +1048,18 @@ The dependencies and their licenses are as follows:
 **License:** MIT
 
 **License URL:** <https://github.com/urfave/cli/blob/master/LICENSE>
+
+## github.com/wagoodman/go-partybus
+
+**License:** MIT
+
+**License URL:** <https://github.com/wagoodman/go-partybus/blob/master/LICENSE>
+
+## github.com/wagoodman/go-progress
+
+**License:** MIT
+
+**License URL:** <https://github.com/wagoodman/go-progress/blob/master/LICENSE>
 
 ## go.etcd.io/bbolt
 

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -57,6 +57,9 @@ var (
 	pullArch string
 	// pullArchVariant is the architecture variant, e.g., arm32v5, arm32v6, arm32v7, v5,v6,v7 are variants
 	pullArchVariant string
+	// pullOci sets whether a pull from an OCI source should be converted to an
+	// OCI-SIF, rather than apptainer's native SIF format.
+	pullOci bool
 )
 
 // --arch
@@ -144,6 +147,18 @@ var pullAllowUnauthenticatedFlag = cmdline.Flag{
 	Hidden:       true,
 }
 
+// --oci
+var pullOciFlag = cmdline.Flag{
+	ID:           "pullOciFlag",
+	Value:        &pullOci,
+	DefaultValue: false,
+	Name:         "oci",
+	ShortHand:    "",
+	Usage:        "pull to an OCI-SIF (OCI sources only)",
+	EnvKeys:      []string{"OCI"},
+	Hidden:       true,
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(PullCmd)
@@ -166,6 +181,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&pullAllowUnauthenticatedFlag, PullCmd)
 		cmdManager.RegisterFlagForCmd(&pullArchFlag, PullCmd)
 		cmdManager.RegisterFlagForCmd(&pullArchVariantFlag, PullCmd)
+		cmdManager.RegisterFlagForCmd(&pullOciFlag, PullCmd)
 	})
 }
 
@@ -294,6 +310,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			NoHTTPS:    noHTTPS,
 			NoCleanUp:  buildArgs.noCleanUp,
 			Pullarch:   arch,
+			OciSif:     pullOci,
 		}
 
 		_, err = oci.PullToFile(ctx, imgCache, pullTo, pullFrom, pullOpts)

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -334,9 +334,6 @@ func EnsureOCIArchive(t *testing.T, env TestEnv) {
 
 // EnsureImage checks if e2e OCI-SIF file is available, and fetches it
 // otherwise.
-//
-// TODO - Temporary implementation. This should eventually be built here from an
-// OCI source, not downloaded.
 func EnsureOCISIF(t *testing.T, env TestEnv) {
 	ensureMutex.Lock()
 	defer ensureMutex.Unlock()
@@ -356,11 +353,13 @@ func EnsureOCISIF(t *testing.T, env TestEnv) {
 			err)
 	}
 
-	ociSifURI := "https://s3.amazonaws.com/singularity-ci-public/alpine-oci-sif-squashfs.sif"
-	t.Logf("Downloading %s to %s", ociSifURI, env.OCISIFPath)
-	if err := DownloadFile(ociSifURI, env.OCISIFPath); err != nil {
-		t.Fatalf("couldn't download oci-sif test image: %v", err)
-	}
+	env.RunApptainer(
+		t,
+		WithProfile(UserProfile),
+		WithCommand("pull"),
+		WithArgs("--oci", "--no-https", env.OCISIFPath, env.TestRegistryImage),
+		ExpectExit(0),
+	)
 }
 
 // EnsureDockerArchive checks if e2e Docker test archive is available, and fetches

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -47,6 +47,7 @@ type testStruct struct {
 	unauthenticated  bool   // pass --allow-unauthenticated
 	setImagePath     bool   // pass destination path
 	setPullDir       bool   // pass --dir
+	oci              bool   // pass --oci
 	expectedExitCode int
 	workDir          string
 	pullDir          string
@@ -91,6 +92,10 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 
 	if tt.library != "" {
 		argv += "--library " + tt.library + " "
+	}
+
+	if tt.oci {
+		argv += "--oci "
 	}
 
 	if tt.imagePath != "" {
@@ -359,6 +364,15 @@ func (c ctx) testPullCmd(t *testing.T) {
 			force:            true,
 			expectedExitCode: 255,
 		},
+		// pulling from local registry to OCI-SIF
+		{
+			desc:             "local registry oci-sif",
+			srcURI:           c.env.TestRegistryImage,
+			oci:              true,
+			noHTTPS:          true,
+			force:            true,
+			expectedExitCode: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -519,21 +533,37 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 		name      string
 		imagePath string
 		imageSrc  string
+		oci       bool
+		noHTTPS   bool
 	}{
 		{
 			name:      "library",
-			imagePath: filepath.Join(c.env.TestDir, "library.sif"),
+			imagePath: filepath.Join(c.env.TestDir, "nocache-library.sif"),
 			imageSrc:  "oras://ghcr.io/apptainer/alpine:latest",
 		},
 		{
 			name:      "oras",
-			imagePath: filepath.Join(c.env.TestDir, "oras.sif"),
+			imagePath: filepath.Join(c.env.TestDir, "nocache-oras.sif"),
 			imageSrc:  fmt.Sprintf("oras://%s/pull_test_sif:latest", c.env.TestRegistry),
+		},
+		{
+			name:      "oci-sif",
+			imagePath: filepath.Join(c.env.TestDir, "nocache-oci-sif.sif"),
+			imageSrc:  c.env.TestRegistryImage,
+			oci:       true,
+			noHTTPS:   true,
 		},
 	}
 
 	for _, tt := range disableCacheTests {
-		cmdArgs := []string{"--disable-cache", tt.imagePath, tt.imageSrc}
+		cmdArgs := []string{"--disable-cache"}
+		if tt.oci {
+			cmdArgs = append(cmdArgs, "--oci")
+		}
+		if tt.noHTTPS {
+			cmdArgs = append(cmdArgs, "--no-https")
+		}
+		cmdArgs = append(cmdArgs, tt.imagePath, tt.imageSrc)
 		c.env.RunApptainer(
 			t,
 			e2e.AsSubtest(tt.name),

--- a/go.mod
+++ b/go.mod
@@ -78,13 +78,18 @@ require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/alexflint/go-filemutex v1.2.0 // indirect
+	github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8 // indirect
+	github.com/anchore/stereoscope v0.0.0-20230627195312-cd49355d934e // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/becheran/wildmatch-go v1.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
 	github.com/bugsnag/bugsnag-go v1.5.1 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
 	github.com/containers/ocicrypt v1.1.7 // indirect
 	github.com/containers/storage v1.48.0 // indirect
@@ -101,6 +106,7 @@ require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -138,6 +144,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/patternmatcher v0.5.0 // indirect
@@ -148,6 +155,8 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/networkplumbing/go-nft v0.3.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pelletier/go-toml v1.9.5 // indirect
+	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/proglottis/gpgme v0.1.3 // indirect
 	github.com/prometheus/client_golang v1.15.1 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
@@ -157,11 +166,15 @@ require (
 	github.com/rootless-containers/proto v0.1.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/safchain/ethtool v0.3.0 // indirect
+	github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
 	github.com/sigstore/fulcio v1.3.1 // indirect
 	github.com/sigstore/rekor v1.2.2-0.20230601122533-4c81ff246d12 // indirect
+	github.com/spf13/afero v1.9.5 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 // indirect
+	github.com/sylabs/squashfs v0.6.1 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
+	github.com/therootcompany/xz v1.0.1 // indirect
 	github.com/theupdateframework/go-tuf v0.5.2 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/ulikunitz/xz v0.5.11 // indirect
@@ -169,6 +182,8 @@ require (
 	github.com/vbatts/tar-split v0.11.3 // indirect
 	github.com/vishvananda/netlink v1.2.1-beta.2 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
+	github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d // indirect
+	github.com/wagoodman/go-progress v0.0.0-20230301185719-21920a456ad5 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
+cloud.google.com/go v0.44.3/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
@@ -16,6 +17,7 @@ cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOY
 cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
 cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKPI=
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
+cloud.google.com/go v0.75.0/go.mod h1:VGuuCn7PG0dwsd5XPVm2Mm3wlh3EL55/79EKB6hlPTY=
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
 cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb8=
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
@@ -46,6 +48,7 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
+cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774/go.mod h1:6/0dYRLLXyJjbkIPeeGyoJ/eKOSI0eU6eTlCBYibgd0=
@@ -132,6 +135,11 @@ github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:C
 github.com/alexflint/go-filemutex v1.1.0/go.mod h1:7P4iRhttt/nUvUOrYIhcpMzv2G6CY9UnI16Z+UJqRyk=
 github.com/alexflint/go-filemutex v1.2.0 h1:1v0TJPDtlhgpW4nJ+GvxCLSlUDC3+gW0CQQvlmfDR/s=
 github.com/alexflint/go-filemutex v1.2.0/go.mod h1:mYyQSWvw9Tx2/H2n9qXPb52tTYfE0pZAWcBq5mK025c=
+github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8 h1:imgMA0gN0TZx7PSa/pdWqXadBvrz8WsN6zySzCe4XX0=
+github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8/go.mod h1:+gPap4jha079qzRTUaehv+UZ6sSdaNwkH0D3b6zhTuk=
+github.com/anchore/stereoscope v0.0.0-20230627195312-cd49355d934e h1:zhk3ZLtomMJ750nNCE+c24PonMzoO/SeL/4uTr1L9kM=
+github.com/anchore/stereoscope v0.0.0-20230627195312-cd49355d934e/go.mod h1:0LsgHgXO4QFnk2hsYwtqd3fR18PIZXlFLIl2qb9tu3g=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apex/log v1.4.0/go.mod h1:UMNC4vQNC7hb5gyr47r18ylK1n34rV7GO+gb0wpXvcE=
@@ -163,6 +171,8 @@ github.com/astromechza/etcpwdparse v0.0.0-20170319193008-f0e5f0779716/go.mod h1:
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
+github.com/becheran/wildmatch-go v1.0.0 h1:mE3dGGkTmpKtT4Z+88t8RStG40yN9T+kFEGj2PZFSzA=
+github.com/becheran/wildmatch-go v1.0.0/go.mod h1:gbMvj0NtVdJ15Mg/mH9uxk2R1QCistMyU7d9KFzroX4=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -175,6 +185,8 @@ github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
@@ -304,6 +316,7 @@ github.com/containerd/nri v0.1.0/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3
 github.com/containerd/stargz-snapshotter/estargz v0.4.1/go.mod h1:x7Q9dg9QYb4+ELgxmo4gBUeJB0tl5dqH1Sdz0nJU1QM=
 github.com/containerd/stargz-snapshotter/estargz v0.11.0/go.mod h1:/KsZXsJRllMbTKFfG0miFQWViQKdI9+9aSXs+HN0+ac=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3 h1:OqlDCK3ZVUO6C3B/5FSkDwbkEETK84kQgEeFwDC+62k=
+github.com/containerd/stargz-snapshotter/estargz v0.14.3/go.mod h1:KY//uOCIkSuNAHhJogcZtrNHdKrA99/FCCRjE3HD36o=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c/go.mod h1:LPm1u0xBw8r8NOKoOdNMeVHSawSsltak+Ihv+etqsE8=
@@ -459,6 +472,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
+github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
+github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
@@ -472,6 +487,8 @@ github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
+github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
+github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 h1:LofdAjjjqCSXMwLGgOgnE+rdPuvX9DxCqaHwKy7i/ko=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -664,6 +681,7 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
@@ -683,6 +701,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
+github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gookit/color v1.2.5/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
@@ -1013,16 +1033,21 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.9 h1:uH2qQXheeefCCkuBBSLi7jCiSmj3VRh2+Goq2N7Xxu0=
 github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
+github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
+github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
+github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -1097,6 +1122,8 @@ github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXn
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
+github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e h1:7q6NSFZDeGfvvtIRwBrU/aegEYJYmvev0cHAwo17zZQ=
+github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
 github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
@@ -1145,6 +1172,8 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
+github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
+github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
@@ -1194,12 +1223,16 @@ github.com/sylabs/release-tools v0.1.0/go.mod h1:pqP/z/11/rYMQ0OM/Nn7TxGijw7KfZw
 github.com/sylabs/sif/v2 v2.3.1/go.mod h1:NnvveH62GiibimL00MrI6YYcZfb7DnZMcRo/40giY+0=
 github.com/sylabs/sif/v2 v2.11.6-0.20230615203820-9fe9b624c3fd h1:aysDHxLYzP6NZalH2TqqvouQVshwBcXpY4wDknj7Hxg=
 github.com/sylabs/sif/v2 v2.11.6-0.20230615203820-9fe9b624c3fd/go.mod h1:XxXJwOlRZY5B9RcT+eCy76aSpdNwkRWmFmI4mX1LnwA=
+github.com/sylabs/squashfs v0.6.1 h1:4hgvHnD9JGlYWwT0bPYNt9zaz23mAV3Js+VEgQoRGYQ=
+github.com/sylabs/squashfs v0.6.1/go.mod h1:ZwpbPCj0ocIvMy2br6KZmix6Gzh6fsGQcCnydMF+Kx8=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tchap/go-patricia v2.3.0+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/therootcompany/xz v1.0.1 h1:CmOtsn1CbtmyYiusbfmhmkpAAETj0wBIH6kCYaX+xzw=
+github.com/therootcompany/xz v1.0.1/go.mod h1:3K3UH1yCKgBneZYhuQUvJ9HPD19UEXEI0BWbMn8qNMY=
 github.com/theupdateframework/go-tuf v0.5.2 h1:habfDzTmpbzBLIFGWa2ZpVhYvFBoK0C1onC3a4zuPRA=
 github.com/theupdateframework/go-tuf v0.5.2/go.mod h1:SyMV5kg5n4uEclsyxXJZI2UxPFJNDc4Y+r7wv+MlvTA=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -1250,6 +1283,10 @@ github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1Y
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d h1:KOxOL6qpmqwoPloNwi+CEgc1ayjHNOFNrvoOmeDOjDg=
+github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d/go.mod h1:JPirS5jde/CF5qIjcK4WX+eQmKXdPc6vcZkJ/P0hfPw=
+github.com/wagoodman/go-progress v0.0.0-20230301185719-21920a456ad5 h1:lwgTsTy18nYqASnH58qyfRW/ldj7Gt2zzBvgYPzdA4s=
+github.com/wagoodman/go-progress v0.0.0-20230301185719-21920a456ad5/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
@@ -1349,6 +1386,7 @@ golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/crypto v0.11.0 h1:6Ewdq3tDic1mg5xRO4milcWCfMVQhI4NkqWWvqejpuA=
@@ -1576,6 +1614,7 @@ golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1586,6 +1625,7 @@ golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1713,6 +1753,7 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
@@ -1807,7 +1848,9 @@ google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210222152913-aa3ee6e6a81c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=

--- a/internal/pkg/client/oci/ocisif.go
+++ b/internal/pkg/client/oci/ocisif.go
@@ -1,0 +1,166 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2023 Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	buildoci "github.com/apptainer/apptainer/internal/pkg/build/oci"
+	"github.com/apptainer/apptainer/internal/pkg/cache"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs"
+	"github.com/apptainer/apptainer/pkg/sylog"
+	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/match"
+	ggcrmutate "github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/sylabs/oci-tools/pkg/mutate"
+	"github.com/sylabs/oci-tools/pkg/sif"
+)
+
+// pull will create an OCI-SIF image in the cache if directTo="", or a specific file if directTo is set.
+//
+//nolint:dupl
+func pullOciSif(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, opts PullOptions) (imagePath string, err error) {
+	sys := sysCtx(opts)
+	hash, err := buildoci.ImageDigest(ctx, pullFrom, sys)
+	if err != nil {
+		return "", fmt.Errorf("failed to get checksum for %s: %s", pullFrom, err)
+	}
+
+	if directTo != "" {
+		sylog.Infof("Converting OCI image to OCI-SIF format")
+		if err := createOciSif(ctx, imgCache, pullFrom, directTo, opts); err != nil {
+			return "", fmt.Errorf("while creating OCI-SIF: %v", err)
+		}
+		imagePath = directTo
+	} else {
+
+		cacheEntry, err := imgCache.GetEntry(cache.OciSifCacheType, hash)
+		if err != nil {
+			return "", fmt.Errorf("unable to check if %v exists in cache: %v", hash, err)
+		}
+		defer cacheEntry.CleanTmp()
+		if !cacheEntry.Exists {
+			sylog.Infof("Converting OCI image to OCI-SIF format")
+
+			if err := createOciSif(ctx, imgCache, pullFrom, cacheEntry.TmpPath, opts); err != nil {
+				return "", fmt.Errorf("while creating OCI-SIF: %v", err)
+			}
+
+			err = cacheEntry.Finalize()
+			if err != nil {
+				return "", err
+			}
+
+		} else {
+			sylog.Infof("Using cached OCI-SIF image")
+		}
+		imagePath = cacheEntry.Path
+	}
+
+	return imagePath, nil
+}
+
+// createOciSif will convert an OCI source into an OCI-SIF using sylabs/oci-tools
+func createOciSif(ctx context.Context, imgCache *cache.Handle, imageSrc, imageDest string, opts PullOptions) error {
+	// Step 1 - Pull the OCI config and blobs to a standalone oci layout directory, through the cache if necessary.
+	sys := sysCtx(opts)
+	layoutDir, err := os.MkdirTemp(opts.TmpDir, "oci-sif-tmp-")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		sylog.Infof("Cleaning up...")
+		if err := fs.ForceRemoveAll(layoutDir); err != nil {
+			sylog.Warningf("Couldn't remove oci-sif temporary layout %q: %v", layoutDir, err)
+		}
+	}()
+	sylog.Debugf("Fetching image to temporary layout %q", layoutDir)
+	layoutRef, err := buildoci.FetchLayout(ctx, sys, imgCache, imageSrc, layoutDir)
+	if err != nil {
+		return fmt.Errorf("while fetching OCI image: %w", err)
+	}
+
+	// Step 2 - Work from containers/image ImageReference -> gocontainerregistry digest
+	layoutSrc, err := layoutRef.NewImageSource(ctx, sys)
+	if err != nil {
+		return err
+	}
+	defer layoutSrc.Close()
+	imgManifest, _, err := layoutSrc.GetManifest(ctx, nil)
+	if err != nil {
+		return err
+	}
+	digest, _, err := v1.SHA256(bytes.NewBuffer(imgManifest))
+	if err != nil {
+		return err
+	}
+
+	// Step 3 - Convert the layout into a squashed, single squashfs-layer oci-sif image
+	return layoutToOciSif(layoutDir, digest, imageDest, opts.TmpDir)
+}
+
+// layoutToOciSif will convert an image in an OCI layout to a squashed oci-sif with squashfs layer format.
+// The OCI layout can contain only a single image.
+func layoutToOciSif(layoutDir string, digest v1.Hash, imageDest, tmpDir string) error {
+	lp, err := layout.FromPath(layoutDir)
+	if err != nil {
+		return fmt.Errorf("while opening layout: %w", err)
+	}
+	img, err := lp.Image(digest)
+	if err != nil {
+		return fmt.Errorf("while retrieving image: %w", err)
+	}
+
+	sylog.Infof("Squashing image to single layer...")
+	img, err = mutate.Squash(img)
+	if err != nil {
+		return fmt.Errorf("while squashing image: %w", err)
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		return fmt.Errorf("while retrieving layers: %w", err)
+	}
+	if len(layers) != 1 {
+		return fmt.Errorf("%d > 1 layers remaining after squash operation", len(layers))
+	}
+	squashfsLayer, err := mutate.SquashfsLayer(layers[0], tmpDir)
+	if err != nil {
+		return fmt.Errorf("while converting to squashfs format: %w", err)
+	}
+	img, err = mutate.Apply(img,
+		mutate.ReplaceLayers(squashfsLayer),
+		mutate.SetHistory(v1.History{
+			Created:    v1.Time{time.Now()}, //nolint:govet
+			CreatedBy:  useragent.Value(),
+			Comment:    "oci-sif created from " + digest.Hex,
+			EmptyLayer: false,
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("while replacing layers: %w", err)
+	}
+
+	sylog.Infof("Writing oci-sif image...")
+	if err := lp.ReplaceImage(img, match.Digests(digest)); err != nil {
+		return fmt.Errorf("while replacing image: %w", err)
+	}
+	ii := ggcrmutate.AppendManifests(empty.Index, ggcrmutate.IndexAddendum{
+		Add: img,
+	})
+	return sif.Write(imageDest, ii)
+}

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -14,14 +14,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 
-	"github.com/apptainer/apptainer/internal/pkg/build"
-	"github.com/apptainer/apptainer/internal/pkg/build/oci"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
-	buildtypes "github.com/apptainer/apptainer/pkg/build/types"
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
@@ -37,8 +33,8 @@ type PullOptions struct {
 	Pullarch   string
 }
 
-// pull will build a SIF image into the cache if directTo="", or a specific file if directTo is set.
-func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, opts PullOptions) (imagePath string, err error) {
+// sysCtx provides authentication and tempDir config for containers/image OCI operations
+func sysCtx(opts PullOptions) *ocitypes.SystemContext {
 	// DockerInsecureSkipTLSVerify is set only if --no-https is specified to honor
 	// configuration from /etc/containers/registries.conf because DockerInsecureSkipTLSVerify
 	// can have three possible values true/false and undefined, so we left it as undefined instead
@@ -51,88 +47,11 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 		DockerRegistryUserAgent:  useragent.Value(),
 		BigFilesTemporaryDir:     opts.TmpDir,
 	}
-	if opts.Pullarch != "" {
-		if arch, ok := oci.ArchMap[opts.Pullarch]; ok {
-			sysCtx.ArchitectureChoice = arch.Arch
-			sysCtx.VariantChoice = arch.Var
-		} else {
-			keys := reflect.ValueOf(oci.ArchMap).MapKeys()
-			return "", fmt.Errorf("failed to parse the arch value: %s, should be one of %v", opts.Pullarch, keys)
-		}
-	}
 
 	if opts.NoHTTPS {
 		sysCtx.DockerInsecureSkipTLSVerify = ocitypes.NewOptionalBool(true)
 	}
-
-	hash, err := oci.ImageDigest(ctx, pullFrom, sysCtx)
-	if err != nil {
-		return "", fmt.Errorf("failed to get checksum for %s: %s", pullFrom, err)
-	}
-
-	if directTo != "" {
-		sylog.Infof("Converting OCI blobs to SIF format")
-		if err := convertOciToSIF(ctx, imgCache, pullFrom, directTo, opts); err != nil {
-			return "", fmt.Errorf("while building SIF from layers: %v", err)
-		}
-		imagePath = directTo
-	} else {
-
-		cacheEntry, err := imgCache.GetEntry(cache.OciTempCacheType, hash)
-		if err != nil {
-			return "", fmt.Errorf("unable to check if %v exists in cache: %v", hash, err)
-		}
-		defer cacheEntry.CleanTmp()
-		if !cacheEntry.Exists {
-			sylog.Infof("Converting OCI blobs to SIF format")
-
-			if err := convertOciToSIF(ctx, imgCache, pullFrom, cacheEntry.TmpPath, opts); err != nil {
-				return "", fmt.Errorf("while building SIF from layers: %v", err)
-			}
-
-			err = cacheEntry.Finalize()
-			if err != nil {
-				return "", err
-			}
-
-		} else {
-			sylog.Infof("Using cached SIF image")
-		}
-		imagePath = cacheEntry.Path
-	}
-
-	return imagePath, nil
-}
-
-// convertOciToSIF will convert an OCI source into a SIF using the build routines
-func convertOciToSIF(ctx context.Context, imgCache *cache.Handle, image, cachedImgPath string, opts PullOptions) error {
-	if imgCache == nil {
-		return fmt.Errorf("image cache is undefined")
-	}
-
-	b, err := build.NewBuild(
-		image,
-		build.Config{
-			Dest:      cachedImgPath,
-			Format:    "sif",
-			NoCleanUp: opts.NoCleanUp,
-			Opts: buildtypes.Options{
-				TmpDir:           opts.TmpDir,
-				NoCache:          imgCache.IsDisabled(),
-				NoTest:           true,
-				NoHTTPS:          opts.NoHTTPS,
-				DockerAuthConfig: opts.OciAuth,
-				DockerDaemonHost: opts.DockerHost,
-				ImgCache:         imgCache,
-				Arch:             opts.Pullarch,
-			},
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("unable to create new build: %v", err)
-	}
-
-	return b.Full(ctx)
+	return sysCtx
 }
 
 // Pull will build a SIF image to the cache or direct to a temporary file if cache is disabled
@@ -148,7 +67,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, opts Pul
 		sylog.Infof("Downloading library image to tmp cache: %s", directTo)
 	}
 
-	return pull(ctx, imgCache, directTo, pullFrom, opts)
+	return pullSif(ctx, imgCache, directTo, pullFrom, opts)
 }
 
 // PullToFile will build a SIF image from the specified oci URI and place it at the specified dest
@@ -159,7 +78,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom st
 		sylog.Debugf("Cache disabled, pulling directly to: %s", directTo)
 	}
 
-	src, err := pull(ctx, imgCache, directTo, pullFrom, opts)
+	src, err := pullSif(ctx, imgCache, directTo, pullFrom, opts)
 	if err != nil {
 		if strings.Contains(err.Error(), "unsupported image-specific operation on artifact with type \"application/vnd.unknown.config.v1+json\"") {
 			return "", fmt.Errorf("%v; try changing the protocol to oras://", err)

--- a/internal/pkg/client/oci/sif.go
+++ b/internal/pkg/client/oci/sif.go
@@ -1,0 +1,104 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/apptainer/apptainer/internal/pkg/build"
+	"github.com/apptainer/apptainer/internal/pkg/build/oci"
+	"github.com/apptainer/apptainer/internal/pkg/cache"
+	buildtypes "github.com/apptainer/apptainer/pkg/build/types"
+	"github.com/apptainer/apptainer/pkg/sylog"
+)
+
+// pullSif will build a SIF image into the cache if directTo="", or a specific file if directTo is set.
+func pullSif(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, opts PullOptions) (imagePath string, err error) {
+	sys := sysCtx(opts)
+	if opts.Pullarch != "" {
+		if arch, ok := oci.ArchMap[opts.Pullarch]; ok {
+			sys.ArchitectureChoice = arch.Arch
+			sys.VariantChoice = arch.Var
+		} else {
+			keys := reflect.ValueOf(oci.ArchMap).MapKeys()
+			return "", fmt.Errorf("failed to parse the arch value: %s, should be one of %v", opts.Pullarch, keys)
+		}
+	}
+	hash, err := oci.ImageDigest(ctx, pullFrom, sys)
+	if err != nil {
+		return "", fmt.Errorf("failed to get checksum for %s: %s", pullFrom, err)
+	}
+
+	if directTo != "" {
+		sylog.Infof("Converting OCI blobs to SIF format")
+		if err := convertOciToSIF(ctx, imgCache, pullFrom, directTo, opts); err != nil {
+			return "", fmt.Errorf("while building SIF from layers: %v", err)
+		}
+		imagePath = directTo
+	} else {
+
+		cacheEntry, err := imgCache.GetEntry(cache.OciTempCacheType, hash)
+		if err != nil {
+			return "", fmt.Errorf("unable to check if %v exists in cache: %v", hash, err)
+		}
+		defer cacheEntry.CleanTmp()
+		if !cacheEntry.Exists {
+			sylog.Infof("Converting OCI blobs to SIF format")
+
+			if err := convertOciToSIF(ctx, imgCache, pullFrom, cacheEntry.TmpPath, opts); err != nil {
+				return "", fmt.Errorf("while building SIF from layers: %v", err)
+			}
+
+			err = cacheEntry.Finalize()
+			if err != nil {
+				return "", err
+			}
+
+		} else {
+			sylog.Infof("Using cached SIF image")
+		}
+		imagePath = cacheEntry.Path
+	}
+
+	return imagePath, nil
+}
+
+// convertOciToSIF will convert an OCI source into a SIF using the build routines
+func convertOciToSIF(ctx context.Context, imgCache *cache.Handle, image, cachedImgPath string, opts PullOptions) error {
+	if imgCache == nil {
+		return fmt.Errorf("image cache is undefined")
+	}
+
+	b, err := build.NewBuild(
+		image,
+		build.Config{
+			Dest:      cachedImgPath,
+			Format:    "sif",
+			NoCleanUp: opts.NoCleanUp,
+			Opts: buildtypes.Options{
+				TmpDir:           opts.TmpDir,
+				NoCache:          imgCache.IsDisabled(),
+				NoTest:           true,
+				NoHTTPS:          opts.NoHTTPS,
+				DockerAuthConfig: opts.OciAuth,
+				DockerDaemonHost: opts.DockerHost,
+				ImgCache:         imgCache,
+			},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create new build: %v", err)
+	}
+
+	return b.Full(ctx)
+}

--- a/internal/pkg/client/oci/sif.go
+++ b/internal/pkg/client/oci/sif.go
@@ -23,6 +23,8 @@ import (
 )
 
 // pullSif will build a SIF image into the cache if directTo="", or a specific file if directTo is set.
+//
+//nolint:dupl
 func pullSif(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, opts PullOptions) (imagePath string, err error) {
 	sys := sysCtx(opts)
 	if opts.Pullarch != "" {


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1878
 which fixed
- sylabs/singularity# 1859

The original PR description was:
> Add a new flag `--oci` to the `pull` command.
> 
> When `pull --oci` is used to pull from an OCI source, create an OCI-SIF image.
> 
> First, we use existing code built around containers/image to create a temporary oci layout directory holding the source image. This step will use the existing OCI blob cache.
> 
> We modify the temporary oci layout using sylabs/oci-tools, to squash the layers down to one, and convert from .tar.gz to squashfs format.
> 
> _Note r.e. test coverage:_
> 
> There is coverage of the code added and amended here, in `E2E/PULL` and because a `pull --oci` is now used to generate the image used for most OCI mode e2e tests.
> 
> However, it would be useful to break up the OCI -> OCI-SIF conversion so that it's possible to introduce non-e2e tests that use: https://pkg.go.dev/github.com/google/go-containerregistry/pkg/v1/validate to perform explicit validation. I'll open a tech debt issue.

