### PR TITLE
oci: switch `oci mount` to squashfuse, from sylabs 1904

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   inheritable / ambient capabilites, matching other OCI runtimes.
 - In OCI-mode, a container run as root, or with `--fakeroot` has OCI default
   effective/permitted capabilities.
+- `apptainer oci mount` now uses, and requires, `squashfuse` to mount a SIF
+  image to an OCI bundle.
 
 ### New Features & Functionality
 

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -84,6 +84,8 @@ func (c *ctx) checkOciState(t *testing.T, containerID, state string) {
 
 func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 	require.Seccomp(t)
+	require.Command(t, "squashfuse")
+	require.Command(t, "fusermount")
 	require.Filesystem(t, "overlay")
 
 	bundleDir, err := os.MkdirTemp(c.env.TestDir, "bundle-")

--- a/internal/pkg/util/fs/squashfs/squashfs.go
+++ b/internal/pkg/util/fs/squashfs/squashfs.go
@@ -10,6 +10,13 @@
 package squashfs
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
 	"github.com/apptainer/apptainer/internal/pkg/util/bin"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
@@ -51,4 +58,47 @@ func GetMem() (string, error) {
 	mem := c.MksquashfsMem
 
 	return mem, err
+}
+
+func FUSEMount(ctx context.Context, offset uint64, path, mountPath string) error {
+	args := []string{
+		"-o", fmt.Sprintf("ro,offset=%d,uid=%d,gid=%d", offset, os.Getuid(), os.Getgid()),
+		filepath.Clean(path),
+		filepath.Clean(mountPath),
+	}
+
+	squashfuse, err := bin.FindBin("squashfuse")
+	if err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, squashfuse, args...) //nolint:gosec
+
+	sylog.Debugf("Executing %s %s", squashfuse, strings.Join(args, " "))
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to mount: %w", err)
+	}
+
+	return nil
+}
+
+func FUSEUnmount(ctx context.Context, mountPath string) error {
+	args := []string{
+		"-u",
+		filepath.Clean(mountPath),
+	}
+
+	fusermount, err := bin.FindBin("fusermount")
+	if err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, fusermount, args...) //nolint:gosec
+
+	sylog.Debugf("Executing %s %s", fusermount, strings.Join(args, " "))
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to unmount: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/ocibundle/ocisif/bundle_linux.go
+++ b/pkg/ocibundle/ocisif/bundle_linux.go
@@ -14,11 +14,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs/squashfs"
 	"github.com/apptainer/apptainer/pkg/ocibundle"
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -86,7 +86,7 @@ func (b *Bundle) Delete(ctx context.Context) error {
 
 	if b.imageMounted {
 		sylog.Debugf("Unmounting squashfs rootfs image from %q", tools.RootFs(b.bundlePath).Path())
-		if err := unmountSquashFS(ctx, tools.RootFs(b.bundlePath).Path()); err != nil {
+		if err := squashfs.FUSEUnmount(ctx, tools.RootFs(b.bundlePath).Path()); err != nil {
 			return err
 		}
 	}
@@ -225,39 +225,5 @@ func mount(ctx context.Context, path, mountPath string, digest v1.Hash) error {
 	if err != nil {
 		return fmt.Errorf("failed to get partition descriptor: %w", err)
 	}
-	return mountSquashFS(ctx, d.Offset(), path, mountPath)
-}
-
-func mountSquashFS(ctx context.Context, offset int64, path, mountPath string) error {
-	args := []string{
-		"-o", fmt.Sprintf("ro,offset=%d,uid=%d,gid=%d", offset, os.Getuid(), os.Getgid()),
-		filepath.Clean(path),
-		filepath.Clean(mountPath),
-	}
-	//nolint:gosec // note (gosec exclusion) - we require callers to be able to specify squashfuse not on PATH
-	cmd := exec.CommandContext(ctx, "squashfuse", args...)
-
-	sylog.Debugf("Executing squashfuse %s", strings.Join(args, " "))
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to mount: %w", err)
-	}
-
-	return nil
-}
-
-func unmountSquashFS(ctx context.Context, mountPath string) error {
-	args := []string{
-		"-u",
-		filepath.Clean(mountPath),
-	}
-	cmd := exec.CommandContext(ctx, "fusermount", args...) //nolint:gosec
-
-	sylog.Debugf("Executing fusermount %s", strings.Join(args, " "))
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to unmount: %w", err)
-	}
-
-	return nil
+	return squashfs.FUSEMount(ctx, uint64(d.Offset()), path, mountPath)
 }

