### PR TITLE
e2e: oci: oras push/pull/run, from sylabs 1884

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - The `pull` command now accepts a new flag `--oci` for OCI image sources. This
   will create an OCI-SIF image rather than convert to Apptainer's native
   container format.
-- OCI-mode now supports running OCI-SIF images directly from http/https URIs.
+- OCI-mode now supports running OCI-SIF images directly from http/https and oras
+  URIs.
+- OCI-SIF images can be pushed/pulled to/from oras URIs.
 
 ### Developer / API
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -45,6 +45,7 @@ func (c actionTests) actionOciRun(t *testing.T) {
 	e2e.EnsureOCIArchive(t, c.env)
 	e2e.EnsureOCISIF(t, c.env)
 	e2e.EnsureDockerArchive(t, c.env)
+	e2e.EnsureORASOCISIF(t, c.env)
 
 	// Prepare oci source (oci directory layout)
 	ociLayout := t.TempDir()
@@ -63,6 +64,11 @@ func (c actionTests) actionOciRun(t *testing.T) {
 		{
 			name:     "oci-sif",
 			imageRef: "oci-sif:" + c.env.OCISIFPath,
+			exit:     0,
+		},
+		{
+			name:     "oci-sif-oras",
+			imageRef: c.env.OrasTestOCISIF,
 			exit:     0,
 		},
 		{

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -18,6 +18,7 @@ type TestEnv struct {
 	SingularityImagePath string // Path to a Singularity image for legacy tests
 	DebianImagePath      string // Path to an image containing a Debian distribution with libc compatible to the host libc
 	OrasTestImage        string // URI to SIF image pushed into local registry with ORAS
+	OrasTestOCISIF       string // URI to OCI-SIF image pushed into local registry with ORAS
 	OCIArchivePath       string // Path to test OCI archive tar file
 	OCISIFPath           string // Path to test OCI-SIF file
 	TestDir              string // Path to the directory from which an Apptainer command needs to be executed

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -286,6 +286,29 @@ func BusyboxSIF(t *testing.T) string {
 	return busyboxSIF
 }
 
+var orasOCISIFOnce sync.Once
+
+func EnsureORASOCISIF(t *testing.T, env TestEnv) {
+	EnsureOCISIF(t, env)
+
+	ensureMutex.Lock()
+	defer ensureMutex.Unlock()
+
+	orasOCISIFOnce.Do(func() {
+		t.Logf("Pushing %s to %s", env.OCISIFPath, env.OrasTestOCISIF)
+		env.RunApptainer(
+			t,
+			WithProfile(UserProfile),
+			WithCommand("push"),
+			WithArgs(env.OCISIFPath, env.OrasTestOCISIF),
+			ExpectExit(0),
+		)
+		if t.Failed() {
+			t.Fatalf("failed to push ORAS oci-sif image to local registry")
+		}
+	})
+}
+
 func DownloadFile(url string, path string) error {
 	dl, err := os.Create(path)
 	if err != nil {

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -144,6 +144,7 @@ func getImageNameFromURI(imgURI string) string {
 
 func (c *ctx) setup(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
+	e2e.EnsureOCISIF(t, c.env)
 
 	// setup file and dir to use as invalid images
 	orasInvalidDir, err := os.MkdirTemp(c.env.TestDir, "oras_push_dir-")
@@ -182,6 +183,11 @@ func (c *ctx) setup(t *testing.T) {
 		{
 			srcPath:        orasInvalidFile,
 			uri:            fmt.Sprintf("%s/pull_test_invalid_file:latest", c.env.TestRegistry),
+			layerMediaType: syoras.SifLayerMediaTypeV1,
+		},
+		{
+			srcPath:        c.env.OCISIFPath,
+			uri:            fmt.Sprintf("%s/pull_test_oci-sif:latest", c.env.TestRegistry),
 			layerMediaType: syoras.SifLayerMediaTypeV1,
 		},
 	}
@@ -316,6 +322,13 @@ func (c ctx) testPullCmd(t *testing.T) {
 			srcURI:           fmt.Sprintf("oras://%s/pull_test_sif_mediatypeproto:latest", c.env.TestRegistry),
 			force:            true,
 			unauthenticated:  false,
+			expectedExitCode: 0,
+		},
+		// OCI-SIF
+		{
+			desc:             "oras pull of oci-sif",
+			srcURI:           "oras://" + c.env.TestRegistry + "/pull_test_oci-sif:latest",
+			force:            true,
 			expectedExitCode: 0,
 		},
 

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -59,6 +59,7 @@ func (c ctx) testInvalidTransport(t *testing.T) {
 
 func (c ctx) testPushCmd(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
+	e2e.EnsureOCISIF(t, c.env)
 
 	// setup file and dir to use as invalid sources
 	orasInvalidDir, err := os.MkdirTemp(c.env.TestDir, "oras_push_dir-")
@@ -109,6 +110,12 @@ func (c ctx) testPushCmd(t *testing.T) {
 			imagePath:        c.env.ImagePath,
 			dstURI:           fmt.Sprintf("oras://%s/standard_sif:test_nohttps", c.env.InsecureRegistry),
 			noHTTPS:          true,
+			expectedExitCode: 0,
+		},
+		{
+			desc:             "OCI-SIF push",
+			imagePath:        c.env.OCISIFPath,
+			dstURI:           fmt.Sprintf("oras://%s/oci-sif:test", c.env.TestRegistry),
 			expectedExitCode: 0,
 		},
 	}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -206,6 +206,9 @@ func Run(t *testing.T) {
 	// Local registry ORAS SIF image, built on demand by e2e.EnsureORASImage
 	testenv.OrasTestImage = fmt.Sprintf("oras://%s/oras_test_sif:latest", testenv.TestRegistry)
 
+	// Local registry ORAS OCI-SIF image, built on demand by e2e.EnsureORASOCISIF
+	testenv.OrasTestOCISIF = fmt.Sprintf("oras://%s/oras_test_oci-sif:latest", testenv.TestRegistry)
+
 	t.Cleanup(func() {
 		if !t.Failed() {
 			os.Remove(imagePath)


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1884
 which fixed
- sylabs/singularity# 1863
- sylabs/singularity# 1864

The original PR description was:
> Add e2e tests for push / pull / run against oras URIs, with OCI-SIF images.
> 
> This is a testing-only change. Because our oras code will push/pull any SIF image, it is working as of sylabs/singularity# 1882.