### PR TITLE
pull: Pull previously pushed OCI-SIF from OCI registry (docker://), from sylabs 1926

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,9 +118,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - The `pull` command now accepts a new flag `--oci` for OCI image sources. This
   will create an OCI-SIF image rather than convert to Apptainer's native
   container format.
-- OCI-mode now supports running OCI-SIF images directly from http/https and oras
-  URIs.
-- OCI-SIF images can be pushed/pulled to/from oras URIs.
+- OCI-mode now supports running OCI-SIF images directly from `docker://`,
+  `http://`, `https://` and `oras://`. URIs.
+- OCI-SIF images can be pushed/pulled to/from OCI registries as single file
+  artifacts using `oras://` URIs.
+- OCI-SIF images can be pushed/pulled to/from OCI registries as single layer,
+  squashfs layer format OCI images using `docker://` URIs.
 
 ### Developer / API
 

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -25,6 +25,7 @@ type TestEnv struct {
 	DockerArchivePath    string // Path to test Docker archive tar file
 	TestRegistry         string // Host:Port of local registry
 	TestRegistryImage    string // URI to OCI image pushed into local registry
+	TestRegistryOCISIF   string // URI to OCI SIF pushed into local registry as OCI image (non-oras)
 	HomeDir              string // HomeDir sets the home directory that will be used for the execution of a command
 	KeyringDir           string // KeyringDir sets the directory where the keyring will be created for the execution of a command (instead of using APPTAINER_KEYSDIR which should be avoided when running e2e tests)
 	PrivCacheDir         string // PrivCacheDir sets the location of the image cache to be used by the Apptainer command to be executed as root (instead of using APPTAINER_CACHE_DIR which should be avoided when running e2e tests)

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -309,6 +309,29 @@ func EnsureORASOCISIF(t *testing.T, env TestEnv) {
 	})
 }
 
