### PR TITLE
oci: re-exec as early as possible, from sylabs 1883

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -28,7 +28,6 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher/native"
 	ocilauncher "github.com/apptainer/apptainer/internal/pkg/runtime/launcher/oci"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
-	"github.com/apptainer/apptainer/internal/pkg/util/rootless"
 	"github.com/apptainer/apptainer/internal/pkg/util/uri"
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -307,20 +306,6 @@ var TestCmd = &cobra.Command{
 }
 
 func launchContainer(cmd *cobra.Command, image string, containerCmd string, containerArgs []string, instanceName string) error {
-	// The OCI runtime must always be launched where the effective uid/gid is 0 (root or fake-root).
-	if ociRuntime && !rootless.InNS() {
-		// If we need to, enter a new cgroup now, to workaround an issue with crun container cgroup creation (#1538).
-		if err := ocilauncher.CrunNestCgroup(); err != nil {
-			return fmt.Errorf("while applying crun cgroup workaround: %w", err)
-		}
-		// If we are root already, run the launcher in a new mount namespace only.
-		if os.Geteuid() == 0 {
-			return rootless.RunInMountNS(os.Args[1:])
-		}
-		// If we are not root, re-exec in a root-mapped user namespace and mount namespace.
-		return rootless.ExecWithFakeroot(os.Args[1:])
-	}
-
 	ns := launcher.Namespaces{
 		User: userNamespace,
 		UTS:  utsNamespace,

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -28,8 +28,10 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/plugin"
 	"github.com/apptainer/apptainer/internal/pkg/remote"
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
+	ocilauncher "github.com/apptainer/apptainer/internal/pkg/runtime/launcher/oci"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
+	"github.com/apptainer/apptainer/internal/pkg/util/rootless"
 	"github.com/apptainer/apptainer/pkg/cmdline"
 	clicallback "github.com/apptainer/apptainer/pkg/plugin/callback/cli"
 	"github.com/apptainer/apptainer/pkg/syfs"
@@ -515,6 +517,11 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 	// It will be overridden later if using setuid flow.
 	apptainerconf.SetBinaryPath(buildcfg.LIBEXECDIR, true)
 
+	// If we need to enter a namespace (oci-mode) do the re-exec now, before any other handling happens.
+	if err := maybeReExec(); err != nil {
+		return err
+	}
+
 	// Handle the config dir (~/.apptainer),
 	// then check the remove conf file permission.
 	handleConfDir(syfs.ConfigDir(), syfs.LegacyConfigDir())
@@ -869,4 +876,22 @@ func getLibraryClientConfig(uri string) (*libClient.Config, error) {
 		return nil, fmt.Errorf("remote has no library client (see https://apptainer.org/docs/user/latest/endpoint.html#no-default-remote)")
 	}
 	return libClientConfig, nil
+}
+
+func maybeReExec() error {
+	sylog.Debugf("Checking whether to re-exec")
+	// The OCI runtime must always be launched where the effective uid/gid is 0 (root or fake-root).
+	if ociRuntime && !rootless.InNS() {
+		// If we need to, enter a new cgroup now, to workaround an issue with crun container cgroup creation (#1538).
+		if err := ocilauncher.CrunNestCgroup(); err != nil {
+			return fmt.Errorf("while applying crun cgroup workaround: %w", err)
+		}
+		// If we are root already, run the launcher in a new mount namespace only.
+		if os.Geteuid() == 0 {
+			return rootless.RunInMountNS(os.Args[1:])
+		}
+		// If we are not root, re-exec in a root-mapped user namespace and mount namespace.
+		return rootless.ExecWithFakeroot(os.Args[1:])
+	}
+	return nil
 }

--- a/internal/pkg/util/rootless/rootless.go
+++ b/internal/pkg/util/rootless/rootless.go
@@ -123,5 +123,10 @@ func RunInMountNS(args []string) error {
 	if errors.As(err, &exitErr) {
 		os.Exit(exitErr.ExitCode())
 	}
+
+	if err == nil {
+		os.Exit(0)
+	}
+
 	return err
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1883

The original PR description was:
> When we need to enter a mount or user namespace to begin oci-mode operation, do so as early as possible.
> 
> The CLI code has a lot of logic in it, much of which may run twice if we re-exec in `launchContainer`. This code may also cause side effects.
> 
> Re-execing much earlier, at the root command's `PersistentPreRun`, avoids these issues.


