### PR TITLE
push: OCI-SIF to docker:// OCI registries, from sylabs 1917

### DIFF
--- a/LICENSE_THIRD_PARTY.md
+++ b/LICENSE_THIRD_PARTY.md
@@ -503,3 +503,28 @@ Contain code from the podman project, under the Apache License, Version 2.0.
    See the License for the specific language governing permissions and
    limitations under the License.
 ```
+
+## github.com/google/go-containerregistry
+
+The source files:
+
+* `internal/pkg/client/oci/auth.go`
+
+Contain code from the go-containerregistry project, under the Apache License,
+Version 2.0.
+
+```text
+Copyright 2018 Google LLC All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -41,6 +41,8 @@ const (
 	HTTPSProtocol = "https"
 	// OrasProtocol holds the oras URI.
 	OrasProtocol = "oras"
+	// Docker Registry protocol
+	DockerProtocol = "docker"
 )
 
 var (

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/apptainer/apptainer/docs"
 	"github.com/apptainer/apptainer/internal/app/apptainer"
+	"github.com/apptainer/apptainer/internal/pkg/client/oci"
 	"github.com/apptainer/apptainer/internal/pkg/client/oras"
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 	"github.com/apptainer/apptainer/internal/pkg/util/uri"
@@ -142,6 +143,20 @@ var PushCmd = &cobra.Command{
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)
 			}
 			sylog.Infof("Upload complete")
