### PR TITLE
Use `t.Context` instead of `context.Background` in tests, from sylabs 3779

### DIFF
--- a/internal/app/starter/master_linux_test.go
+++ b/internal/app/starter/master_linux_test.go
@@ -10,7 +10,6 @@
 package starter
 
 import (
-	"context"
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine"
@@ -57,7 +56,7 @@ func TestCreateContainer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			go createContainer(context.Background(), tt.rpcSocket, tt.containerPid, tt.engine, fatalChan)
+			go createContainer(t.Context(), tt.rpcSocket, tt.containerPid, tt.engine, fatalChan)
 			// createContainer is creating a separate thread and we sync with that
 			// thread through a channel similarly to the createContainer function itself,
 			// as well as the Master function.
@@ -105,7 +104,7 @@ func TestStartContainer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			go startContainer(context.Background(), tt.masterSocket, tt.containerPid, tt.engine, fatalChan)
+			go startContainer(t.Context(), tt.masterSocket, tt.containerPid, tt.engine, fatalChan)
 			fatal = <-fatalChan
 			if tt.shallPass && fatal != nil {
 				t.Fatalf("test %s expected to succeed but failed: %s", tt.name, fatal)

--- a/internal/pkg/build/assemblers/sandbox_test.go
+++ b/internal/pkg/build/assemblers/sandbox_test.go
@@ -10,7 +10,6 @@
 package assemblers_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,11 +54,11 @@ func TestSandboxAssemblerDocker(t *testing.T) {
 
 	ocp := &sources.OCIConveyorPacker{}
 
-	if err := ocp.Get(context.Background(), b); err != nil {
+	if err := ocp.Get(t.Context(), b); err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", assemblerDockerURI, err)
 	}
 
-	_, err = ocp.Pack(context.Background())
+	_, err = ocp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", assemblerDockerURI, err)
 	}
@@ -96,11 +95,11 @@ func TestSandboxAssemblerShub(t *testing.T) {
 
 	scp := &sources.ShubConveyorPacker{}
 
-	if err := scp.Get(context.Background(), b); err != nil {
+	if err := scp.Get(t.Context(), b); err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", assemblerShubURI, err)
 	}
 
-	_, err = scp.Pack(context.Background())
+	_, err = scp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", assemblerShubURI, err)
 	}

--- a/internal/pkg/build/assemblers/sif_test.go
+++ b/internal/pkg/build/assemblers/sif_test.go
@@ -10,7 +10,6 @@
 package assemblers_test
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -76,11 +75,11 @@ func TestSIFAssemblerDocker(t *testing.T) {
 
 	ocp := &sources.OCIConveyorPacker{}
 
-	if err = ocp.Get(context.Background(), b); err != nil {
+	if err = ocp.Get(t.Context(), b); err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", assemblerDockerURI, err)
 	}
 
-	_, err = ocp.Pack(context.Background())
+	_, err = ocp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", assemblerDockerURI, err)
 	}
@@ -124,11 +123,11 @@ func TestSIFAssemblerShub(t *testing.T) {
 
 	scp := &sources.ShubConveyorPacker{}
 
-	if err := scp.Get(context.Background(), b); err != nil {
+	if err := scp.Get(t.Context(), b); err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", assemblerShubURI, err)
 	}
 
-	_, err = scp.Pack(context.Background())
+	_, err = scp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", assemblerShubURI, err)
 	}

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -275,7 +275,7 @@ func TestConvertReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// nolint: staticcheck
-			_, err := ConvertReference(context.Background(), imgCache, tt.ref, ociimage.TransportOptionsFromSystemContext(tt.ctx))
+			_, err := ConvertReference(t.Context(), imgCache, tt.ref, ociimage.TransportOptionsFromSystemContext(tt.ctx))
 			if tt.shouldPass == true && err != nil {
 				t.Fatalf("test expected to succeeded but failed: %s\n", err)
 			}
@@ -347,7 +347,7 @@ func TestImageNameAndImageSHA(t *testing.T) {
 		testName := "ParseImageName - " + tt.name
 		t.Run(testName, func(t *testing.T) {
 			// nolint:staticcheck
-			_, err := ParseImageName(context.Background(), imgCache, tt.uri, ociimage.TransportOptionsFromSystemContext(tt.ctx))
+			_, err := ParseImageName(t.Context(), imgCache, tt.uri, ociimage.TransportOptionsFromSystemContext(tt.ctx))
 			if tt.shouldPass == true && err != nil {
 				t.Fatalf("test expected to succeeded but failed: %s\n", err)
 			}
@@ -359,7 +359,7 @@ func TestImageNameAndImageSHA(t *testing.T) {
 		testName = "ImageSHA - " + tt.name
 		t.Run(testName, func(t *testing.T) {
 			// nolint: staticcheck
-			_, err := ImageDigest(context.Background(), tt.uri, ociimage.TransportOptionsFromSystemContext(tt.ctx))
+			_, err := ImageDigest(t.Context(), tt.uri, ociimage.TransportOptionsFromSystemContext(tt.ctx))
 			if tt.shouldPass == true && err != nil {
 				t.Fatal("test expected to succeeded but failed")
 			}
@@ -415,7 +415,7 @@ func TestNewImageSource(t *testing.T) {
 	}
 
 	imgRef := createValidImageRef(t, ref)
-	validImgRef, err := ConvertReference(context.Background(), imgCache, imgRef, nil)
+	validImgRef, err := ConvertReference(t.Context(), imgCache, imgRef, nil)
 	if err != nil {
 		t.Fatalf("failed to convert image reference: %s", err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_arch_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch_test.go
@@ -10,7 +10,6 @@
 package sources_test
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,7 +58,7 @@ func TestArchConveyor(t *testing.T) {
 
 	cp := &sources.ArchConveyorPacker{}
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
@@ -97,14 +96,14 @@ func TestArchPacker(t *testing.T) {
 
 	cp := &sources.ArchConveyorPacker{}
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", archDef, err)
 	}
 
-	_, err = cp.Pack(context.Background())
+	_, err = cp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", archDef, err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_busybox_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox_test.go
@@ -10,7 +10,6 @@
 package sources_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -56,7 +55,7 @@ func TestBusyBoxConveyor(t *testing.T) {
 
 	c := &sources.BusyBoxConveyor{}
 
-	err = c.Get(context.Background(), b)
+	err = c.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer c.CleanUp()
 	if err != nil {
@@ -92,14 +91,14 @@ func TestBusyBoxPacker(t *testing.T) {
 
 	cp := &sources.BusyBoxConveyorPacker{}
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", busyBoxDef, err)
 	}
 
-	_, err = cp.Pack(context.Background())
+	_, err = cp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", busyBoxDef, err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
@@ -10,7 +10,6 @@
 package sources_test
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -46,7 +45,7 @@ func TestDebootstrapConveyor(t *testing.T) {
 
 	cp := sources.DebootstrapConveyorPacker{}
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
@@ -79,14 +78,14 @@ func TestDebootstrapPacker(t *testing.T) {
 
 	cp := sources.DebootstrapConveyorPacker{}
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("Debootstrap Get failed: %v", err)
 	}
 
-	_, err = cp.Pack(context.Background())
+	_, err = cp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("Debootstrap Pack failed: %v", err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_library_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_library_test.go
@@ -10,7 +10,6 @@
 package sources_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -58,7 +57,7 @@ func TestLibraryConveyor(t *testing.T) {
 	defer cleanup()
 	b.Opts.ImgCache = imgCache
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
@@ -95,14 +94,14 @@ func TestLibraryPacker(t *testing.T) {
 	defer cleanup()
 	b.Opts.ImgCache = imgCache
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", libraryURI, err)
 	}
 
-	_, err = cp.Pack(context.Background())
+	_, err = cp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", libraryURI, err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_local_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_local_test.go
@@ -10,7 +10,6 @@
 package sources_test
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -87,10 +86,10 @@ func TestLocalPackerSquashfs(t *testing.T) {
 
 	// Create and execute packer
 	lcp := &sources.LocalConveyorPacker{}
-	if err := lcp.Get(context.Background(), b); err != nil {
+	if err := lcp.Get(t.Context(), b); err != nil {
 		t.Fatalf("while getting local packer: %v", err)
 	}
-	if _, err = lcp.Pack(context.Background()); err != nil {
+	if _, err = lcp.Pack(t.Context()); err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", image, err)
 	}
 	rootfsPath := b.RootfsPath

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -10,7 +10,6 @@
 package sources_test
 
 import (
-	"context"
 	"io"
 	"log"
 	"net/http"
@@ -79,7 +78,7 @@ func TestOCIConveyorDocker(t *testing.T) {
 
 	cp := &sources.OCIConveyorPacker{}
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
@@ -118,7 +117,7 @@ func TestOCIConveyorDockerArchive(t *testing.T) {
 
 	cp := &sources.OCIConveyorPacker{}
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
@@ -165,7 +164,7 @@ func TestOCIConveyorDockerDaemon(t *testing.T) {
 
 	cp := &sources.OCIConveyorPacker{}
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
@@ -200,7 +199,7 @@ func TestOCIConveyorOCIArchive(t *testing.T) {
 
 	cp := &sources.OCIConveyorPacker{}
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
@@ -244,7 +243,7 @@ func TestOCIConveyorOCILayout(t *testing.T) {
 
 	cp := &sources.OCIConveyorPacker{}
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
@@ -281,14 +280,14 @@ func TestOCIPacker(t *testing.T) {
 	}
 	b.Opts.Platform = *p
 
-	err = ocp.Get(context.Background(), b)
+	err = ocp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer ocp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", dockerURI, err)
 	}
 
-	_, err = ocp.Pack(context.Background())
+	_, err = ocp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", dockerURI, err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_scratch_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch_test.go
@@ -10,7 +10,6 @@
 package sources_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -49,7 +48,7 @@ func TestScratchConveyor(t *testing.T) {
 
 	c := &sources.ScratchConveyor{}
 
-	err = c.Get(context.Background(), b)
+	err = c.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer c.CleanUp()
 	if err != nil {
@@ -79,14 +78,14 @@ func TestScratchPacker(t *testing.T) {
 
 	cp := &sources.ScratchConveyorPacker{}
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", scratchDef, err)
 	}
 
-	_, err = cp.Pack(context.Background())
+	_, err = cp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", scratchDef, err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_shub_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub_test.go
@@ -10,7 +10,6 @@
 package sources_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,7 +47,7 @@ func TestShubConveyor(t *testing.T) {
 
 	cp := &sources.ShubConveyorPacker{}
 
-	err = cp.Get(context.Background(), b)
+	err = cp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
@@ -75,14 +74,14 @@ func TestShubPacker(t *testing.T) {
 
 	scp := &sources.ShubConveyorPacker{}
 
-	err = scp.Get(context.Background(), b)
+	err = scp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer scp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", shubURI, err)
 	}
 
-	_, err = scp.Pack(context.Background())
+	_, err = scp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", shubURI, err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_yum_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum_test.go
@@ -10,7 +10,6 @@
 package sources
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -77,14 +76,14 @@ func testYumConveyorPacker(t *testing.T, yumDef string) {
 
 	ycp := &YumConveyorPacker{}
 
-	err = ycp.Get(context.Background(), b)
+	err = ycp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer ycp.b.Remove()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", yumDef, err)
 	}
 
-	_, err = ycp.Pack(context.Background())
+	_, err = ycp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", yumDef, err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_zypper_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper_test.go
@@ -10,7 +10,6 @@
 package sources
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -60,14 +59,14 @@ func testZypperConveyorPacker(t *testing.T, defName string) {
 
 	zcp := &ZypperConveyorPacker{}
 
-	err = zcp.Get(context.Background(), b)
+	err = zcp.Get(t.Context(), b)
 	// clean up tmpfs since assembler isn't called
 	defer zcp.b.Remove()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", defName, err)
 	}
 
-	_, err = zcp.Pack(context.Background())
+	_, err = zcp.Pack(t.Context())
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", defName, err)
 	}

--- a/internal/pkg/client/progress_test.go
+++ b/internal/pkg/client/progress_test.go
@@ -11,7 +11,6 @@ package client
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"testing"
 
@@ -20,7 +19,7 @@ import (
 
 func TestProgressCallback(t *testing.T) {
 	const input = "Hello World!"
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Check the progress bar, or invisible copy-through, works at all sylog
 	// levels

--- a/internal/pkg/client/shub/pull_test.go
+++ b/internal/pkg/client/shub/pull_test.go
@@ -10,7 +10,6 @@
 package shub
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -45,7 +44,7 @@ func TestDownloadImage(t *testing.T) {
 		t.Fatalf("failed to get manifest from shub: %s", err)
 	}
 
-	err = DownloadImage(context.Background(), manifest, shubImgPath, shubImageURI, false, false)
+	err = DownloadImage(t.Context(), manifest, shubImgPath, shubImageURI, false, false)
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", shubURI, err)
 	}

--- a/internal/pkg/signature/sign_test.go
+++ b/internal/pkg/signature/sign_test.go
@@ -10,7 +10,6 @@
 package signature
 
 import (
-	"context"
 	"crypto"
 	"errors"
 	"io"
@@ -147,7 +146,7 @@ func TestSign(t *testing.T) {
 			}
 			defer os.Remove(path)
 
-			if got, want := Sign(context.Background(), path, tt.opts...), tt.wantErr; !errors.Is(got, want) {
+			if got, want := Sign(t.Context(), path, tt.opts...), tt.wantErr; !errors.Is(got, want) {
 				t.Errorf("got error %v, want %v", got, want)
 			}
 		})

--- a/internal/pkg/signature/verify_test.go
+++ b/internal/pkg/signature/verify_test.go
@@ -11,7 +11,6 @@ package signature
 
 import (
 	"bytes"
-	"context"
 	"crypto"
 	"crypto/x509"
 	"encoding/pem"
@@ -346,7 +345,7 @@ func Test_verifier_getOpts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			opts, err := tt.v.getOpts(context.Background(), tt.f)
+			opts, err := tt.v.getOpts(t.Context(), tt.f)
 
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Errorf("got error %v, want %v", got, want)
@@ -586,7 +585,7 @@ func TestVerify(t *testing.T) { //nolint:maintidx
 			}
 			tt.opts = append(tt.opts, OptVerifyCallback(cb))
 
-			err := Verify(context.Background(), tt.path, tt.opts...)
+			err := Verify(t.Context(), tt.path, tt.opts...)
 
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Errorf("got error %v, want %v", got, want)
@@ -772,7 +771,7 @@ func TestVerifyFingerPrint(t *testing.T) {
 				return false
 			}
 			tt.opts = append(tt.opts, OptVerifyCallback(cb))
-			err := VerifyFingerprints(context.Background(), tt.path, tt.fingerprints, tt.opts...)
+			err := VerifyFingerprints(t.Context(), tt.path, tt.fingerprints, tt.opts...)
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Errorf("got error %v, want %v", got, want)
 			}

--- a/internal/pkg/syecl/syecl_test.go
+++ b/internal/pkg/syecl/syecl_test.go
@@ -11,7 +11,6 @@
 package syecl
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -432,7 +431,7 @@ func TestShouldRun(t *testing.T) {
 			}
 
 			// Test ShouldRun (takes path).
-			got, err := c.ShouldRun(context.Background(), tt.path, openpgp.EntityList{getTestEntity(t)})
+			got, err := c.ShouldRun(t.Context(), tt.path, openpgp.EntityList{getTestEntity(t)})
 
 			if want := !tt.wantErr; got != want {
 				t.Errorf("got run %v, want %v", got, want)
@@ -449,7 +448,7 @@ func TestShouldRun(t *testing.T) {
 			}
 			defer f.Close()
 
-			got, err = c.ShouldRunFp(context.Background(), f, openpgp.EntityList{getTestEntity(t)})
+			got, err = c.ShouldRunFp(t.Context(), f, openpgp.EntityList{getTestEntity(t)})
 
 			if want := !tt.wantErr; got != want {
 				t.Errorf("got run %v, want %v", got, want)

--- a/internal/pkg/sypgp/sypgp_test.go
+++ b/internal/pkg/sypgp/sypgp_test.go
@@ -12,7 +12,6 @@ package sypgp
 
 import (
 	"bytes"
-	"context"
 	"encoding/hex"
 	"log"
 	"net/http"
@@ -93,7 +92,7 @@ func TestSearchPubkey(t *testing.T) {
 				client.OptHTTPClient(srv.Client()),
 			}
 
-			if err := SearchPubkey(context.Background(), tt.search, false, opts...); (err != nil) != tt.wantErr {
+			if err := SearchPubkey(t.Context(), tt.search, false, opts...); (err != nil) != tt.wantErr {
 				t.Fatalf("got err %v, want error %v", err, tt.wantErr)
 			}
 		})
@@ -136,7 +135,7 @@ func TestFetchPubkey(t *testing.T) {
 				client.OptHTTPClient(srv.Client()),
 			}
 
-			el, err := FetchPubkey(context.Background(), tt.fingerprint, opts...)
+			el, err := FetchPubkey(t.Context(), tt.fingerprint, opts...)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("unexpected error: %v", err)
 				return
@@ -217,7 +216,7 @@ func TestPushPubkey(t *testing.T) {
 				client.OptHTTPClient(srv.Client()),
 			}
 
-			if err := PushPubkey(context.Background(), testEntity, opts...); (err != nil) != tt.wantErr {
+			if err := PushPubkey(t.Context(), testEntity, opts...); (err != nil) != tt.wantErr {
 				t.Fatalf("got err %v, want error %v", err, tt.wantErr)
 			}
 		})

--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -11,7 +11,6 @@ package require
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -80,7 +79,7 @@ func Network(t *testing.T) {
 			t.Logf("Could not use network: %s", err)
 		}
 
-		ctx := context.TODO()
+		ctx := t.Context()
 
 		cmd := exec.Command("/bin/cat")
 		cmd.SysProcAttr = &syscall.SysProcAttr{}

--- a/internal/pkg/util/env/env_test.go
+++ b/internal/pkg/util/env/env_test.go
@@ -10,7 +10,6 @@
 package env
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -240,7 +239,7 @@ func TestEnvFileMap(t *testing.T) {
 				t.Fatalf("Could not write test env-file: %v", err)
 			}
 
-			got, err := FileMap(context.Background(), envFile, []string{}, tt.hostEnv)
+			got, err := FileMap(t.Context(), envFile, []string{}, tt.hostEnv)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("envFileMap() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/pkg/util/shell/interpreter/interpreter_test.go
+++ b/internal/pkg/util/shell/interpreter/interpreter_test.go
@@ -197,7 +197,7 @@ func TestInterpreter(t *testing.T) {
 			if tt.openHandler != nil {
 				shell.RegisterOpenHandler(tt.openHandler.path, tt.openHandler.fn(shell))
 			}
-			if err := shell.Run(context.Background()); err != nil {
+			if err := shell.Run(t.Context()); err != nil {
 				if tt.expectExit != 0 && shell.Status() != tt.expectExit {
 					t.Fatalf("unexpected exit status for %s: got %d instead of %d", tt.name, shell.Status(), tt.expectExit)
 				} else if tt.expectExit == 0 {
@@ -313,7 +313,7 @@ func TestEvaluateEnv(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env, err := EvaluateEnv(context.Background(), []byte(tt.script), tt.argv, tt.env)
+			env, err := EvaluateEnv(t.Context(), []byte(tt.script), tt.argv, tt.env)
 			if !tt.expectErr && err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			} else if tt.expectErr && err == nil {

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -12,7 +12,6 @@
 package network
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net"
@@ -375,10 +374,10 @@ func testPingIP(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io
 		return err
 	}
 	setup.SetArgs([]string{"IP=" + testIP})
-	if err := setup.AddNetworks(context.Background()); err != nil {
+	if err := setup.AddNetworks(t.Context()); err != nil {
 		return err
 	}
-	defer setup.DelNetworks(context.Background())
+	defer setup.DelNetworks(t.Context())
 
 	ip, err := setup.GetNetworkIP("test-bridge", "4")
 	if err != nil {
@@ -404,10 +403,10 @@ func testPingRandomIP(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, std
 	if err != nil {
 		return err
 	}
-	if err := setup.AddNetworks(context.Background()); err != nil {
+	if err := setup.AddNetworks(t.Context()); err != nil {
 		return err
 	}
-	defer setup.DelNetworks(context.Background())
+	defer setup.DelNetworks(t.Context())
 
 	ip, err := setup.GetNetworkIP("test-bridge", "4")
 	if err != nil {
@@ -431,10 +430,10 @@ func testPingIPRange(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdo
 		return err
 	}
 	setup.SetArgs([]string{"ipRange=10.111.112.0/24"})
-	if err := setup.AddNetworks(context.Background()); err != nil {
+	if err := setup.AddNetworks(t.Context()); err != nil {
 		return err
 	}
-	defer setup.DelNetworks(context.Background())
+	defer setup.DelNetworks(t.Context())
 
 	ip, err := setup.GetNetworkIP("test-bridge", "4")
 	if err != nil {
@@ -465,10 +464,10 @@ func testHTTPPortmap(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdo
 		return err
 	}
 	setup.SetArgs([]string{"portmap=31080:80/tcp"})
-	if err := setup.AddNetworks(context.Background()); err != nil {
+	if err := setup.AddNetworks(t.Context()); err != nil {
 		return err
 	}
-	defer setup.DelNetworks(context.Background())
+	defer setup.DelNetworks(t.Context())
 
 	eth, err := setup.GetNetworkInterface("test-bridge-iprange")
 	if err != nil {
@@ -507,10 +506,10 @@ func testBadBridge(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout
 	if err != nil {
 		return err
 	}
-	if err := setup.AddNetworks(context.Background()); err == nil {
+	if err := setup.AddNetworks(t.Context()); err == nil {
 		return fmt.Errorf("unexpected success while calling non existent plugin")
 	}
-	defer setup.DelNetworks(context.Background())
+	defer setup.DelNetworks(t.Context())
 
 	return nil
 }

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -12,6 +12,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -366,7 +367,7 @@ func TestNewSetup(t *testing.T) {
 }
 
 // ping requested IP from host
-func testPingIP(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io.ReadCloser) error {
+func testPingIP(ctx context.Context, nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io.ReadCloser) error {
 	testIP := "10.111.111.10"
 
 	setup, err := NewSetup([]string{"test-bridge"}, "test_", nsPath, cniPath)
@@ -374,10 +375,10 @@ func testPingIP(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io
 		return err
 	}
 	setup.SetArgs([]string{"IP=" + testIP})
-	if err := setup.AddNetworks(t.Context()); err != nil {
+	if err := setup.AddNetworks(ctx); err != nil {
 		return err
 	}
-	defer setup.DelNetworks(t.Context())
+	defer setup.DelNetworks(ctx)
 
 	ip, err := setup.GetNetworkIP("test-bridge", "4")
 	if err != nil {
@@ -398,15 +399,15 @@ func testPingIP(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io
 }
 
 // ping random acquired IP from host
-func testPingRandomIP(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io.ReadCloser) error {
+func testPingRandomIP(ctx context.Context, nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io.ReadCloser) error {
 	setup, err := NewSetup([]string{"test-bridge"}, "test_", nsPath, cniPath)
 	if err != nil {
 		return err
 	}
-	if err := setup.AddNetworks(t.Context()); err != nil {
+	if err := setup.AddNetworks(ctx); err != nil {
 		return err
 	}
-	defer setup.DelNetworks(t.Context())
+	defer setup.DelNetworks(ctx)
 
 	ip, err := setup.GetNetworkIP("test-bridge", "4")
 	if err != nil {
@@ -424,16 +425,16 @@ func testPingRandomIP(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, std
 }
 
 // ping IP from host within requested IP range
-func testPingIPRange(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io.ReadCloser) error {
+func testPingIPRange(ctx context.Context, nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io.ReadCloser) error {
 	setup, err := NewSetup([]string{"test-bridge-iprange"}, "test_", nsPath, cniPath)
 	if err != nil {
 		return err
 	}
 	setup.SetArgs([]string{"ipRange=10.111.112.0/24"})
-	if err := setup.AddNetworks(t.Context()); err != nil {
+	if err := setup.AddNetworks(ctx); err != nil {
 		return err
 	}
-	defer setup.DelNetworks(t.Context())
+	defer setup.DelNetworks(ctx)
 
 	ip, err := setup.GetNetworkIP("test-bridge", "4")
 	if err != nil {
@@ -458,16 +459,16 @@ func testPingIPRange(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdo
 
 // test port mapping by connecting to port 80 mapped inside container
 // to 31080 on host
-func testHTTPPortmap(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io.ReadCloser) error {
+func testHTTPPortmap(ctx context.Context, nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io.ReadCloser) error {
 	setup, err := NewSetup([]string{"test-bridge"}, "test_", nsPath, cniPath)
 	if err != nil {
 		return err
 	}
 	setup.SetArgs([]string{"portmap=31080:80/tcp"})
-	if err := setup.AddNetworks(t.Context()); err != nil {
+	if err := setup.AddNetworks(ctx); err != nil {
 		return err
 	}
-	defer setup.DelNetworks(t.Context())
+	defer setup.DelNetworks(ctx)
 
 	eth, err := setup.GetNetworkInterface("test-bridge-iprange")
 	if err != nil {
@@ -501,15 +502,15 @@ func testHTTPPortmap(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdo
 }
 
 // try with an non existent plugin
-func testBadBridge(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io.ReadCloser) error {
+func testBadBridge(ctx context.Context, nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout io.ReadCloser) error {
 	setup, err := NewSetup([]string{"test-badbridge"}, "", nsPath, cniPath)
 	if err != nil {
 		return err
 	}
-	if err := setup.AddNetworks(t.Context()); err == nil {
+	if err := setup.AddNetworks(ctx); err == nil {
 		return fmt.Errorf("unexpected success while calling non existent plugin")
 	}
-	defer setup.DelNetworks(t.Context())
+	defer setup.DelNetworks(ctx)
 
 	return nil
 }
@@ -526,7 +527,7 @@ func TestAddDelNetworks(t *testing.T) {
 		name    string
 		command string
 		args    []string
-		runFunc func(string, *CNIPath, io.WriteCloser, io.ReadCloser) error
+		runFunc func(context.Context, string, *CNIPath, io.WriteCloser, io.ReadCloser) error
 	}{
 		{
 			name:    "TestPingIP",
@@ -582,7 +583,7 @@ func TestAddDelNetworks(t *testing.T) {
 		}
 
 		nsPath := fmt.Sprintf("/proc/%d/ns/net", cmd.Process.Pid)
-		if err := c.runFunc(nsPath, cniPath, stdinPipe, stdoutPipe); err != nil {
+		if err := c.runFunc(t.Context(), nsPath, cniPath, stdinPipe, stdoutPipe); err != nil {
 			t.Errorf("unexpected failure for %q: %s", c.name, err)
 			if err := cmd.Process.Kill(); err != nil {
 				t.Fatalf("error killing process %q: %s", cmdPath, err)


### PR DESCRIPTION
Tests now obtain their context from the `testing` package, which removes the need for context.Background() usage in test files.
The idea to change the test context usage comes from the sylabs PR
  * sylabs/singularity# 3779

The original PR had no description.

---
This is one of the PRs listed in 
  * apptainer/apptainer# 3281