### PR TITLE
pkg/image: Add minimal oci-sif type, from sylabs 1886

### DIFF
--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -257,7 +257,7 @@ func ensureSIF(filepath string) error {
 	}
 	defer img.File.Close()
 
-	if img.Type != image.SIF {
+	if img.Type != image.SIF && img.Type != image.OCISIF {
 		return fmt.Errorf("%q is not a SIF", filepath)
 	}
 

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -30,7 +30,7 @@ const (
 	EXT3
 	// SANDBOX constant for directory format
 	SANDBOX
-	// SIF constant for sif format
+	// SIF constant for sif format (native image, not OCI-SIF)
 	SIF
 	// ENCRYPTSQUASHFS constant for encrypted squashfs format
 	ENCRYPTSQUASHFS
@@ -38,6 +38,8 @@ const (
 	RAW
 	// GOCRYPTFS constant for encrypted gocryptfs format
 	GOCRYPTFSSQUASHFS
+	// OCISIF constant for OCI-SIF images
+	OCISIF
 )
 
 type Usage uint8
@@ -105,6 +107,7 @@ var registeredFormats = []struct {
 }{
 	{"sandbox", &sandboxFormat{}},
 	{"sif", &sifFormat{}},
+	{"ocisif", &ociSifFormat{}},
 	{"squashfs", &squashfsFormat{}},
 	{"ext3", &ext3Format{}},
 }

--- a/pkg/image/ocisif.go
+++ b/pkg/image/ocisif.go
@@ -1,0 +1,66 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package image
+
+import (
+	"bytes"
+	"os"
+
+	"github.com/apptainer/sif/v2/pkg/sif"
+)
+
+type ociSifFormat struct{}
+
+// initializer performs minimal detection of oci-sif images only.
+// It does not populate any information except img.Type.
+func (f *ociSifFormat) initializer(img *Image, fi os.FileInfo) error {
+	if fi.IsDir() {
+		return debugError("not an oci-sif file image")
+	}
+	b := make([]byte, bufferSize)
+	if n, err := img.File.Read(b); err != nil || n != bufferSize {
+		return debugErrorf("can't read first %d bytes: %v", bufferSize, err)
+	}
+	if !bytes.Contains(b, []byte("SIF_MAGIC")) {
+		return debugError("SIF magic not found")
+	}
+
+	flag := os.O_RDONLY
+	if img.Writable {
+		flag = os.O_RDWR
+	}
+
+	// Load the SIF file
+	fimg, err := sif.LoadContainer(img.File,
+		sif.OptLoadWithFlag(flag),
+		sif.OptLoadWithCloseOnUnload(false),
+	)
+	if err != nil {
+		return err
+	}
+	defer fimg.UnloadContainer()
+
+	// It's a SIF, but an OCI-SIF.
+	if _, err := fimg.GetDescriptor(sif.WithDataType(sif.DataOCIRootIndex)); err != nil {
+		return debugErrorf("image is not an OCI-SIF")
+	}
+
+	img.Type = OCISIF
+
+	return nil
+}
+
+func (f *ociSifFormat) openMode(writable bool) int {
+	return os.O_RDONLY
+}
+
+func (f *ociSifFormat) lock(img *Image) error {
+	return nil
+}

--- a/pkg/image/ocisif_test.go
+++ b/pkg/image/ocisif_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package image
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/apptainer/sif/v2/pkg/sif"
+)
+
+//nolint:dupl
+func TestOCISIFInitializer(t *testing.T) {
+	ociMinimal := func() (sif.DescriptorInput, error) {
+		return sif.NewDescriptorInput(sif.DataOCIRootIndex, bytes.NewBufferString("{}\n"))
+	}
+
+	tests := []struct {
+		name               string
+		path               string
+		writable           bool
+		expectedSuccess    bool
+		expectedPartitions int
+		expectedSections   int
+	}{
+		{
+			name:               "OCISIF",
+			path:               createSIF(t, false, ociMinimal),
+			writable:           false,
+			expectedSuccess:    true,
+			expectedPartitions: 0,
+			expectedSections:   0,
+		},
+		{
+			name:               "Empty",
+			path:               createSIF(t, false),
+			writable:           false,
+			expectedSuccess:    false,
+			expectedPartitions: 0,
+			expectedSections:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+
+			ociSifFmt := new(ociSifFormat)
+			mode := ociSifFmt.openMode(tt.writable)
+
+			img := &Image{
+				Path: tt.path,
+				Name: tt.path,
+			}
+
+			img.Writable = tt.writable
+			img.File, err = os.OpenFile(tt.path, mode, 0)
+			if err != nil {
+				t.Fatalf("cannot open image's file: %s\n", err)
+			}
+			defer img.File.Close()
+
+			fileinfo, err := img.File.Stat()
+			if err != nil {
+				t.Fatalf("cannot stat the image file: %s\n", err)
+			}
+
+			err = ociSifFmt.initializer(img, fileinfo)
+			os.Remove(tt.path)
+
+			if (err == nil) != tt.expectedSuccess {
+				t.Fatalf("got error %v, expect success %v", err, tt.expectedSuccess)
+			} else if tt.expectedPartitions != len(img.Partitions) {
+				t.Fatalf("unexpected partitions number: %d instead of %d", len(img.Partitions), tt.expectedPartitions)
+			} else if tt.expectedSections != len(img.Sections) {
+				t.Fatalf("unexpected sections number: %d instead of %d", len(img.Sections), tt.expectedSections)
+			}
+		})
+	}
+}
+
+func TestOCISIFOpenMode(t *testing.T) {
+	var ociSifFmt ociSifFormat
+
+	if ociSifFmt.openMode(true) != os.O_RDONLY {
+		t.Fatal("openMode(true) returned the wrong value")
+	}
+	if ociSifFmt.openMode(false) != os.O_RDONLY {
+		t.Fatal("openMode(false) returned the wrong value")
+	}
+}

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -83,6 +83,11 @@ func (f *sifFormat) initializer(img *Image, fi os.FileInfo) error {
 		return err
 	}
 	defer fimg.UnloadContainer()
