### PR TITLE
oci: Execute non-oci SIF in --oci mode, from sylabs 1906

### DIFF
--- a/cmd/internal/cli/checkpoint.go
+++ b/cmd/internal/cli/checkpoint.go
@@ -17,6 +17,7 @@ import (
 	"github.com/apptainer/apptainer/docs"
 	"github.com/apptainer/apptainer/internal/pkg/checkpoint/dmtcp"
 	"github.com/apptainer/apptainer/internal/pkg/instance"
+	"github.com/apptainer/apptainer/internal/pkg/runtime/launcher"
 	"github.com/apptainer/apptainer/pkg/cmdline"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/spf13/cobra"
@@ -166,9 +167,13 @@ var CheckpointInstanceCmd = &cobra.Command{
 
 		sylog.Infof("Using checkpoint %q", e.Name())
 
-		containerCmd := "/.singularity.d/actions/exec"
-		containerArgs := dmtcp.CheckpointArgs(port)
-		if err := launchContainer(cmd, "instance://"+args[0], containerCmd, containerArgs, ""); err != nil {
+		ep := launcher.ExecParams{
+			Image:   "instance://" + args[0],
+			Action:  "exec",
+			Process: "/.singularity.d/actions/exec",
+			Args:    dmtcp.CheckpointArgs(port),
+		}
+		if err := launchContainer(cmd, ep); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -109,9 +109,19 @@ func (c actionTests) actionOciRun(t *testing.T) {
 			exit:     1,
 		},
 		{
-			name:     "non-oci-sif",
+			name:     "native-sif",
 			imageRef: c.env.ImagePath,
-			exit:     255,
+			exit:     0,
+		},
+		{
+			name:     "native-sif-oras",
+			imageRef: c.env.OrasTestImage,
+			exit:     0,
+		},
+		{
+			name:     "native-sif-library",
+			imageRef: "library://busybox:1.31.1",
+			exit:     0,
 		},
 	}
 

--- a/internal/pkg/runtime/launcher/launcher.go
+++ b/internal/pkg/runtime/launcher/launcher.go
@@ -2,24 +2,20 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 // Package launcher is responsible for implementing launchers, which can start a
 // container, with configuration passed from the CLI layer.
-//
-// The package currently implements a single native.Launcher, with an Exec
-// method that constructs a runtime configuration and calls the Apptainer
-// runtime starter binary to start the container.
-//
-// TODO - the launcher package will be extended to support launching containers
-// via the OCI runc/crun runtime, in addition to the current Apptainer runtime
-// starter, by adding an oci.Launcher.
 package launcher
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+)
 
 // Launcher is responsible for configuring and launching a container image.
 // It will execute a runtime, such as Apptainer's native runtime (via the starter
@@ -29,5 +25,62 @@ type Launcher interface {
 	// passing arguments 'args'. If instanceName is specified, the container
 	// must be launched as a background instance, otherwise it must run
 	// interactively, attached to the console.
-	Exec(ctx context.Context, image string, process string, args []string, instanceName string) error
+	Exec(ctx context.Context, ep ExecParams) error
+}
+
+// ExecParams specifies the image and process for a launcher to Exec.
+type ExecParams struct {
+	// Image is the container image to execute, as a bare path, or <transport>:<path>.
+	Image string
+	// Action is one of exec/run/shell/start/test as specified on the CLI.
+	Action string
+	// Process is the command to execute as the container process, where applicable.
+	Process string
+	// Args are the arguments passed to the container process.
+	Args []string
+	// Instance is the name of an instance (optional).
+	Instance string
+}
+
+const apptainerActions = "/.singularity.d/actions"
+
+// ActionScriptArgs returns the args that will appropriately exec the action
+// script in a apptainer (non-oci) container, for a given ExecParams.
+func (ep ExecParams) ActionScriptArgs() (args []string, err error) {
+	if ep.Image == "" {
+		return []string{}, fmt.Errorf("%s action requires an image", ep.Action)
+	}
+
+	args = []string{filepath.Join(apptainerActions, ep.Action)}
+
+	switch ep.Action {
+	case "exec":
+		if ep.Process == "" {
+			return []string{}, fmt.Errorf("%s action requires a process", ep.Action)
+		}
+		if ep.Instance != "" {
+			return []string{}, fmt.Errorf("%s action doesn't support specifying an instance", ep.Action)
+		}
+		args = append(args, ep.Process)
+		args = append(args, ep.Args...)
+	case "run", "shell", "test":
+		if ep.Process != "" {
+			return []string{}, fmt.Errorf("%s action doesn't support specifying a process", ep.Action)
+		}
+		if ep.Instance != "" {
+			return []string{}, fmt.Errorf("%s action doesn't support specifying an instance", ep.Action)
+		}
+		args = append(args, ep.Args...)
+	case "start":
+		if ep.Process != "" {
+			return []string{}, fmt.Errorf("%s action doesn't support specifying a process", ep.Action)
+		}
+		if ep.Instance == "" {
+			return []string{}, fmt.Errorf("%s action requires an instance", ep.Action)
+		}
+		args = append(args, ep.Args...)
+	default:
+		return []string{}, fmt.Errorf("unknown action %q", ep.Action)
+	}
+	return args, nil
 }

--- a/internal/pkg/runtime/launcher/launcher_test.go
+++ b/internal/pkg/runtime/launcher/launcher_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package launcher
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExecParams_ActionArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		Image    string
+		Action   string
+		Process  string
+		Args     []string
+		Instance string
+		wantArgs []string
+		wantErr  bool
+	}{
+		// exec
+		{
+			name:     "exec",
+			Image:    "image.sif",
+			Action:   "exec",
+			Process:  "process",
+			wantArgs: []string{"/.singularity.d/actions/exec", "process"},
+			wantErr:  false,
+		},
+		{
+			name:     "execArgs",
+			Image:    "image.sif",
+			Action:   "exec",
+			Process:  "process",
+			Args:     []string{"a", "b", "c"},
+			wantArgs: []string{"/.singularity.d/actions/exec", "process", "a", "b", "c"},
+			wantErr:  false,
+		},
+		{
+			name:     "execNoProcess",
+			Image:    "image.sif",
+			Action:   "exec",
+			Args:     []string{"a", "b", "c"},
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "execWithInstance",
+			Image:    "image.sif",
+			Action:   "exec",
+			Process:  "process",
+			Instance: "myinstance",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		// run
+		{
+			name:     "run",
+			Image:    "image.sif",
+			Action:   "run",
+			wantArgs: []string{"/.singularity.d/actions/run"},
+			wantErr:  false,
+		},
+		{
+			name:     "runArgs",
+			Image:    "image.sif",
+			Action:   "run",
+			Args:     []string{"a", "b", "c"},
+			wantArgs: []string{"/.singularity.d/actions/run", "a", "b", "c"},
+			wantErr:  false,
+		},
+		{
+			name:     "runNoImage",
+			Action:   "run",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "runWithProcess",
+			Image:    "image.sif",
+			Action:   "run",
+			Process:  "process",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "runWithInstance",
+			Image:    "image.sif",
+			Action:   "run",
+			Instance: "myinstance",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		// shell
+		{
+			name:     "shell",
+			Image:    "image.sif",
+			Action:   "shell",
+			wantArgs: []string{"/.singularity.d/actions/shell"},
+			wantErr:  false,
+		},
+		{
+			name:     "shellArgs",
+			Image:    "image.sif",
+			Action:   "shell",
+			Args:     []string{"a", "b", "c"},
+			wantArgs: []string{"/.singularity.d/actions/shell", "a", "b", "c"},
+			wantErr:  false,
+		},
+		{
+			name:     "shellWithProcess",
+			Image:    "image.sif",
+			Action:   "shell",
+			Process:  "process",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "shellWithInstance",
+			Image:    "image.sif",
+			Action:   "shell",
+			Instance: "myinstance",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		// start
+		{
+			name:     "start",
+			Image:    "image.sif",
+			Action:   "start",
+			Instance: "myinstance",
+			wantArgs: []string{"/.singularity.d/actions/start"},
+			wantErr:  false,
+		},
+		{
+			name:     "startArgs",
+			Image:    "image.sif",
+			Action:   "start",
+			Instance: "myinstance",
+			Args:     []string{"a", "b", "c"},
+			wantArgs: []string{"/.singularity.d/actions/start", "a", "b", "c"},
+			wantErr:  false,
+		},
+		{
+			name:     "startWithProcess",
+			Image:    "image.sif",
+			Action:   "start",
+			Instance: "myinstance",
+			Process:  "process",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "startNoInstance",
+			Image:    "image.sif",
+			Action:   "start",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		// test
+		{
+			name:     "test",
+			Image:    "image.sif",
+			Action:   "test",
+			wantArgs: []string{"/.singularity.d/actions/test"},
+			wantErr:  false,
+		},
+		{
+			name:     "testArgs",
+			Image:    "image.sif",
+			Action:   "test",
+			Args:     []string{"a", "b", "c"},
+			wantArgs: []string{"/.singularity.d/actions/test", "a", "b", "c"},
+			wantErr:  false,
+		},
+		{
+			name:     "testWithProcess",
+			Image:    "image.sif",
+			Action:   "test",
+			Process:  "process",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "testWithInstance",
+			Image:    "image.sif",
+			Action:   "test",
+			Instance: "myinstance",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		// Invalid
+		{
+			name:     "InvalidAction",
+			Image:    "image.sif",
+			Action:   "delete",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := ExecParams{
+				Image:    tt.Image,
+				Action:   tt.Action,
+				Process:  tt.Process,
+				Args:     tt.Args,
+				Instance: tt.Instance,
+			}
+			gotArgs, err := ep.ActionScriptArgs()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExecParams.ActionArgs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Errorf("ExecParams.ActionArgs() = %v, want %v", gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/ocibundle"
 	"github.com/apptainer/apptainer/pkg/ocibundle/native"
 	"github.com/apptainer/apptainer/pkg/ocibundle/ocisif"
+	sifbundle "github.com/apptainer/apptainer/pkg/ocibundle/sif"
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
@@ -64,6 +65,8 @@ type Launcher struct {
 	// homeDest is the computed destination (in the container) for the user's home directory.
 	// An empty value is not valid at mount time.
 	homeDest string
+	// nativeSIF is set true when we are running a non-OCI SIF built for the native runtime.
+	nativeSIF bool
 }
 
 // NewLauncher returns a oci.Launcher with an initial configuration set by opts.
@@ -270,7 +273,7 @@ func (l *Launcher) createSpec() (spec *specs.Spec, err error) {
 }
 
 // finalizeSpec updates the bundle config, filling in Process config that depends on the image spec.
-func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *specs.Spec, image string, process string, args []string) (err error) {
+func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *specs.Spec, ep launcher.ExecParams) (err error) {
 	imgSpec := b.ImageSpec()
 	if imgSpec == nil {
 		return fmt.Errorf("bundle has no image spec")
@@ -340,7 +343,7 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 		GID: targetGID,
 	}
 
-	specProcess, err := l.getProcess(ctx, *imgSpec, image, b.Path(), process, args, u)
+	specProcess, err := l.getProcess(ctx, *imgSpec, b.Path(), ep, u)
 	if err != nil {
 		return err
 	}
@@ -527,8 +530,8 @@ func (l *Launcher) prepareResolvConf(bundlePath string) (*specs.Mount, error) {
 
 // Exec will interactively execute a container via the runc low-level runtime.
 // image is a reference to an OCI image, e.g. docker://ubuntu or oci:/tmp/mycontainer
-func (l *Launcher) Exec(ctx context.Context, image string, process string, args []string, instanceName string) error {
-	if instanceName != "" {
+func (l *Launcher) Exec(ctx context.Context, ep launcher.ExecParams) error {
+	if ep.Instance != "" {
 		return fmt.Errorf("%w: instanceName", ErrNotImplemented)
 	}
 
@@ -537,7 +540,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	}
 
 	// Handle bare image paths and check image file format.
-	image, err := normalizeImageRef(image)
+	image, err := normalizeImageRef(ep.Image)
 	if err != nil {
 		return err
 	}
@@ -577,12 +580,23 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 
 	// Create a bundle - obtain and extract the image.
 	var b ocibundle.Bundle
-	if strings.HasPrefix(image, "oci-sif:") {
+
+	switch {
+
+	case strings.HasPrefix(image, "oci-sif:"):
 		b, err = ocisif.New(
 			ocisif.OptBundlePath(bundleDir),
 			ocisif.OptImageRef(image),
 		)
-	} else {
+	case strings.HasPrefix(image, "sif:"):
+		sylog.Infof("Running a non-OCI SIF in OCI mode. See user guide for compatibility information.")
+		b, err = sifbundle.FromSif(
+			strings.TrimPrefix(image, "sif:"),
+			bundleDir,
+			false,
+		)
+		l.nativeSIF = true
+	default:
 		b, err = native.New(
 			native.OptBundlePath(bundleDir),
 			native.OptImageRef(image),
@@ -598,7 +612,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	}
 
 	// With reference to the bundle's image spec, now set the process configuration.
-	if err := l.finalizeSpec(ctx, b, spec, image, process, args); err != nil {
+	if err := l.finalizeSpec(ctx, b, spec, ep); err != nil {
 		return err
 	}
 
@@ -709,8 +723,8 @@ func mergeMap(a map[string]string, b map[string]string) map[string]string {
 	return a
 }
 
-// normalizeImageRef transforms a bare image path to an oci-sif: prefixed path,
-// after checking the image is an oci-sif.
+// normalizeImageRef transforms a bare image path to an oci-sif: or sif: prefixed path,
+// after checking the image is an oci-sif or native (non-oci) sif.
 func normalizeImageRef(imageRef string) (string, error) {
 	imageRef = strings.TrimPrefix(imageRef, "oci-sif:")
 
@@ -738,7 +752,7 @@ func normalizeImageRef(imageRef string) (string, error) {
 	case imgutil.SANDBOX:
 		return "", fmt.Errorf("OCI mode cannot run bare directory/sandbox images")
 	case imgutil.SIF:
-		return "", fmt.Errorf("OCI mode cannot run non-OCI SIF images")
+		return "sif:" + imageRef, nil
 	case imgutil.RAW:
 		return "", fmt.Errorf("OCI mode cannot run raw images")
 	}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -119,8 +119,8 @@ func Test_normalizeImageRef(t *testing.T) {
 		{
 			name:     "sif image",
 			imageRef: "../../../../../test/images/empty.sif",
-			want:     "",
-			wantErr:  true,
+			want:     "sif:../../../../../test/images/empty.sif",
+			wantErr:  false,
 		},
 		{
 			name:     "oci ref",

--- a/internal/pkg/runtime/launcher/oci/process_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux_test.go
@@ -157,6 +157,7 @@ func TestEnvFileMap(t *testing.T) {
 func TestGetProcessArgs(t *testing.T) {
 	tests := []struct {
 		name              string
+		nativeSIF         bool
 		imgEntrypoint     []string
 		imgCmd            []string
 		bundleProcess     string
@@ -261,7 +262,11 @@ func TestGetProcessArgs(t *testing.T) {
 					Cmd:        tt.imgCmd,
 				},
 			}
-			args := getProcessArgs(i, tt.bundleProcess, tt.bundleArgs)
+			ep := launcher.ExecParams{
+				Process: tt.bundleProcess,
+				Args:    tt.bundleArgs,
+			}
+			args := getProcessArgs(i, ep)
 			if !reflect.DeepEqual(args, tt.expectProcessArgs) {
 				t.Errorf("Expected: %v, Got: %v", tt.expectProcessArgs, args)
 			}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -127,6 +127,8 @@ type Section struct {
 	ID           uint32 `json:"id"`
 	Type         uint32 `json:"type"`
 	AllowedUsage Usage  `json:"allowed_usage"`
+	// Architecture is only known for system partitions in SIF files.
+	Architecture string `json:"architecture,omitempty"`
 }
 
 // Image describes an image object, an image is composed of one

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -122,6 +122,7 @@ func (f *sifFormat) initializer(img *Image, fi os.FileInfo) error {
 				Name:         RootFs,
 				Type:         htype,
 				AllowedUsage: RootFsUsage,
+				Architecture: goArch,
 			},
 		}
 	}

--- a/pkg/ocibundle/sif/bundle_linux.go
+++ b/pkg/ocibundle/sif/bundle_linux.go
@@ -158,7 +158,7 @@ func (s *sifBundle) Update(ctx context.Context, ociConfig *specs.Spec) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate OCI bundle/config: %s", err)
 	}
-	return s.writeConfig(g)
+	return tools.SaveBundleConfig(s.bundlePath, g)
 }
 
 // Delete erases OCI bundle create from SIF image

--- a/pkg/ocibundle/sif/bundle_linux.go
+++ b/pkg/ocibundle/sif/bundle_linux.go
@@ -16,16 +16,19 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
+	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs/squashfs"
-	imageSpecs "github.com/opencontainers/image-spec/specs-go/v1"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/apptainer/apptainer/pkg/image"
 	"github.com/apptainer/apptainer/pkg/ocibundle"
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
+	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
 )
 
 type sifBundle struct {
@@ -33,22 +36,16 @@ type sifBundle struct {
 	bundlePath string
 	writable   bool
 	ocibundle.Bundle
+	arch string
+	// imageSpec is the OCI image information, CMD, ENTRYPOINT, etc.
+	imageSpec *imgspecv1.Image
 }
 
-func (s *sifBundle) writeConfig(img *image.Image, g *generate.Generator) error {
-	// check if SIF file contain an OCI image configuration
-	reader, err := image.NewSectionReader(img, image.SIFDescOCIConfigJSON, -1)
-	if err != nil && err != image.ErrNoSection {
-		return fmt.Errorf("failed to read %s section: %s", image.SIFDescOCIConfigJSON, err)
-	} else if err == image.ErrNoSection {
-		return tools.SaveBundleConfig(s.bundlePath, g)
+func (s *sifBundle) writeConfig(g *generate.Generator) error {
+	if s.imageSpec == nil {
+		return fmt.Errorf("cannot write bundle config with nil image spec")
 	}
-
-	var imgConfig imageSpecs.ImageConfig
-
-	if err := json.NewDecoder(reader).Decode(&imgConfig); err != nil {
-		return fmt.Errorf("failed to decode %s: %s", image.SIFDescOCIConfigJSON, err)
-	}
+	imgConfig := s.imageSpec.Config
 
 	if len(g.Config.Process.Args) == 1 && g.Config.Process.Args[0] == tools.RunScript {
 		args := imgConfig.Entrypoint
@@ -118,6 +115,11 @@ func (s *sifBundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 		return fmt.Errorf("unsupported image fs type: %v", part.Type)
 	}
 	offset := part.Offset
+	s.arch = part.Architecture
+
+	if err := s.setImageSpec(img); err != nil {
+		return fmt.Errorf("failed to set image spec: %w", err)
+	}
 
 	// generate OCI bundle directory and config
 	g, err := tools.GenerateBundleConfig(s.bundlePath, ociConfig)
@@ -131,7 +133,7 @@ func (s *sifBundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 		return fmt.Errorf("failed to mount SIF partition: %s", err)
 	}
 
-	if err := s.writeConfig(img, g); err != nil {
+	if err := s.writeConfig(g); err != nil {
 		// best effort to release FUSE mount
 		squashfs.FUSEUnmount(ctx, rootFs)
 		tools.DeleteBundle(s.bundlePath)
@@ -151,7 +153,12 @@ func (s *sifBundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 
 // Update will update the OCI config for the OCI bundle, so that it is ready for execution.
 func (s *sifBundle) Update(ctx context.Context, ociConfig *specs.Spec) error {
-	return fmt.Errorf("cannot update config of a SIF OCI bundle: not implemented")
+	// generate OCI bundle directory and config
+	g, err := tools.GenerateBundleConfig(s.bundlePath, ociConfig)
+	if err != nil {
+		return fmt.Errorf("failed to generate OCI bundle/config: %s", err)
+	}
+	return s.writeConfig(g)
 }
 
 // Delete erases OCI bundle create from SIF image
@@ -171,8 +178,47 @@ func (s *sifBundle) Delete(ctx context.Context) error {
 	return tools.DeleteBundle(s.bundlePath)
 }
 
-// ImageSpec returns nil for SIF bundles, as they currently do not carry an OCI image spec.
-func (s *sifBundle) ImageSpec() (imgSpec *imageSpecs.Image) {
+// ImageSpec returns an OCI Image Spec for the container.
+func (s *sifBundle) ImageSpec() *imgspecv1.Image {
+	return s.imageSpec
+}
+
+// setImageSpec will generate an imageSpec, using the OCI image config embedded
+// in the SIF file if present.
+func (s *sifBundle) setImageSpec(img *image.Image) error {
+	now := time.Now()
+	p := imgspecv1.Platform{
+		Architecture: s.arch,
+		OS:           "linux",
+	}
+
+	// Apptainer images have a runscript and/or startscript. These do not
+	// translate well to the OCI Entrypoint/Cmd specification. The OCI config
+	// embedded into a SIF at build time doesn't try to resolve the issue, and
+	// just sets Cmd to /bin/sh. Use the same default here, so it's up to the
+	// launcher to resolve runscript/startscript handling.
+	c := imgspecv1.ImageConfig{
+		Cmd: []string{"/bin/sh"},
+		Env: []string{"PATH=" + env.DefaultPath},
+	}
+
+	reader, err := image.NewSectionReader(img, image.SIFDescOCIConfigJSON, -1)
+	if err != nil && err != image.ErrNoSection {
+		return fmt.Errorf("failed to read %s section: %s", image.SIFDescOCIConfigJSON, err)
+	}
+	// We have an image config from the SIF, so overwrite default
+	if err == nil {
+		if err := json.NewDecoder(reader).Decode(&c); err != nil {
+			return fmt.Errorf("failed to decode %s: %s", image.SIFDescOCIConfigJSON, err)
+		}
+	}
+
+	s.imageSpec = &imgspecv1.Image{
+		Created:  &now,
+		Author:   useragent.Value(),
+		Platform: p,
+		Config:   c,
+	}
 	return nil
 }
 

--- a/pkg/ocibundle/sif/bundle_linux_test.go
+++ b/pkg/ocibundle/sif/bundle_linux_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -21,6 +21,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/ocibundle/tools"
 	"github.com/apptainer/apptainer/pkg/util/fs/proc"
+	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
 )
 
 // We need a busybox SIF for these tests. We used to download it each time, but we have one
@@ -28,6 +29,7 @@ import (
 const busyboxSIF = "../../../e2e/testdata/busybox_" + runtime.GOARCH + ".sif"
 
 func TestFromSif(t *testing.T) {
+	useragent.InitValue("TestFromSif", "0.0.0")
 	test.EnsurePrivilege(t)
 
 	bundlePath := t.TempDir()


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1906
 which fixed
- sylabs/singularity# 1899

The original PR description was:
> Implement `ImageSpec()` for `ocibundle/sif`, so that it returns a usable OCI image spec. Use the OCI image config embedded in the SIF file, if it is present.
> 
> Implement basic execution of non-oci SIF images in `--oci` mode. This is acheived by calling the `/singularity.d/action/*` scripts inside the non-oci SIF container. Generation of container process args including the action script has been moved to a struct `ExecParams` in the `launcher` package, so that it can be called from the OCI launcher when needed.
> 
> e2e testing is currently minimal. As work proceeds to wire-up native runtime compatible env handling, and have the option to run in non- `--compat`, we will be adding proper tests of the behaviour of the non-oci containers.
> 
> Note that due to prior work, we already have handling of non-oci SIF from `library://`, `oras://` via pull through the cache, so an e2e test for these sources is also added.