--- a/pkg/ocibundle/sif/bundle_linux.go
+++ b/pkg/ocibundle/sif/bundle_linux.go
@@ -16,9 +16,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs/squashfs"
 	imageSpecs "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
@@ -117,7 +118,6 @@ func (s *sifBundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 		return fmt.Errorf("unsupported image fs type: %v", part.Type)
 	}
 	offset := part.Offset
-	size := part.Size
 
 	// generate OCI bundle directory and config
 	g, err := tools.GenerateBundleConfig(s.bundlePath, ociConfig)
@@ -125,31 +125,23 @@ func (s *sifBundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 		return fmt.Errorf("failed to generate OCI bundle/config: %s", err)
 	}
 
-	// associate SIF image with a block
-	loop, loopCloser, err := tools.CreateLoop(img.File, offset, size)
-	if err != nil {
-		tools.DeleteBundle(s.bundlePath)
-		return fmt.Errorf("failed to find loop device: %s", err)
-	}
-	defer loopCloser.Close()
-
 	rootFs := tools.RootFs(s.bundlePath).Path()
-	if err := syscall.Mount(loop, rootFs, "squashfs", syscall.MS_RDONLY, ""); err != nil {
+	if err := squashfs.FUSEMount(ctx, offset, s.image, rootFs); err != nil {
 		tools.DeleteBundle(s.bundlePath)
 		return fmt.Errorf("failed to mount SIF partition: %s", err)
 	}
 
 	if err := s.writeConfig(img, g); err != nil {
-		// best effort to release loop device
-		syscall.Unmount(rootFs, syscall.MNT_DETACH)
+		// best effort to release FUSE mount
+		squashfs.FUSEUnmount(ctx, rootFs)
 		tools.DeleteBundle(s.bundlePath)
 		return fmt.Errorf("failed to write OCI configuration: %s", err)
 	}
 
 	if s.writable {
 		if err := tools.CreateOverlay(s.bundlePath); err != nil {
-			// best effort to release loop device
-			syscall.Unmount(rootFs, syscall.MNT_DETACH)
+			// best effort to release FUSE mount
+			squashfs.FUSEUnmount(ctx, rootFs)
 			tools.DeleteBundle(s.bundlePath)
 			return fmt.Errorf("failed to create overlay: %s", err)
 		}
@@ -164,14 +156,15 @@ func (s *sifBundle) Update(ctx context.Context, ociConfig *specs.Spec) error {
 
 // Delete erases OCI bundle create from SIF image
 func (s *sifBundle) Delete(ctx context.Context) error {
-	if s.writable {
+	overlayExists := fs.IsDir(filepath.Join(s.bundlePath, "overlay"))
+	if s.writable && overlayExists {
 		if err := tools.DeleteOverlay(s.bundlePath); err != nil {
 			return fmt.Errorf("delete error: %s", err)
 		}
 	}
 	// Umount rootfs
 	rootFsDir := tools.RootFs(s.bundlePath).Path()
-	if err := syscall.Unmount(rootFsDir, syscall.MNT_DETACH); err != nil {
+	if err := squashfs.FUSEUnmount(ctx, rootFsDir); err != nil {
 		return fmt.Errorf("failed to unmount %s: %s", rootFsDir, err)
 	}
 	// delete bundle directory


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1904
 which fixed
- sylabs/singularity# 1897

The original PR description was:
> The singularity SIF -> OCI bundle mount was previously performed with a kernel squashfs mount.
> 
> We will be using `pkg/ocibundle/sif` as the basis of `--oci` mode execution of singularity SIF (non oci-sif) images.
> 
> Switch the mount to use squashfuse for consistency. `--oci` mode does not perform kernel mounts from SIF.