### PR TITLE
fix: Remove Warningf of credential in oci-sif docker:// push, from sylabs 1923

### DIFF
--- a/internal/pkg/client/oci/auth.go
+++ b/internal/pkg/client/oci/auth.go
@@ -88,8 +88,6 @@ func (sk *apptainerKeychain) Resolve(target authn.Resource) (authn.Authenticator
 		}
 	}
 
-	sylog.Warningf("%v", cfg)
-
 	if cfg == empty {
 		return authn.Anonymous, nil
 	}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1923

The original PR description was:
> Oversight in review / rebase to merge sylabs/singularity# 1917