+
+		case DockerProtocol:
+			if cmd.Flag(pushDescriptionFlag.Name).Changed {
+				sylog.Warningf("Description is not supported for push to docker / OCI registries. Ignoring it.")
+			}
+			ociAuth, err := makeDockerCredentials(cmd)
+			if err != nil {
+				sylog.Fatalf("Unable to make docker oci credentials: %s", err)
+			}
+			if err := oci.Push(cmd.Context(), file, ref, ociAuth); err != nil {
+				sylog.Fatalf("Unable to push image to oci registry: %v", err)
+			}
+			sylog.Infof("Upload complete")
+
 		case "":
 			sylog.Fatalf("Transport type URI required but not supplied")
 		default:

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -62,15 +62,15 @@ func (c ctx) testPushCmd(t *testing.T) {
 	e2e.EnsureOCISIF(t, c.env)
 
 	// setup file and dir to use as invalid sources
-	orasInvalidDir, err := os.MkdirTemp(c.env.TestDir, "oras_push_dir-")
+	invalidDir, err := os.MkdirTemp(c.env.TestDir, "push_dir-")
 	if err != nil {
-		err = errors.Wrap(err, "creating oras temporary directory")
+		err = errors.Wrap(err, "creating temporary directory")
 		t.Fatalf("unable to create src dir for push tests: %+v", err)
 	}
 
-	orasInvalidFile, err := e2e.WriteTempFile(orasInvalidDir, "oras_invalid_image-", "Invalid Image Contents")
+	invalidFile, err := e2e.WriteTempFile(invalidDir, "invalid_image-", "Invalid Image Contents")
 	if err != nil {
-		err = errors.Wrap(err, "creating oras temporary file")
+		err = errors.Wrap(err, "creating temporary file")
 		t.Fatalf("unable to create src file for push tests: %+v", err)
 	}
 
@@ -82,40 +82,63 @@ func (c ctx) testPushCmd(t *testing.T) {
 		noHTTPS          bool   // --no-https/--nohttps flag
 	}{
 		{
-			desc:             "non existent image",
-			imagePath:        filepath.Join(orasInvalidDir, "not_an_existing_file.sif"),
-			dstURI:           fmt.Sprintf("oras://%s/non_existent:test", c.env.TestRegistry),
+			desc:             "oras non existent image",
+			imagePath:        filepath.Join(invalidDir, "not_an_existing_file.sif"),
+			dstURI:           fmt.Sprintf("oras://%s/oras_non_existent:test", c.env.TestRegistry),
 			expectedExitCode: 255,
 		},
 		{
-			desc:             "non SIF file",
-			imagePath:        orasInvalidFile,
-			dstURI:           fmt.Sprintf("oras://%s/non_sif:test", c.env.TestRegistry),
+			desc:             "oras non SIF file",
+			imagePath:        invalidFile,
+			dstURI:           fmt.Sprintf("oras://%s/oras_non_sif:test", c.env.TestRegistry),
 			expectedExitCode: 255,
 		},
 		{
-			desc:             "directory",
-			imagePath:        orasInvalidDir,
-			dstURI:           fmt.Sprintf("oras://%s/directory:test", c.env.TestRegistry),
+			desc:             "oras directory",
+			imagePath:        invalidDir,
+			dstURI:           fmt.Sprintf("oras://%s/oras_directory:test", c.env.TestRegistry),
 			expectedExitCode: 255,
 		},
 		{
-			desc:             "standard SIF push",
+			desc:             "oras standard SIF push",
 			imagePath:        c.env.ImagePath,
-			dstURI:           fmt.Sprintf("oras://%s/standard_sif:test", c.env.InsecureRegistry),
-			expectedExitCode: 255,
-		},
-		{
-			desc:             "standard SIF push with --no-https/--nohttps",
-			imagePath:        c.env.ImagePath,
-			dstURI:           fmt.Sprintf("oras://%s/standard_sif:test_nohttps", c.env.InsecureRegistry),
-			noHTTPS:          true,
+			dstURI:           fmt.Sprintf("oras://%s/oras_standard_sif:test", c.env.TestRegistry),
 			expectedExitCode: 0,
 		},
 		{
-			desc:             "OCI-SIF push",
+			desc:             "oras OCI-SIF push",
 			imagePath:        c.env.OCISIFPath,
-			dstURI:           fmt.Sprintf("oras://%s/oci-sif:test", c.env.TestRegistry),
+			dstURI:           fmt.Sprintf("oras://%s/oras_oci-sif:test", c.env.TestRegistry),
+			expectedExitCode: 0,
+		},
+		{
+			desc:             "docker non existent image",
+			imagePath:        filepath.Join(invalidDir, "not_an_existing_file.sif"),
+			dstURI:           fmt.Sprintf("docker://%s/docker_non_existent:test", c.env.TestRegistry),
+			expectedExitCode: 255,
+		},
+		{
+			desc:             "docker non SIF file",
+			imagePath:        invalidFile,
+			dstURI:           fmt.Sprintf("docker://%s/docker_non_sif:test", c.env.TestRegistry),
+			expectedExitCode: 255,
+		},
+		{
+			desc:             "docker directory",
+			imagePath:        invalidDir,
+			dstURI:           fmt.Sprintf("docker://%s/docker_directory:test", c.env.TestRegistry),
+			expectedExitCode: 255,
+		},
+		{
+			desc:             "docker standard SIF push",
+			imagePath:        c.env.ImagePath,
+			dstURI:           fmt.Sprintf("docker://%s/docker_standard_sif:test", c.env.TestRegistry),
+			expectedExitCode: 255,
+		},
+		{
+			desc:             "docker OCI-SIF push",
+			imagePath:        c.env.OCISIFPath,
+			dstURI:           fmt.Sprintf("docker://%s/docker_oci-sif:test", c.env.TestRegistry),
 			expectedExitCode: 0,
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/containers/image/v5 v5.26.1
 	github.com/creack/pty v1.1.18 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3
+	github.com/docker/cli v24.0.2+incompatible
 	github.com/docker/docker v24.0.4+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/fatih/color v1.15.0
@@ -99,7 +100,6 @@ require (
 	github.com/cyberphone/json-canonicalization v0.0.0-20230514072755-504adb8a8af1 // indirect
 	github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c // indirect
 	github.com/d2g/dhcp4client v1.0.0 // indirect
-	github.com/docker/cli v24.0.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/internal/pkg/client/oci/auth.go
+++ b/internal/pkg/client/oci/auth.go
@@ -1,0 +1,104 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2023 Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+//
+// The following code is adapted from:
+//
+//	https://github.com/google/go-containerregistry/blob/v0.15.2/pkg/authn/keychain.go
+//
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"os"
+	"sync"
+
+	"github.com/apptainer/apptainer/pkg/syfs"
+	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/types"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+type apptainerKeychain struct {
+	mu sync.Mutex
+}
+
+// Resolve implements Keychain.
+func (sk *apptainerKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	sk.mu.Lock()
+	defer sk.mu.Unlock()
+
+	authFile := syfs.DockerConf()
+	f, err := os.Open(authFile)
+	if os.IsNotExist(err) {
+		sylog.Debugf("Auth file %q does not exist, using anonymous auth.", authFile)
+		return authn.Anonymous, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	cf, err := config.LoadFromReader(f)
+	if err != nil {
+		return nil, err
+	}
+
+	// See:
+	// https://github.com/google/ko/issues/90
+	// https://github.com/moby/moby/blob/fc01c2b481097a6057bec3cd1ab2d7b4488c50c4/registry/config.go#L397-L404
+	var cfg, empty types.AuthConfig
+	for _, key := range []string{
+		target.String(),
+		target.RegistryStr(),
+	} {
+		if key == name.DefaultRegistry {
+			key = authn.DefaultAuthKey
+		}
+
+		cfg, err = cf.GetAuthConfig(key)
+		if err != nil {
+			return nil, err
+		}
+		// cf.GetAuthConfig automatically sets the ServerAddress attribute. Since
+		// we don't make use of it, clear the value for a proper "is-empty" test.
+		// See: https://github.com/google/go-containerregistry/issues/1510
+		cfg.ServerAddress = ""
+		if cfg != empty {
+			break
+		}
+	}
+
+	sylog.Warningf("%v", cfg)
+
+	if cfg == empty {
+		return authn.Anonymous, nil
+	}
+
+	return authn.FromConfig(authn.AuthConfig{
+		Username:      cfg.Username,
+		Password:      cfg.Password,
+		Auth:          cfg.Auth,
+		IdentityToken: cfg.IdentityToken,
+		RegistryToken: cfg.RegistryToken,
+	}), nil
+}

--- a/internal/pkg/client/oci/ocisif.go
+++ b/internal/pkg/client/oci/ocisif.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	buildoci "github.com/apptainer/apptainer/internal/pkg/build/oci"
@@ -22,13 +23,18 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
+	ocitypes "github.com/containers/image/v5/types"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/match"
 	ggcrmutate "github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sylabs/oci-tools/pkg/mutate"
-	"github.com/sylabs/oci-tools/pkg/sif"
+	ocisif "github.com/sylabs/oci-tools/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 // pull will create an OCI-SIF image in the cache if directTo="", or a specific file if directTo is set.
@@ -173,5 +179,53 @@ func layoutToOciSif(layoutDir string, digest v1.Hash, imageDest, workDir string)
 	ii := ggcrmutate.AppendManifests(empty.Index, ggcrmutate.IndexAddendum{
 		Add: img,
 	})
-	return sif.Write(imageDest, ii)
+	return ocisif.Write(imageDest, ii)
+}
+
+// pushOCISIF pushes a single image from an OCI SIF to the OCI registry destination ref.
+func pushOCISIF(ctx context.Context, sourceFile, dest string, ociAuth *ocitypes.DockerAuthConfig) error {
+	dest = strings.TrimPrefix(dest, "//")
+	ref, err := name.ParseReference(dest)
+	if err != nil {
+		return fmt.Errorf("invalid reference %q: %w", dest, err)
+	}
+
+	fi, err := sif.LoadContainerFromPath(sourceFile, sif.OptLoadWithFlag(os.O_RDONLY))
+	if err != nil {
+		return err
+	}
+	defer fi.UnloadContainer()
+
+	ix, err := ocisif.ImageIndexFromFileImage(fi)
+	if err != nil {
+		return fmt.Errorf("only OCI-SIF files can be pushed to docker/OCI registries")
+	}
+
+	idxManifest, err := ix.IndexManifest()
+	if err != nil {
+		return fmt.Errorf("while obtaining index manifest: %w", err)
+	}
+
+	if len(idxManifest.Manifests) != 1 {
+		return fmt.Errorf("only single image oci-sif files are supported")
+	}
+	image, err := ix.Image(idxManifest.Manifests[0].Digest)
+	if err != nil {
+		return fmt.Errorf("while obtaining image: %w", err)
+	}
+
+	// By default we use auth from ~/.apptainer/docker-config.json
+	authOptn := remote.WithAuthFromKeychain(&apptainerKeychain{})
+
+	// If explicit credentials in ociAuth were passed in, use those instead.
+	if ociAuth != nil {
+		auth := authn.FromConfig(authn.AuthConfig{
+			Username:      ociAuth.Username,
+			Password:      ociAuth.Password,
+			IdentityToken: ociAuth.IdentityToken,
+		})
+		authOptn = remote.WithAuth(auth)
+	}
+
+	return remote.Write(ref, image, authOptn, remote.WithUserAgent(useragent.Value()))
 }

--- a/internal/pkg/client/oci/push.go
+++ b/internal/pkg/client/oci/push.go
@@ -1,0 +1,37 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apptainer/apptainer/pkg/image"
+	ocitypes "github.com/containers/image/v5/types"
+)
+
+// Push pushes an image into an OCI registry, as an OCI image (not an ORAS artifact).
+// At present, only OCI-SIF images can be pushed in this manner.
+func Push(ctx context.Context, sourceFile string, destRef string, ociAuth *ocitypes.DockerAuthConfig) error {
+	img, err := image.Init(sourceFile, false)
+	if err != nil {
+		return err
+	}
+	defer img.File.Close()
+
+	switch img.Type {
+	case image.OCISIF:
+		return pushOCISIF(ctx, sourceFile, destRef, ociAuth)
+	case image.SIF:
+		return fmt.Errorf("non OCI SIF images can only be pushed to OCI registries via oras://")
+	}
+
+	return fmt.Errorf("push only supports SIF images")
+}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1917
 which fixed
- sylabs/singularity# 1914

The original PR description was:
> Allow `singularity push` to push OCI-SIF images (only) to OCI registries specified by a `docker://` URI.
> 
> This code uses go-containerregistry rather than containers/image so that the implementation is simple to couple to the sylabs/oci-tools package.