+var registryOCISIFOnce sync.Once
+
+func EnsureRegistryOCISIF(t *testing.T, env TestEnv) {
+	EnsureOCISIF(t, env)
+
+	ensureMutex.Lock()
+	defer ensureMutex.Unlock()
+
+	registryOCISIFOnce.Do(func() {
+		t.Logf("Pushing %s to %s", env.OCISIFPath, env.TestRegistryOCISIF)
+		env.RunApptainer(
+			t,
+			WithProfile(UserProfile),
+			WithCommand("push"),
+			WithArgs(env.OCISIFPath, env.TestRegistryOCISIF),
+			ExpectExit(0),
+		)
+		if t.Failed() {
+			t.Fatalf("failed to push oci-sif image to local registry %q", env.TestRegistryOCISIF)
+		}
+	})
+}
+
 func DownloadFile(url string, path string) error {
 	dl, err := os.Create(path)
 	if err != nil {

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -209,6 +209,9 @@ func Run(t *testing.T) {
 	// Local registry ORAS OCI-SIF image, built on demand by e2e.EnsureORASOCISIF
 	testenv.OrasTestOCISIF = fmt.Sprintf("oras://%s/oras_test_oci-sif:latest", testenv.TestRegistry)
 
+	// OCI-SIF image pushed as OCI image to local registry
+	testenv.TestRegistryOCISIF = fmt.Sprintf("docker://%s/registry_test_oci-sif:latest", testenv.TestRegistry)
+
 	t.Cleanup(func() {
 		if !t.Failed() {
 			os.Remove(imagePath)

--- a/internal/pkg/client/oci/ocisif.go
+++ b/internal/pkg/client/oci/ocisif.go
@@ -29,13 +29,16 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
-	"github.com/google/go-containerregistry/pkg/v1/match"
 	ggcrmutate "github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/sylabs/oci-tools/pkg/mutate"
 	ocisif "github.com/sylabs/oci-tools/pkg/sif"
 	"github.com/sylabs/sif/v2/pkg/sif"
 )
+
+// TODO - Replace when exported from SIF / oci-tools
+const SquashfsLayerMediaType types.MediaType = "application/vnd.sylabs.image.layer.v1.squashfs"
 
 // pull will create an OCI-SIF image in the cache if directTo="", or a specific file if directTo is set.
 //
@@ -48,7 +51,6 @@ func pullOciSif(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom 
 	}
 
 	if directTo != "" {
-		sylog.Infof("Converting OCI image to OCI-SIF format")
 		if err := createOciSif(ctx, imgCache, pullFrom, directTo, opts); err != nil {
 			return "", fmt.Errorf("while creating OCI-SIF: %v", err)
 		}
@@ -61,8 +63,6 @@ func pullOciSif(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom 
 		}
 		defer cacheEntry.CleanTmp()
 		if !cacheEntry.Exists {
-			sylog.Infof("Converting OCI image to OCI-SIF format")
-
 			if err := createOciSif(ctx, imgCache, pullFrom, cacheEntry.TmpPath, opts); err != nil {
 				return "", fmt.Errorf("while creating OCI-SIF: %v", err)
 			}
@@ -90,7 +90,7 @@ func createOciSif(ctx context.Context, imgCache *cache.Handle, imageSrc, imageDe
 		return err
 	}
 	defer func() {
-		sylog.Infof("Cleaning up...")
+		sylog.Infof("Cleaning up.")
 		if err := fs.ForceRemoveAll(tmpDir); err != nil {
 			sylog.Warningf("Couldn't remove oci-sif temporary directory %q: %v", tmpDir, err)
 		}
@@ -111,28 +111,55 @@ func createOciSif(ctx context.Context, imgCache *cache.Handle, imageSrc, imageDe
 		return fmt.Errorf("while fetching OCI image: %w", err)
 	}
 
-	// Step 2 - Work from containers/image ImageReference -> gocontainerregistry digest
+	// Step 2 - Work from containers/image ImageReference -> gocontainerregistry digest & manifest
 	layoutSrc, err := layoutRef.NewImageSource(ctx, sys)
 	if err != nil {
 		return err
 	}
 	defer layoutSrc.Close()
-	imgManifest, _, err := layoutSrc.GetManifest(ctx, nil)
+	rawManifest, _, err := layoutSrc.GetManifest(ctx, nil)
 	if err != nil {
 		return err
 	}
-	digest, _, err := v1.SHA256(bytes.NewBuffer(imgManifest))
+	digest, _, err := v1.SHA256(bytes.NewBuffer(rawManifest))
+	if err != nil {
+		return err
+	}
+	mf, err := v1.ParseManifest(bytes.NewBuffer(rawManifest))
 	if err != nil {
 		return err
 	}
 
-	// Step 3 - Convert the layout into a squashed, single squashfs-layer oci-sif image
-	return layoutToOciSif(layoutDir, digest, imageDest, workDir)
+	// If the image has a single squashfs layer, then we can write it directly to oci-sif.
+	if (len(mf.Layers)) == 1 && (mf.Layers[0].MediaType == SquashfsLayerMediaType) {
+		sylog.Infof("Writing OCI-SIF image")
+		return writeLayoutToOciSif(layoutDir, digest, imageDest, workDir)
+	}
+
+	// Otherwise, squashing and converting layers to squashfs is required.
+	sylog.Infof("Converting OCI image to OCI-SIF format")
+	return convertLayoutToOciSif(layoutDir, digest, imageDest, workDir)
 }
 
-// layoutToOciSif will convert an image in an OCI layout to a squashed oci-sif with squashfs layer format.
+// writeLayoutToOciSif will write an image from an OCI layout to an oci-sif without applying any mutations.
+func writeLayoutToOciSif(layoutDir string, digest v1.Hash, imageDest, workDir string) error {
+	lp, err := layout.FromPath(layoutDir)
+	if err != nil {
+		return fmt.Errorf("while opening layout: %w", err)
+	}
+	img, err := lp.Image(digest)
+	if err != nil {
+		return fmt.Errorf("while retrieving image: %w", err)
+	}
+	ii := ggcrmutate.AppendManifests(empty.Index, ggcrmutate.IndexAddendum{
+		Add: img,
+	})
+	return ocisif.Write(imageDest, ii)
+}
+
+// convertLayoutToOciSif will convert an image in an OCI layout to a squashed oci-sif with squashfs layer format.
 // The OCI layout can contain only a single image.
-func layoutToOciSif(layoutDir string, digest v1.Hash, imageDest, workDir string) error {
+func convertLayoutToOciSif(layoutDir string, digest v1.Hash, imageDest, workDir string) error {
 	lp, err := layout.FromPath(layoutDir)
 	if err != nil {
 		return fmt.Errorf("while opening layout: %w", err)
@@ -142,7 +169,7 @@ func layoutToOciSif(layoutDir string, digest v1.Hash, imageDest, workDir string)
 		return fmt.Errorf("while retrieving image: %w", err)
 	}
 
-	sylog.Infof("Squashing image to single layer...")
+	sylog.Infof("Squashing image to single layer")
 	img, err = mutate.Squash(img)
 	if err != nil {
 		return fmt.Errorf("while squashing image: %w", err)
@@ -172,10 +199,7 @@ func layoutToOciSif(layoutDir string, digest v1.Hash, imageDest, workDir string)
 		return fmt.Errorf("while replacing layers: %w", err)
 	}
 
-	sylog.Infof("Writing oci-sif image...")
-	if err := lp.ReplaceImage(img, match.Digests(digest)); err != nil {
-		return fmt.Errorf("while replacing image: %w", err)
-	}
+	sylog.Infof("Writing OCI-SIF image")
 	ii := ggcrmutate.AppendManifests(empty.Index, ggcrmutate.IndexAddendum{
 		Add: img,
 	})


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity# 1926
 which fixed
- sylabs/singularity# 1915

The original PR description was:
> If `singularity pull --oci` is used against an OCI registry `docker://` reference, and the reference is a single-layer squashfs image, pull it into an OCI-SIF without any mutation.
> 
> This is the mirror-image operation of sylabs/singularity# 1917, allowing OCI-SIF images pushed with the code in sylabs/singularity# 1917 to be pulled.
> 
> Note that the pull e2e tests have been re-arranged / re-named. This is to keep all the `library://` `oras://` `docker://` tests next to eachother.... and in an attempt to make it more obvious what is testing what.



