### PR TITLE
oci: switch direct run/shell/exec from URI to oci-sif flow, from sylabs 1882

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - The `pull` command now accepts a new flag `--oci` for OCI image sources. This
   will create an OCI-SIF image rather than convert to Apptainer's native
   container format.
+- OCI-mode now supports running OCI-SIF images directly from http/https URIs.
 
 ### Developer / API
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -66,6 +66,11 @@ func (c actionTests) actionOciRun(t *testing.T) {
 			exit:     0,
 		},
 		{
+			name:     "oci-sif-http",
+			imageRef: "https://s3.amazonaws.com/singularity-ci-public/alpine-oci-sif-squashfs.sif",
+			exit:     0,
+		},
+		{
 			name:     "docker-archive",
 			imageRef: "docker-archive:" + c.env.DockerArchivePath,
 			exit:     0,

--- a/internal/pkg/build/oci/fetch.go
+++ b/internal/pkg/build/oci/fetch.go
@@ -92,7 +92,7 @@ func FetchLayout(ctx context.Context, sysCtx *types.SystemContext, imgCache *cac
 		return nil, fmt.Errorf("invalid image source: %v", err)
 	}
 
-	if imgCache != nil {
+	if imgCache != nil && !imgCache.IsDisabled() {
 		// Grab the modified source ref from the cache
 		srcRef, err = ConvertReference(ctx, imgCache, srcRef, sysCtx)
 		if err != nil {

--- a/internal/pkg/client/oci/ocisif.go
+++ b/internal/pkg/client/oci/ocisif.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	buildoci "github.com/apptainer/apptainer/internal/pkg/build/oci"
@@ -78,16 +79,26 @@ func pullOciSif(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom 
 func createOciSif(ctx context.Context, imgCache *cache.Handle, imageSrc, imageDest string, opts PullOptions) error {
 	// Step 1 - Pull the OCI config and blobs to a standalone oci layout directory, through the cache if necessary.
 	sys := sysCtx(opts)
-	layoutDir, err := os.MkdirTemp(opts.TmpDir, "oci-sif-tmp-")
+	tmpDir, err := os.MkdirTemp(opts.TmpDir, "oci-sif-tmp-")
 	if err != nil {
 		return err
 	}
 	defer func() {
 		sylog.Infof("Cleaning up...")
-		if err := fs.ForceRemoveAll(layoutDir); err != nil {
-			sylog.Warningf("Couldn't remove oci-sif temporary layout %q: %v", layoutDir, err)
+		if err := fs.ForceRemoveAll(tmpDir); err != nil {
+			sylog.Warningf("Couldn't remove oci-sif temporary directory %q: %v", tmpDir, err)
 		}
 	}()
+
+	layoutDir := filepath.Join(tmpDir, "layout")
+	if err := os.Mkdir(layoutDir, 0o755); err != nil {
+		return err
+	}
+	workDir := filepath.Join(tmpDir, "work")
+	if err := os.Mkdir(workDir, 0o755); err != nil {
+		return err
+	}
+
 	sylog.Debugf("Fetching image to temporary layout %q", layoutDir)
 	layoutRef, err := buildoci.FetchLayout(ctx, sys, imgCache, imageSrc, layoutDir)
 	if err != nil {
@@ -110,12 +121,12 @@ func createOciSif(ctx context.Context, imgCache *cache.Handle, imageSrc, imageDe
 	}
 
 	// Step 3 - Convert the layout into a squashed, single squashfs-layer oci-sif image
-	return layoutToOciSif(layoutDir, digest, imageDest, opts.TmpDir)
+	return layoutToOciSif(layoutDir, digest, imageDest, workDir)
 }
 
 // layoutToOciSif will convert an image in an OCI layout to a squashed oci-sif with squashfs layer format.
 // The OCI layout can contain only a single image.
-func layoutToOciSif(layoutDir string, digest v1.Hash, imageDest, tmpDir string) error {
+func layoutToOciSif(layoutDir string, digest v1.Hash, imageDest, workDir string) error {
 	lp, err := layout.FromPath(layoutDir)
 	if err != nil {
 		return fmt.Errorf("while opening layout: %w", err)
@@ -138,7 +149,7 @@ func layoutToOciSif(layoutDir string, digest v1.Hash, imageDest, tmpDir string) 
 	if len(layers) != 1 {
 		return fmt.Errorf("%d > 1 layers remaining after squash operation", len(layers))
 	}
-	squashfsLayer, err := mutate.SquashfsLayer(layers[0], tmpDir)
+	squashfsLayer, err := mutate.SquashfsLayer(layers[0], workDir)
 	if err != nil {
 		return fmt.Errorf("while converting to squashfs format: %w", err)
 	}

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -47,6 +47,7 @@ func sysCtx(opts PullOptions) *ocitypes.SystemContext {
 		AuthFilePath:             syfs.DockerConf(),
 		DockerRegistryUserAgent:  useragent.Value(),
 		BigFilesTemporaryDir:     opts.TmpDir,
+		DockerDaemonHost:         opts.DockerHost,
 	}
 
 	if opts.NoHTTPS {


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1882
 which fixed
- sylabs/singularity# 1860

The original PR description was:
> When a direct URI is provided for `run/shell/exec` in `--oci` mode, perform a pull through the cache to obtain an OCI-SIF image, and execute this.
> 
> `--oci` mode is no longer limited to OCI URIs or `oci-sif` as valid sources. If an `oci-sif` can be retrieved from the library/shub/oras/http/https protocols it can be run.
> 
> At this point, http/https is trivial to e2e-test so can be supported.
> 
> The barriers for the other protocols are primarily around pushing an image, rather than pulling. When push of oci-sif is supported and tested in follow-up PRs, then we can list the protocols as supported.
> 
> This PR also incorporates some small fixes for issues exposed by existing e2e-tests when the URI->oci-sif flow was enabled:
> 
> **fix: Set DockerHost in oci client sysCtx**
> 
> `DOCKER_HOST` was not being honored in this flow.
> 
> **fix: check if cache disabled in FetchLayout**
> 
> We need to avoid trying to use the cache in FetchLayout if it's disabled, as well as if none was provided.
> 
> **fix: Cleanup oci-tools Squash workdir properly**
> 
> As the function docs state, we are responsible for cleaning up the work directory we provide to `mutate.Squash`.