+
+	// It's a SIF, but an OCI-SIF.
+	if _, err := fimg.GetDescriptor(sif.WithDataType(sif.DataOCIRootIndex)); err == nil {
+		return debugErrorf("image is an OCI-SIF")
+	}
 
 	var groupID uint32
 

--- a/pkg/image/sif_test.go
+++ b/pkg/image/sif_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -64,6 +64,7 @@ func createSIF(t *testing.T, corrupted bool, fns ...func() (sif.DescriptorInput,
 	return sifFile.Name()
 }
 
+//nolint:dupl
 func TestSIFInitializer(t *testing.T) {
 	b, err := os.ReadFile(testSquash)
 	if err != nil {
@@ -96,6 +97,10 @@ func TestSIFInitializer(t *testing.T) {
 		return sif.NewDescriptorInput(sif.DataPartition, bytes.NewReader(b),
 			sif.OptPartitionMetadata(sif.FsSquash, sif.PartOverlay, runtime.GOARCH),
 		)
+	}
+
+	ociMinimal := func() (sif.DescriptorInput, error) {
+		return sif.NewDescriptorInput(sif.DataOCIRootIndex, bytes.NewBufferString("{}\n"))
 	}
 
 	tests := []struct {
@@ -169,6 +174,14 @@ func TestSIFInitializer(t *testing.T) {
 			expectedSuccess:    true,
 			expectedPartitions: 1,
 			expectedSections:   1,
+		},
+		{
+			name:               "OCISIF",
+			path:               createSIF(t, false, ociMinimal),
+			writable:           false,
+			expectedSuccess:    false,
+			expectedPartitions: 0,
+			expectedSections:   0,
 		},
 	}
 


### PR DESCRIPTION
This pulls in sylabs PRs

- sylabs/singularity# 1886
- sylabs/singularity# 1891
 which fixed
- sylabs/singularity# 1890

The original PR descriptions were:
> Add a minimal oci-sif image type to pkg/image, that does not implement any functionality other than oci-sif detection.
> 
> Ensure oci-sif detected as oci-sif, and are not detected as the existing sif type.
> 
> Modify the native launcher to return a more friendly error if a user attempts to run an oci-sif with it.
> 
> Prep work for sylabs/singularity# 1861
> 
> Example...
> 
> ```
> $ singularity run alpine_latest.sif 
> FATAL:   While checking image: native runtime does not support OCI-SIF images, use --oci mode
> ```

> After sylabs/singularity# 1886 the check for a vaild SIF image must be relaxed to include `image.OCISIF`.
> 
> e2e-tests caught this bug on main after merge, but not on the PR CI run.